### PR TITLE
Feature/develop/2122 2133/listen on changes

### DIFF
--- a/deluge/core/preferencesmanager.py
+++ b/deluge/core/preferencesmanager.py
@@ -59,16 +59,18 @@ DEFAULT_PREFS = {
     "download_location": deluge.common.get_default_download_dir(),
     "listen_ports": [6881, 6891],
     "listen_interface": "",
-    "listen_use_sys_port": True,
-    "listen_reuse_port": False,
+    "random_port": True,
+    "listen_random_port": None,
+    "listen_use_sys_port": False,
+    "listen_reuse_port": True,
+    "outgoing_ports": [0, 0],
+    "random_outgoing_ports": True,
     "copy_torrent_file": False,
     "del_copy_torrent_file": False,
     "torrentfiles_location": deluge.common.get_default_download_dir(),
     "plugins_location": os.path.join(deluge.configmanager.get_config_dir(), "plugins"),
     "prioritize_first_last_pieces": False,
     "sequential_download": False,
-    "random_port": True,
-    "random_port_fixed": 0,
     "dht": True,
     "upnp": True,
     "natpmp": True,
@@ -127,8 +129,6 @@ DEFAULT_PREFS = {
         "hostname": "",
         "port": 0
     },
-    "outgoing_ports": [0, 0],
-    "random_outgoing_ports": True,
     "peer_tos": "0x00",
     "rate_limit_ip_overhead": True,
     "geoip_db_location": "/usr/share/GeoIP/GeoIP.dat",
@@ -156,8 +156,16 @@ class PreferencesManager(component.Component):
         self.session = component.get("Core").session
         self.new_release_timer = None
 
+        # Setup listen port followed by dht to ensure both use same port.
+        self.__set_listen_on()
+        self._on_set_dht("dht", self.config["dht"])
+
         # Set the initial preferences on start-up
         for key in DEFAULT_PREFS:
+            # Listen port and dht already setup in correct order so skip
+            # repeated running of the dht and listen port functions on startup.
+            if key in ("dht", "random_port") or key.startswith("listen_"):
+                continue
             self.do_config_set_func(key, self.config[key])
 
         self.config.register_change_callback(self._on_config_value_change)
@@ -189,47 +197,40 @@ class PreferencesManager(component.Component):
                 log.debug("Unable to make directory: %s", e)
 
     def _on_set_listen_ports(self, key, value):
-        self.set_listen_on()
-
-    def _on_set_listen_use_sys_port(self, key, value):
-        self.set_listen_on()
-
-    def _on_set_listen_reuse_port(self, key, value):
-        self.set_listen_on()
+        self.__set_listen_on()
 
     def _on_set_listen_interface(self, key, value):
-        self.set_listen_on()
+        self.__set_listen_on()
 
     def _on_set_random_port(self, key, value):
         log.debug("Listen on random port set to %s", value)
-        self.set_listen_on()
+        self.__set_listen_on()
 
-    def set_listen_on(self, ):
+    def __set_listen_on(self):
         """ Set the ports and interface address to listen for incoming connections on."""
         listen_ports = self.config["listen_ports"]
         interface = str(self.config["listen_interface"].strip())
         reuse_port = self.config["listen_reuse_port"]
         use_sys_port = self.config["listen_use_sys_port"]
 
-        log.debug("Listen on Interface: %s, Ports: %s-%s and Flags: reuse_port: %s, use_sys_port: %s",
-                  interface, listen_ports[0], listen_ports[1], reuse_port, use_sys_port)
-
-        if self.config["random_port"]:
-            if self.config["random_port_fixed"]:
-                port = self.config["random_port_fixed"]
-            else:
-                port = random.randrange(49152, 65525)
-                self.config["random_port_fixed"] = port
+        if self.config["random_port"] and self.config["listen_random_port"] is not None:
+            port = self.config["listen_random_port"]
+        elif self.config["random_port"]:
+            port = random.randrange(49152, 65525)
+            self.config["listen_random_port"] = port
             listen_ports = [port, port]
         else:
-            self.config["random_port_fixed"] = 0
+            self.config["listen_random_port"] = None
 
         # If a single port is set then enable re-use port flag
         if listen_ports[0] == listen_ports[1]:
             reuse_port = True
 
-        flags = (lt.listen_on_flags_t.listen_no_system_port if not use_sys_port
-                 else 0) | (lt.listen_on_flags_t.listen_reuse_address  if reuse_port else 0)
+        flags = ((lt.listen_on_flags_t.listen_no_system_port if not use_sys_port else 0) |
+                 (lt.listen_on_flags_t.listen_reuse_address if reuse_port else 0))
+
+        log.debug("Listen on Interface: %s, Ports: %s-%s and Flags: reuse_port: %s, use_sys_port: %s",
+                  interface, listen_ports[0], listen_ports[1], reuse_port, use_sys_port)
         try:
             self.session.listen_on(listen_ports[0], listen_ports[1], interface, flags)
         except RuntimeError as ex:


### PR DESCRIPTION
This is an unfinished branch but looking for input on the direction of the changes. 

There are two detailed tickets that are required reading to understand the changes:

http://dev.deluge-torrent.org/ticket/2133
http://dev.deluge-torrent.org/ticket/2122

The code changes I have made are straightforward and don't affect the UIs at all but I have some unanswered questions...
- Do we need to expose `listen_use_sys_port` and/or `listen_reuse_port` to the user? 
- I included some basic logic to reuse port if only a single port range is supplied. This might be unwanted functionality.
- Should we remove the port range as suggested in the tickets and only have a single port entry?
- Do we also get rid of the random port option and simply generate a port if `listen_ports` is empty or zero?
