### PR TITLE
Fix Auto-add plugin to accept torrent files with uppercase extension

### DIFF
--- a/deluge/plugins/AutoAdd/deluge/plugins/autoadd/core.py
+++ b/deluge/plugins/AutoAdd/deluge/plugins/autoadd/core.py
@@ -252,12 +252,13 @@ class Core(CorePluginBase):
                 # Skip directories
                 continue
             else:
-                ext = os.path.splitext(filename)[1]
+                ext = os.path.splitext(filename)[1].lower()
                 if ext == ".torrent":
                     magnet = False
                 elif ext == ".magnet":
                     magnet = True
                 else:
+                    log.debug("File checked for auto-loading is invalid: %s", filename)
                     continue
                 try:
                     filedump = self.load_torrent(filepath, magnet)


### PR DESCRIPTION
The auto-add feature completely misses the all-caps version of the .torrent extension. Some torrent sites share trackers with the extension as ".TORRENT" instead of ".torrent"