### PR TITLE
Added method remove_torrents to core.

### DIFF
--- a/deluge/tests/test_torrentmanager.py
+++ b/deluge/tests/test_torrentmanager.py
@@ -1,0 +1,44 @@
+import base64
+import os
+import warnings
+
+from twisted.trial import unittest
+
+import common
+from deluge import component
+from deluge.core.core import Core
+from deluge.core.rpcserver import RPCServer
+from deluge.error import InvalidTorrentError
+
+warnings.filterwarnings("ignore", category=RuntimeWarning)
+warnings.resetwarnings()
+
+
+class TorrentmanagerTestCase(unittest.TestCase):
+
+    def setUp(self):  # NOQA
+        common.set_tmp_config_dir()
+        self.rpcserver = RPCServer(listen=False)
+        self.core = Core()
+        self.torrentManager = self.core.torrentmanager
+        return component.start()
+
+    def tearDown(self):  # NOQA
+        def on_shutdown(result):
+            component._ComponentRegistry.components = {}
+            del self.rpcserver
+            del self.core
+            del self.torrentManager
+        return component.shutdown().addCallback(on_shutdown)
+
+    def test_remove_torrent(self):
+        filename = os.path.join(os.path.dirname(__file__), "test.torrent")
+        torrent_id = self.core.add_torrent_file(filename, base64.encodestring(open(filename).read()), {})
+        self.assertTrue(self.torrentManager.remove(torrent_id, False))
+
+    def test_remove_torrent_false(self):
+        """Test when remove_torrent returns False"""
+        raise unittest.SkipTest("")
+
+    def test_remove_invalid_torrent(self):
+        self.assertRaises(InvalidTorrentError, self.torrentManager.remove, "torrentidthatdoesntexist")

--- a/deluge/ui/gtkui/removetorrentdialog.py
+++ b/deluge/ui/gtkui/removetorrentdialog.py
@@ -67,8 +67,14 @@ class RemoveTorrentDialog(object):
         # Unselect all to avoid issues with the selection changed event
         component.get("TorrentView").treeview.get_selection().unselect_all()
 
-        for torrent_id in self.__torrent_ids:
-            client.core.remove_torrent(torrent_id, remove_data)
+        def on_removed_finished(errors):
+            if errors:
+                log.info("Error(s) occured when trying to delete torrent(s).")
+                for t_id, e_msg in errors:
+                    log.warn("Error removing torrent %s : %s" % (t_id, e_msg))
+
+        d = client.core.remove_torrents(self.__torrent_ids, remove_data)
+        d.addCallback(on_removed_finished)
 
     def run(self):
         """


### PR DESCRIPTION
Removing multiple torrents with remove_torrents will be faster
than calling remove_torrent for each torrent, as the state file
will be written only once, after all the torrents are deleted.
