### PR TITLE
Use less versbose units in UI's to gain space and cleaner look

### DIFF
--- a/deluge/log.py
+++ b/deluge/log.py
@@ -151,7 +151,14 @@ def setup_logger(level="error", filename=None, filemode="w", logrotate=None, twi
     )
 
     handler.setFormatter(formatter)
-    root_logger.addHandler(handler)
+
+    # Check for existing handler to prevent duplicate logging.
+    if root_logger.handlers:
+        for handle in root_logger.handlers:
+            if not isinstance(handle, type(handler)):
+                root_logger.addHandler(handler)
+    else:
+        root_logger.addHandler(handler)
     root_logger.setLevel(level)
 
     if twisted_observer:

--- a/deluge/tests/test_common.py
+++ b/deluge/tests/test_common.py
@@ -15,8 +15,9 @@ class CommonTestCase(unittest.TestCase):
         pass
 
     def test_fsize(self):
-        self.assertEquals(fsize(100), "100 Bytes")
-        self.assertEquals(fsize(1023), "1023 Bytes")
+        self.assertEquals(fsize(0), "0 B")
+        self.assertEquals(fsize(100), "100 B")
+        self.assertEquals(fsize(1023), "1023 B")
         self.assertEquals(fsize(1024), "1.0 KiB")
         self.assertEquals(fsize(1048575), "1024.0 KiB")
         self.assertEquals(fsize(1048576), "1.0 MiB")
@@ -24,6 +25,9 @@ class CommonTestCase(unittest.TestCase):
         self.assertEquals(fsize(1073741824), "1.0 GiB")
         self.assertEquals(fsize(112245), "109.6 KiB")
         self.assertEquals(fsize(110723441824), "103.1 GiB")
+        self.assertEquals(fsize(1099511627775), "1024.0 GiB")
+        self.assertEquals(fsize(1099511627777), "1.0 TiB")
+        self.assertEquals(fsize(766148267453245), "696.8 TiB")
 
     def test_fpcnt(self):
         self.failUnless(fpcnt(0.9311) == "93.11%")

--- a/deluge/ui/gtkui/details_tab.py
+++ b/deluge/ui/gtkui/details_tab.py
@@ -17,8 +17,8 @@ from deluge.ui.gtkui.torrentdetails import Tab
 log = logging.getLogger(__name__)
 
 
-def fpeer_size_second(first, second):
-    return "%s (%s)" % (first, fsize(second))
+def fpieces_num_size(num_pieces, piece_size):
+    return "%s (%s)" % (num_pieces, fsize(piece_size, precision=0))
 
 
 def fdate_or_dash(value):
@@ -57,7 +57,7 @@ class DetailsTab(Tab):
             (builder.get_object("summary_comments"), str, ("comment",)),
             (builder.get_object("summary_owner"), str, ("owner",)),
             (builder.get_object("summary_shared"), str_yes_no, ("shared",)),
-            (builder.get_object("summary_pieces"), fpeer_size_second, ("num_pieces", "piece_length")),
+            (builder.get_object("summary_pieces"), fpieces_num_size, ("num_pieces", "piece_length")),
         ]
 
         self.status_keys = [status for widget in self.label_widgets for status in widget[2]]

--- a/deluge/ui/gtkui/files_tab.py
+++ b/deluge/ui/gtkui/files_tab.py
@@ -433,7 +433,7 @@ class FilesTab(Tab):
                 # Catch the unusal error found when moving folders around
                 value = 0
             self.treestore[parent][3] = value
-            self.treestore[parent][2] = "%.2f%%" % value
+            self.treestore[parent][2] = "%i%%" % value
             return completed_bytes
 
         get_completed_bytes(self.treestore.iter_children(root))
@@ -464,7 +464,7 @@ class FilesTab(Tab):
                 continue
 
             try:
-                progress_string = "%.2f%%" % (status["file_progress"][index] * 100)
+                progress_string = "%i%%" % (status["file_progress"][index] * 100)
             except IndexError:
                 continue
             if row[2] != progress_string:

--- a/deluge/ui/gtkui/glade/main_window.tabs.ui
+++ b/deluge/ui/gtkui/glade/main_window.tabs.ui
@@ -247,57 +247,10 @@
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkAlignment" id="alignment45">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="right_padding">5</property>
-                                <child>
-                                  <object class="GtkLabel" id="label39">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="xalign">0</property>
-                                    <property name="label" translatable="yes">Uploaded:</property>
-                                    <attributes>
-                                      <attribute name="weight" value="bold"/>
-                                    </attributes>
-                                  </object>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="top_attach">3</property>
-                                <property name="bottom_attach">4</property>
-                                <property name="x_options">GTK_FILL</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkAlignment" id="alignment44">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="right_padding">5</property>
-                                <child>
-                                  <object class="GtkLabel" id="label38">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="xalign">0</property>
-                                    <property name="label" translatable="yes">Downloaded:</property>
-                                    <attributes>
-                                      <attribute name="weight" value="bold"/>
-                                    </attributes>
-                                  </object>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="top_attach">2</property>
-                                <property name="bottom_attach">3</property>
-                                <property name="x_options">GTK_FILL</property>
-                              </packing>
-                            </child>
-                            <child>
                               <object class="GtkLabel" id="summary_total_uploaded">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="xalign">0</property>
-                                <property name="xpad">5</property>
                               </object>
                               <packing>
                                 <property name="left_attach">1</property>
@@ -312,7 +265,6 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="xalign">0</property>
-                                <property name="xpad">5</property>
                               </object>
                               <packing>
                                 <property name="left_attach">1</property>
@@ -323,59 +275,14 @@
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkAlignment" id="alignment48">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="right_padding">5</property>
-                                <child>
-                                  <object class="GtkLabel" id="label42">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="xalign">0</property>
-                                    <property name="label" translatable="yes">Down Speed:</property>
-                                    <attributes>
-                                      <attribute name="weight" value="bold"/>
-                                    </attributes>
-                                  </object>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="x_options">GTK_FILL</property>
-                              </packing>
-                            </child>
-                            <child>
                               <object class="GtkLabel" id="summary_download_speed">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="xalign">0</property>
-                                <property name="xpad">5</property>
                               </object>
                               <packing>
                                 <property name="left_attach">1</property>
                                 <property name="right_attach">2</property>
-                                <property name="x_options">GTK_FILL</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkAlignment" id="alignment49">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="right_padding">5</property>
-                                <child>
-                                  <object class="GtkLabel" id="label43">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="xalign">0</property>
-                                    <property name="label" translatable="yes">Up Speed:</property>
-                                    <attributes>
-                                      <attribute name="weight" value="bold"/>
-                                    </attributes>
-                                  </object>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="top_attach">1</property>
-                                <property name="bottom_attach">2</property>
                                 <property name="x_options">GTK_FILL</property>
                               </packing>
                             </child>
@@ -384,36 +291,12 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="xalign">0</property>
-                                <property name="xpad">5</property>
                               </object>
                               <packing>
                                 <property name="left_attach">1</property>
                                 <property name="right_attach">2</property>
                                 <property name="top_attach">1</property>
                                 <property name="bottom_attach">2</property>
-                                <property name="x_options">GTK_FILL</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkAlignment" id="alignment50">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="right_padding">5</property>
-                                <child>
-                                  <object class="GtkLabel" id="label45">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="xalign">0</property>
-                                    <property name="label" translatable="yes">ETA:</property>
-                                    <attributes>
-                                      <attribute name="weight" value="bold"/>
-                                    </attributes>
-                                  </object>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="left_attach">3</property>
-                                <property name="right_attach">4</property>
                                 <property name="x_options">GTK_FILL</property>
                               </packing>
                             </child>
@@ -528,38 +411,6 @@
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkLabel" id="label41">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="xalign">0</property>
-                                <property name="label" translatable="yes">Share Ratio:</property>
-                                <attributes>
-                                  <attribute name="weight" value="bold"/>
-                                </attributes>
-                              </object>
-                              <packing>
-                                <property name="left_attach">3</property>
-                                <property name="right_attach">4</property>
-                                <property name="top_attach">3</property>
-                                <property name="bottom_attach">4</property>
-                                <property name="x_options">GTK_FILL</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="summary_share_ratio">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="xalign">0</property>
-                              </object>
-                              <packing>
-                                <property name="left_attach">4</property>
-                                <property name="right_attach">5</property>
-                                <property name="top_attach">3</property>
-                                <property name="bottom_attach">4</property>
-                                <property name="x_options">GTK_FILL</property>
-                              </packing>
-                            </child>
-                            <child>
                               <object class="GtkVSeparator" id="vseparator1">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
@@ -596,8 +447,135 @@
                               <packing>
                                 <property name="left_attach">3</property>
                                 <property name="right_attach">4</property>
+                                <property name="top_attach">3</property>
+                                <property name="bottom_attach">4</property>
+                                <property name="x_options">GTK_FILL</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="summary_share_ratio">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="xalign">0</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">1</property>
+                                <property name="right_attach">2</property>
                                 <property name="top_attach">4</property>
                                 <property name="bottom_attach">5</property>
+                                <property name="x_options">GTK_FILL</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkAlignment" id="alignment44">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="right_padding">5</property>
+                                <child>
+                                  <object class="GtkLabel" id="label38">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="xalign">0</property>
+                                    <property name="label" translatable="yes">Downloaded:</property>
+                                    <attributes>
+                                      <attribute name="weight" value="bold"/>
+                                    </attributes>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="top_attach">2</property>
+                                <property name="bottom_attach">3</property>
+                                <property name="x_options">GTK_FILL</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkAlignment" id="alignment48">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="right_padding">5</property>
+                                <child>
+                                  <object class="GtkLabel" id="label42">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="xalign">0</property>
+                                    <property name="label" translatable="yes">Down Speed:</property>
+                                    <attributes>
+                                      <attribute name="weight" value="bold"/>
+                                    </attributes>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="x_options">GTK_FILL</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkAlignment" id="alignment49">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="right_padding">5</property>
+                                <child>
+                                  <object class="GtkLabel" id="label43">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="xalign">0</property>
+                                    <property name="label" translatable="yes">Up Speed:</property>
+                                    <attributes>
+                                      <attribute name="weight" value="bold"/>
+                                    </attributes>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="top_attach">1</property>
+                                <property name="bottom_attach">2</property>
+                                <property name="x_options">GTK_FILL</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkAlignment" id="alignment50">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="right_padding">5</property>
+                                <child>
+                                  <object class="GtkLabel" id="label45">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="xalign">0</property>
+                                    <property name="label" translatable="yes">ETA:</property>
+                                    <attributes>
+                                      <attribute name="weight" value="bold"/>
+                                    </attributes>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="left_attach">3</property>
+                                <property name="right_attach">4</property>
+                                <property name="x_options">GTK_FILL</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkAlignment" id="alignment45">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="right_padding">5</property>
+                                <child>
+                                  <object class="GtkLabel" id="label39">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="xalign">0</property>
+                                    <property name="label" translatable="yes">Uploaded:</property>
+                                    <attributes>
+                                      <attribute name="weight" value="bold"/>
+                                    </attributes>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="top_attach">3</property>
+                                <property name="bottom_attach">4</property>
                                 <property name="x_options">GTK_FILL</property>
                               </packing>
                             </child>
@@ -610,6 +588,29 @@
                               <packing>
                                 <property name="left_attach">4</property>
                                 <property name="right_attach">5</property>
+                                <property name="top_attach">3</property>
+                                <property name="bottom_attach">4</property>
+                                <property name="x_options">GTK_FILL</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkAlignment" id="alignment4">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="right_padding">5</property>
+                                <child>
+                                  <object class="GtkLabel" id="label41">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="xalign">0</property>
+                                    <property name="label" translatable="yes">Share Ratio:</property>
+                                    <attributes>
+                                      <attribute name="weight" value="bold"/>
+                                    </attributes>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
                                 <property name="top_attach">4</property>
                                 <property name="bottom_attach">5</property>
                                 <property name="x_options">GTK_FILL</property>

--- a/deluge/ui/gtkui/listview.py
+++ b/deluge/ui/gtkui/listview.py
@@ -520,7 +520,7 @@ class ListView(object):
         column.set_clickable(True)
         column.set_resizable(True)
         column.set_expand(False)
-        column.set_min_width(10)
+        column.set_min_width(20)
         column.set_reorderable(True)
         column.set_visible(not hidden)
         column.connect('button-press-event',

--- a/deluge/ui/gtkui/mainwindow.py
+++ b/deluge/ui/gtkui/mainwindow.py
@@ -300,9 +300,9 @@ class MainWindow(component.Component):
     def update(self):
         # Update the window title
         def _on_get_session_status(status):
-            download_rate = deluge.common.fsize_short(status["payload_download_rate"])
-            upload_rate = deluge.common.fsize_short(status["payload_upload_rate"])
-            self.window.set_title("%s%s %s%s - Deluge" % (_("D:"), download_rate, _("U:"), upload_rate))
+            download_rate = deluge.common.fspeed(status["payload_download_rate"], precision=0, shortform=True)
+            upload_rate = deluge.common.fspeed(status["payload_upload_rate"], precision=0, shortform=True)
+            self.window.set_title(_("D: %s U: %s - Deluge" % (download_rate, upload_rate)))
         if self.config["show_rate_in_title"]:
             client.core.get_session_status(["payload_download_rate",
                                             "payload_upload_rate"]).addCallback(_on_get_session_status)
@@ -311,7 +311,7 @@ class MainWindow(component.Component):
         if value:
             self.update()
         else:
-            self.window.set_title("Deluge")
+            self.window.set_title(_("Deluge"))
 
     def on_newversionavailable_event(self, new_version):
         if self.config["show_new_releases"]:

--- a/deluge/ui/gtkui/peers_tab.py
+++ b/deluge/ui/gtkui/peers_tab.py
@@ -25,9 +25,9 @@ log = logging.getLogger(__name__)
 
 
 def cell_data_progress(column, cell, model, row, data):
-    value = model.get_value(row, data)
-    cell.set_property("value", value * 100)
-    cell.set_property("text", "%.2f%%" % (value * 100))
+    value = model.get_value(row, data) * 100
+    cell.set_property("value", value)
+    cell.set_property("text", "%i%%" % value)
 
 
 class PeersTab(Tab):

--- a/deluge/ui/gtkui/systemtray.py
+++ b/deluge/ui/gtkui/systemtray.py
@@ -14,6 +14,7 @@ import gtk
 
 import deluge.common
 import deluge.component as component
+from deluge.common import fspeed
 from deluge.configmanager import ConfigManager
 from deluge.ui.client import client
 from deluge.ui.gtkui import dialogs
@@ -192,8 +193,8 @@ class SystemTray(component.Component):
             self.build_tray_bwsetsubmenu()
 
     def _on_get_session_status(self, status):
-        self.download_rate = deluge.common.fsize(status["payload_download_rate"])
-        self.upload_rate = deluge.common.fsize(status["payload_upload_rate"])
+        self.download_rate = fspeed(status["payload_download_rate"], shortform=True)
+        self.upload_rate = fspeed(status["payload_upload_rate"], shortform=True)
 
     def update(self):
         if not self.config["enable_system_tray"]:
@@ -214,11 +215,11 @@ class SystemTray(component.Component):
         if max_download_speed == -1:
             max_download_speed = _("Unlimited")
         else:
-            max_download_speed = "%s %s" % (max_download_speed, _("KiB/s"))
+            max_download_speed = "%s %s" % (max_download_speed, _("K/s"))
         if max_upload_speed == -1:
             max_upload_speed = _("Unlimited")
         else:
-            max_upload_speed = "%s %s" % (max_upload_speed, _("KiB/s"))
+            max_upload_speed = "%s %s" % (max_upload_speed, _("K/s"))
 
         msg = '%s\n%s: %s (%s)\n%s: %s (%s)' % (
             _("Deluge"), _("Down"), self.download_rate,
@@ -235,14 +236,14 @@ class SystemTray(component.Component):
         submenu_bwdownset = build_menu_radio_list(
             self.config["tray_download_speed_list"], self.on_tray_setbwdown,
             self.max_download_speed,
-            _("KiB/s"), show_notset=True, show_other=True
+            _("K/s"), show_notset=True, show_other=True
         )
 
         # Create the Upload speed list sub-menu
         submenu_bwupset = build_menu_radio_list(
             self.config["tray_upload_speed_list"], self.on_tray_setbwup,
             self.max_upload_speed,
-            _("KiB/s"), show_notset=True, show_other=True
+            _("K/s"), show_notset=True, show_other=True
         )
         # Add the sub-menus to the tray menu
         self.builder.get_object("menuitem_download_limit").set_submenu(
@@ -393,7 +394,7 @@ class SystemTray(component.Component):
         if widget.get_name() == "unlimited":
             set_value(-1)
         elif widget.get_name() == "other":
-            dialog = dialogs.OtherDialog(header, text, _("KiB/s"), image, default)
+            dialog = dialogs.OtherDialog(header, text, _("K/s"), image, default)
             dialog.run().addCallback(set_value)
         else:
             set_value(widget.get_children()[0].get_text().split(" ")[0])

--- a/deluge/ui/gtkui/torrentview_data_funcs.py
+++ b/deluge/ui/gtkui/torrentview_data_funcs.py
@@ -140,7 +140,7 @@ def cell_data_progress(column, cell, model, row, data):
     # Marked for translate states text are in filtertreeview
     textstr = _(state_str)
     if state_str not in ("Error", "Seeding") and value < 100:
-        textstr = "%s %.2f%%" % (textstr, value)
+        textstr = "%s %i%%" % (textstr, value)
 
     if func_last_value["cell_data_progress"][1] != textstr:
         func_last_value["cell_data_progress"][1] = textstr
@@ -172,10 +172,11 @@ def cell_data_speed(cell, model, row, data, cache_key):
         return
     func_last_value[cache_key] = speed
 
-    speed_str = ""
     if speed > 0:
-        speed_str = common.fspeed(speed)
-    cell.set_property('text', speed_str)
+        speed_str = common.fspeed(speed, shortform=True)
+        cell.set_property("markup", "{0} <small>{1}</small>".format(*tuple(speed_str.split())))
+    else:
+        cell.set_property("text", "")
 
 
 def cell_data_speed_down(column, cell, model, row, data):
@@ -196,10 +197,11 @@ def cell_data_speed_limit(cell, model, row, data, cache_key):
         return
     func_last_value[cache_key] = speed
 
-    speed_str = ""
     if speed > 0:
-        speed_str = common.fspeed(speed * 1024)
-    cell.set_property('text', speed_str)
+        speed_str = common.fspeed(speed * 1024, shortform=True)
+        cell.set_property("markup", "{0} <small>{1}</small>".format(*tuple(speed_str.split())))
+    else:
+        cell.set_property("text", "")
 
 
 def cell_data_speed_limit_down(column, cell, model, row, data):
@@ -213,7 +215,7 @@ def cell_data_speed_limit_up(column, cell, model, row, data):
 def cell_data_size(column, cell, model, row, data):
     """Display value in terms of size, eg. 2 MB"""
     size = model.get_value(row, data)
-    cell.set_property('text', common.fsize(size))
+    cell.set_property('text', common.fsize(size, shortform=True))
 
 
 def cell_data_peer(column, cell, model, row, data):
@@ -241,13 +243,13 @@ def cell_data_time(column, cell, model, row, data):
 
 
 def cell_data_ratio(cell, model, row, data, cache_key):
-    """Display value as a ratio with a precision of 3."""
+    """Display value as a ratio with a precision of 2."""
     ratio = model.get_value(row, data)
     # Previous value in cell is the same as for this value, so ignore
     if func_last_value[cache_key] == ratio:
         return
     func_last_value[cache_key] = ratio
-    cell.set_property('text', "∞" if ratio < 0 else "%.3f" % ratio)
+    cell.set_property("text", "∞" if ratio < 0 else ("%.1f" % ratio).rstrip("0").rstrip("."))
 
 
 def cell_data_ratio_seeds_peers(column, cell, model, row, data):
@@ -270,7 +272,7 @@ def cell_data_date(column, cell, model, row, data, key):
         return
     func_last_value[key] = date
 
-    date_str = common.fdate(date) if date > 0 else ""
+    date_str = common.fdate(date, date_only=True) if date > 0 else ""
     cell.set_property('text', date_str)
 
 cell_data_date_added = partial(cell_data_date, key="cell_data_date_added")
@@ -285,5 +287,5 @@ def cell_data_date_or_never(column, cell, model, row, data):
         return
     func_last_value["cell_data_date_or_never"] = value
 
-    date_str = common.fdate(value) if value > 0 else _("Never")
+    date_str = common.fdate(value, date_only=True) if value > 0 else _("Never")
     cell.set_property('text', date_str)


### PR DESCRIPTION
This is a work in progress so no cleaned up commits yet...

It is an attempt to regain valuable screen space in areas such as columns, indicators, statusbars by shorting the displayed text for values and units.

- [x] Add a precision option to choose number of decimal places.
- [x] Add a short-form option to shorten the unit displayed.
- [x] Use markup in gtkui to reduce font size of displayed units. 
- [x] Reduced the statusbar item sizes by using markup and `<small>` tag. This provides a decent interim solution to [#1326](http://dev.deluge-torrent.org/ticket/1326), changes so far have reduced width from 930px to ~600px (0 speed reduces space a bit).
 ![selection_047](https://cloud.githubusercontent.com/assets/606038/15321598/75434e98-1c2f-11e6-908d-cf34e519952d.png)
 ![selection_048](https://cloud.githubusercontent.com/assets/606038/15321606/7afa13da-1c2f-11e6-81cd-7a1ad4da9968.png)
- [x] Currently undecided on whether zero should retain the unit i.e. `0`, `0 B/s` or `0 K/s`... (reverted to 0 B/s)
- [ ] WebUI requires all the same changes
- [ ] Console requires the same changes but should wait for #62 

Issues:
- [x] GtkUI speed in titlebar `has no attribute 'fsize_short'`.
- [x] Remove decimal point for pieces size.
- [x] Status tab progress bar percentage remove unneeded decimal places.