### PR TITLE
Prevent crashes on FIPS 140-2 compliant systems

### DIFF
--- a/deluge/core/rpcserver.py
+++ b/deluge/core/rpcserver.py
@@ -530,10 +530,10 @@ def generate_ssl_keys():
     """
     This method generates a new SSL key/cert.
     """
-    digest = "md5"
+    digest = "sha256"
     # Generate key pair
     pkey = crypto.PKey()
-    pkey.generate_key(crypto.TYPE_RSA, 1024)
+    pkey.generate_key(crypto.TYPE_RSA, 3072)
 
     # Generate cert request
     req = crypto.X509Req()
@@ -546,7 +546,7 @@ def generate_ssl_keys():
     cert = crypto.X509()
     cert.set_serial_number(0)
     cert.gmtime_adj_notBefore(0)
-    cert.gmtime_adj_notAfter(60 * 60 * 24 * 365 * 5)  # Five Years
+    cert.gmtime_adj_notAfter(60 * 60 * 24 * 365 * 3)  # Three Years
     cert.set_issuer(req.get_subject())
     cert.set_subject(req.get_subject())
     cert.set_pubkey(req.get_pubkey())

--- a/deluge/ui/web/auth.py
+++ b/deluge/ui/web/auth.py
@@ -9,8 +9,8 @@
 
 import hashlib
 import logging
-import random
 import time
+import os
 from datetime import datetime, timedelta
 from email.utils import formatdate
 from functools import reduce
@@ -106,11 +106,8 @@ class Auth(JSONComponent):
         only for future use currently.
         :type login: string
         """
-        m = hashlib.md5()
-        m.update(login)
-        m.update(str(time.time()))
-        m.update(str(random.getrandbits(40)))
-        m.update(m.hexdigest())
+        m = hashlib.sha256()
+        m.update(os.urandom(32))
         session_id = m.hexdigest()
 
         config = component.get("DelugeWeb").config
@@ -246,7 +243,7 @@ class Auth(JSONComponent):
         :type new_password: string
         """
         log.debug("Changing password")
-        salt = hashlib.sha1(str(random.getrandbits(40))).hexdigest()
+        salt = hashlib.sha1(os.urandom(32)).hexdigest()
         s = hashlib.sha1(salt)
         s.update(utf8_encoded(new_password))
         config = component.get("DelugeWeb").config


### PR DESCRIPTION
Replace weak hashing functions, key sizes, and random number
generation techniques with less weak versions to prevent
crashes when running with the fips module loaded.

Specifically:
Stop using md5 wherever possible. It is a deprecated hash.
Stop using 1024bit RSA keys. Things are unlikely to support such short lengths for much longer.
Stop using 5 year expiry. 3 years and 3 months will soon be the longest accepted expiry time of a certificate.
Do not use random as a source of crypto-strength random data. Use os.urandom instead.
Use 32 bytes of random data instead of 5 when creating a session key. This should make it a little harder to guess.
