### PR TITLE
[2750] Fixed: Torrents forget paused state after a force recheck.

### DIFF
--- a/deluge/core/torrentmanager.py
+++ b/deluge/core/torrentmanager.py
@@ -968,6 +968,7 @@ class TorrentManager(component.Component):
             torrent.forcing_recheck = False
             if torrent.forcing_recheck_paused:
                 torrent.handle.pause()
+                torrent.pause()
 
         # Set the torrent state
         torrent.update_state()


### PR DESCRIPTION
Fix for ticket #2750: http://dev.deluge-torrent.org/ticket/2750

Solves the issue of torrents not returning to paused state after a force re-check. Possibly due to an underlying issue with libtorrent, but this seems to get around the problem.