### PR TITLE
Fix #2829 : Cannot disable Scheduler plugin

### DIFF
--- a/deluge/plugins/Scheduler/deluge/plugins/scheduler/core.py
+++ b/deluge/plugins/Scheduler/deluge/plugins/scheduler/core.py
@@ -105,7 +105,7 @@ class Core(CorePluginBase):
         """
         core_config = deluge.configmanager.ConfigManager("core.conf")
         for setting in CONTROLLED_SETTINGS:
-            component.get("PreferencesManager").do_config_set_func(setting, core_config[setting])
+            component.get("PreferencesManager").session_set_setting(setting, core_config[setting])
         # Resume the session if necessary
         component.get("Core").resume_session()
 


### PR DESCRIPTION
Please refer to http://dev.deluge-torrent.org/ticket/2829 for detailed information about this bug.