### PR TITLE
[#2295] [WebUI] Increased lifespan of display settings

### DIFF
--- a/deluge/ui/web/js/deluge-all/Deluge.js
+++ b/deluge/ui/web/js/deluge-all/Deluge.js
@@ -31,7 +31,14 @@
  */
 
 // Setup the state manager
-Ext.state.Manager.setProvider(new Ext.state.CookieProvider());
+Ext.state.Manager.setProvider(new Ext.state.CookieProvider({
+    /**
+     * By default, cookies will expire after 7 days. Provide
+     * an expiry date 10 years in the future to approximate
+     * a cookie that does not expire.
+     */
+    expires: new Date(new Date().getTime() + (1000 * 60 * 60 * 24 * 365 * 10))
+}));
 
 // Add some additional functions to ext and setup some of the
 // configurable parameters


### PR DESCRIPTION
Display settings for the WebUI are persisted using cookies created by
Ex.state.CookieProvider. When no expiration date is provided, a default
value of (now + 7 days) is used. This causes display settings to be
lost frequently.

This fix adds an 'expires' parameter with a value of (now + 10 years).
This change does not affect the lifespan of the session cookie, which
is created by a separate system.