### PR TITLE
[GTKUI] Fix #2802: GTKUI classic mode shutdown procedure is broken

### DIFF
--- a/deluge/core/daemon.py
+++ b/deluge/core/daemon.py
@@ -154,7 +154,8 @@ class Daemon(object):
 
     def _shutdown(self, *args, **kwargs):
         log.info("Deluge daemon shutting down, waiting for components to shutdown...")
-        return component.shutdown()
+        if not self.classic:
+            return component.shutdown()
 
     @export()
     def get_method_list(self):

--- a/deluge/ui/gtkui/mainwindow.py
+++ b/deluge/ui/gtkui/mainwindow.py
@@ -215,7 +215,7 @@ class MainWindow(component.Component):
         def quit_gtkui():
             def stop_gtk_reactor(result=None):
                 try:
-                    reactor.stop()
+                    reactor.callLater(0, reactor.fireSystemEvent, 'gtkui_close')
                 except ReactorNotRunning:
                     log.debug("Attempted to stop the reactor but it is not running...")
 


### PR DESCRIPTION
As explained in ticket, current shutdown routine in GTKUI is broken: http://dev.deluge-torrent.org/ticket/2802

I think this fixes the issues, but only tested on Ubuntu 15.10
