### PR TITLE
Defer save state function to separate thread

### DIFF
--- a/DEPENDS
+++ b/DEPENDS
@@ -2,7 +2,7 @@
  * libtorrent (rasterbar) >= 0.16.7
  * python >= 2.6
  * setuptools
- * twisted >= 8.1
+ * twisted >= 11.1
  * pyopenssl
  * pyxdg
  * chardet


### PR DESCRIPTION
With large amounts of torrents, saving the state file becomes
a performance bottleneck, mainly due to the required processing
in pickle.dump. When run in the main thread, the server will
hang and be unresponsive for a significant time.

Solve this issue by running the save state job in a separate thread.