### PR TITLE
Added quotes around the path arg for explorer.exe

### DIFF
--- a/deluge/common.py
+++ b/deluge/common.py
@@ -217,7 +217,7 @@ def show_file(path, timestamp=None):
 
     """
     if windows_check():
-        subprocess.Popen(["explorer", "/select,", path])
+        subprocess.Popen(["explorer", "/select, \"", path, "\""])
     elif osx_check():
         subprocess.Popen(["open", "-R", path])
     else:

--- a/deluge/common.py
+++ b/deluge/common.py
@@ -217,7 +217,7 @@ def show_file(path, timestamp=None):
 
     """
     if windows_check():
-        subprocess.Popen(["explorer", "/select, \"", path, "\""])
+        subprocess.Popen(["explorer", "/select,", "\"" + path + "\""])
     elif osx_check():
         subprocess.Popen(["open", "-R", path])
     else:


### PR DESCRIPTION
If the filename has spaces this otherwise causes the file not to be selected (untested)