### PR TITLE
Increased window size of 'Edit trackers' dialog.

### DIFF
--- a/deluge/ui/gtkui/glade/edit_trackers.ui
+++ b/deluge/ui/gtkui/glade/edit_trackers.ui
@@ -3,7 +3,8 @@
   <requires lib="gtk+" version="2.16"/>
   <!-- interface-naming-policy toplevel-contextual -->
   <object class="GtkDialog" id="edit_trackers_dialog">
-    <property name="width_request">400</property>
+    <property name="width_request">800</property>
+    <property name="height_request">400</property>
     <property name="can_focus">False</property>
     <property name="border_width">5</property>
     <property name="title" translatable="yes">Edit Trackers</property>


### PR DESCRIPTION
I always resize the window to be a bit bigger after opening it, so I thought: why not make a PR for this?

When trying to register for Trac, I got a captcha error, so I can't create a ticket for this.
Also, Travis complains, but it looks like a separate issue (gobject can't be found).
