### PR TITLE
Setting listening ports fixes and updates

### DIFF
--- a/deluge/ui/console/modes/preference_panes.py
+++ b/deluge/ui/console/modes/preference_panes.py
@@ -85,12 +85,11 @@ class BasePane(object):
         for ipt in self.inputs:
             if not isinstance(ipt, NoInput):
                 # gross, have to special case in/out ports since they are tuples
-                if ipt.name in ("listen_ports_to", "listen_ports_from", "out_ports_from", "out_ports_to",
+                if ipt.name in ("listen_interface", "listen_port", "out_ports_from", "out_ports_to",
                                 "i2p_port", "i2p_hostname", "proxy_type", "proxy_username", "proxy_hostnames",
-                                "proxy_password", "proxy_hostname", "proxy_port", "proxy_peer_connections",
-                                "listen_interface"):
-                    if ipt.name == "listen_ports_to":
-                        conf_dict["listen_ports"] = (self.infrom.get_value(), self.into.get_value())
+                                "proxy_password", "proxy_hostname", "proxy_port", "proxy_peer_connections"):
+                    if ipt.name == "listen_port":
+                        conf_dict["listen_ports"] = [self.infrom.get_value()] * 2
                     elif ipt.name == "out_ports_to":
                         conf_dict["outgoing_ports"] = (self.outfrom.get_value(), self.outto.get_value())
                     elif ipt.name == "listen_interface":
@@ -309,17 +308,14 @@ class DownloadsPane(BasePane):
 class NetworkPane(BasePane):
     def __init__(self, offset, parent, width):
         BasePane.__init__(self, offset, parent, width)
-        self.add_header("Incomming Ports")
-        inrand = CheckedInput(parent, "Use Random Ports    Active Port: %d" % parent.active_port,
+        self.add_header("Incomming Port")
+        inrand = CheckedInput(parent, "Use Random Port    Active Port: %d" % parent.active_port,
                               "random_port", parent.core_config["random_port"])
         self.inputs.append(inrand)
         listen_ports = parent.core_config["listen_ports"]
-        self.infrom = IntSpinInput(self.parent, "  From:", "listen_ports_from", self.move, listen_ports[0], 0, 65535)
+        self.infrom = IntSpinInput(self.parent, "  ", "listen_port", self.move, listen_ports[0], 0, 65535)
         self.infrom.set_depend(inrand, True)
-        self.into = IntSpinInput(self.parent, "  To:  ", "listen_ports_to", self.move, listen_ports[1], 0, 65535)
-        self.into.set_depend(inrand, True)
         self.inputs.append(self.infrom)
-        self.inputs.append(self.into)
 
         self.add_header("Outgoing Ports", True)
         outrand = CheckedInput(parent, "Use Random Ports", "random_outgoing_ports",

--- a/deluge/ui/gtkui/addtorrentdialog.py
+++ b/deluge/ui/gtkui/addtorrentdialog.py
@@ -404,22 +404,15 @@ class AddTorrentDialog(component.Component):
         options["move_completed_path"] = self.move_completed_path_chooser.get_text()
         options["pre_allocate_storage"] = self.builder.get_object("chk_pre_alloc").get_active()
         options["move_completed"] = self.builder.get_object("chk_move_completed").get_active()
-        options["max_download_speed"] = \
-            self.builder.get_object("spin_maxdown").get_value()
-        options["max_upload_speed"] = \
-            self.builder.get_object("spin_maxup").get_value()
-        options["max_connections"] = \
-            self.builder.get_object("spin_maxconnections").get_value_as_int()
-        options["max_upload_slots"] = \
-            self.builder.get_object("spin_maxupslots").get_value_as_int()
-        options["add_paused"] = \
-            self.builder.get_object("chk_paused").get_active()
-        options["prioritize_first_last_pieces"] = \
-            self.builder.get_object("chk_prioritize").get_active()
-        options["sequential_download"] = \
-            self.builder.get_object("chk_sequential_download").get_active() or False
-        options["move_completed"] = \
-            self.builder.get_object("chk_move_completed").get_active()
+        options["max_download_speed"] = self.builder.get_object("spin_maxdown").get_value()
+        options["max_upload_speed"] = self.builder.get_object("spin_maxup").get_value()
+        options["max_connections"] = self.builder.get_object("spin_maxconnections").get_value_as_int()
+        options["max_upload_slots"] = self.builder.get_object("spin_maxupslots").get_value_as_int()
+        options["add_paused"] = self.builder.get_object("chk_paused").get_active()
+        options["prioritize_first_last_pieces"] = self.builder.get_object("chk_prioritize").get_active()
+        options["sequential_download"] = self.builder.get_object(
+            "chk_sequential_download").get_active() or False
+        options["move_completed"] = self.builder.get_object("chk_move_completed").get_active()
         options["seed_mode"] = self.builder.get_object("chk_seed_mode").get_active()
 
         self.options[torrent_id] = options

--- a/deluge/ui/gtkui/glade/preferences_dialog.ui
+++ b/deluge/ui/gtkui/glade/preferences_dialog.ui
@@ -51,6 +51,11 @@
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
   </object>
+  <object class="GtkAdjustment" id="adjustment_spin_incoming_port">
+    <property name="upper">65535</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
   <object class="GtkAdjustment" id="adjustment_spin_max_conn_global">
     <property name="lower">-1</property>
     <property name="upper">9999</property>
@@ -117,16 +122,6 @@
     <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment_spin_outgoing_port_min">
-    <property name="upper">65535</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
-  </object>
-  <object class="GtkAdjustment" id="adjustment_spin_port_max">
-    <property name="upper">65535</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
-  </object>
-  <object class="GtkAdjustment" id="adjustment_spin_port_min">
     <property name="upper">65535</property>
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
@@ -2796,78 +2791,30 @@ used sparingly.</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <child>
-                                              <object class="GtkLabel" id="label1">
+                                              <object class="GtkSpinButton" id="spin_incoming_port">
                                                 <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="label" translatable="yes">From:</property>
+                                                <property name="sensitive">False</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="max_length">5</property>
+                                                <property name="xalign">1</property>
+                                                <property name="primary_icon_activatable">False</property>
+                                                <property name="secondary_icon_activatable">False</property>
+                                                <property name="primary_icon_sensitive">True</property>
+                                                <property name="secondary_icon_sensitive">True</property>
+                                                <property name="adjustment">adjustment_spin_incoming_port</property>
+                                                <property name="climb_rate">1</property>
+                                                <property name="snap_to_ticks">True</property>
+                                                <property name="numeric">True</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
                                                 <property name="fill">True</property>
+                                                <property name="padding">5</property>
                                                 <property name="position">0</property>
                                               </packing>
                                             </child>
                                             <child>
-                                              <object class="GtkSpinButton" id="spin_port_min">
-                                                <property name="visible">True</property>
-                                                <property name="sensitive">False</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="max_length">5</property>
-                                                <property name="xalign">1</property>
-                                                <property name="primary_icon_activatable">False</property>
-                                                <property name="secondary_icon_activatable">False</property>
-                                                <property name="primary_icon_sensitive">True</property>
-                                                <property name="secondary_icon_sensitive">True</property>
-                                                <property name="adjustment">adjustment_spin_port_min</property>
-                                                <property name="climb_rate">1</property>
-                                                <property name="snap_to_ticks">True</property>
-                                                <property name="numeric">True</property>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">True</property>
-                                                <property name="padding">5</property>
-                                                <property name="position">1</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkLabel" id="label2">
-                                                <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="xpad">5</property>
-                                                <property name="label" translatable="yes">To:</property>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">False</property>
-                                                <property name="position">2</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkSpinButton" id="spin_port_max">
-                                                <property name="visible">True</property>
-                                                <property name="sensitive">False</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="max_length">5</property>
-                                                <property name="xalign">1</property>
-                                                <property name="primary_icon_activatable">False</property>
-                                                <property name="secondary_icon_activatable">False</property>
-                                                <property name="primary_icon_sensitive">True</property>
-                                                <property name="secondary_icon_sensitive">True</property>
-                                                <property name="adjustment">adjustment_spin_port_max</property>
-                                                <property name="climb_rate">1</property>
-                                                <property name="snap_to_ticks">True</property>
-                                                <property name="numeric">True</property>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">True</property>
-                                                <property name="padding">5</property>
-                                                <property name="position">3</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkCheckButton" id="chk_random_port">
+                                              <object class="GtkCheckButton" id="chk_random_incoming_port">
                                                 <property name="label" translatable="yes">Random</property>
                                                 <property name="use_action_appearance">False</property>
                                                 <property name="visible">True</property>
@@ -2881,7 +2828,7 @@ used sparingly.</property>
                                                 <property name="expand">False</property>
                                                 <property name="fill">True</property>
                                                 <property name="padding">5</property>
-                                                <property name="position">4</property>
+                                                <property name="position">1</property>
                                               </packing>
                                             </child>
                                           </object>
@@ -2990,7 +2937,7 @@ used sparingly.</property>
                                   <object class="GtkLabel" id="label4">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="label" translatable="yes">Incoming Ports</property>
+                                    <property name="label" translatable="yes">Incoming Port</property>
                                     <attributes>
                                       <attribute name="weight" value="bold"/>
                                     </attributes>

--- a/deluge/ui/gtkui/options_tab.py
+++ b/deluge/ui/gtkui/options_tab.py
@@ -167,60 +167,39 @@ class OptionsTab(Tab):
 
     def _on_button_apply_clicked(self, button):
         if self.spin_max_download.get_value() != self.prev_status["max_download_speed"]:
-            client.core.set_torrent_max_download_speed(
-                self.prev_torrent_id, self.spin_max_download.get_value()
-            )
+            client.core.set_torrent_max_download_speed(self.prev_torrent_id, self.spin_max_download.get_value())
         if self.spin_max_upload.get_value() != self.prev_status["max_upload_speed"]:
-            client.core.set_torrent_max_upload_speed(
-                self.prev_torrent_id, self.spin_max_upload.get_value()
-            )
+            client.core.set_torrent_max_upload_speed(self.prev_torrent_id, self.spin_max_upload.get_value())
         if self.spin_max_connections.get_value_as_int() != self.prev_status["max_connections"]:
             client.core.set_torrent_max_connections(
-                self.prev_torrent_id, self.spin_max_connections.get_value_as_int()
-            )
+                self.prev_torrent_id, self.spin_max_connections.get_value_as_int())
         if self.spin_max_upload_slots.get_value_as_int() != self.prev_status["max_upload_slots"]:
             client.core.set_torrent_max_upload_slots(
-                self.prev_torrent_id, self.spin_max_upload_slots.get_value_as_int()
-            )
-        if self.chk_prioritize_first_last.get_active() != \
-            self.prev_status["prioritize_first_last"] and \
-                self.prev_status["storage_mode"] != "compact":
+                self.prev_torrent_id, self.spin_max_upload_slots.get_value_as_int())
+        if (self.chk_prioritize_first_last.get_active() !=
+                self.prev_status["prioritize_first_last"] and self.prev_status["storage_mode"] != "compact"):
             client.core.set_torrent_prioritize_first_last(
-                self.prev_torrent_id, self.chk_prioritize_first_last.get_active()
-            )
-        if self.chk_sequential_download.get_active() != \
-            self.prev_status["sequential_download"] and \
-                self.prev_status["storage_mode"] != "compact":
+                self.prev_torrent_id, self.chk_prioritize_first_last.get_active())
+        if (self.chk_sequential_download.get_active() !=
+                self.prev_status["sequential_download"] and self.prev_status["storage_mode"] != "compact"):
             client.core.set_torrent_options(
-                [self.prev_torrent_id], {"sequential_download": self.chk_sequential_download.get_active()}
-            )
+                [self.prev_torrent_id], {"sequential_download": self.chk_sequential_download.get_active()})
         if self.chk_auto_managed.get_active() != self.prev_status["is_auto_managed"]:
-            client.core.set_torrent_auto_managed(
-                self.prev_torrent_id, self.chk_auto_managed.get_active()
-            )
+            client.core.set_torrent_auto_managed(self.prev_torrent_id, self.chk_auto_managed.get_active())
         if self.chk_stop_at_ratio.get_active() != self.prev_status["stop_at_ratio"]:
-            client.core.set_torrent_stop_at_ratio(
-                self.prev_torrent_id, self.chk_stop_at_ratio.get_active()
-            )
+            client.core.set_torrent_stop_at_ratio(self.prev_torrent_id, self.chk_stop_at_ratio.get_active())
         if self.spin_stop_ratio.get_value() != self.prev_status["stop_ratio"]:
-            client.core.set_torrent_stop_ratio(
-                self.prev_torrent_id, self.spin_stop_ratio.get_value()
-            )
+            client.core.set_torrent_stop_ratio(self.prev_torrent_id, self.spin_stop_ratio.get_value())
         if self.chk_remove_at_ratio.get_active() != self.prev_status["remove_at_ratio"]:
-            client.core.set_torrent_remove_at_ratio(
-                self.prev_torrent_id, self.chk_remove_at_ratio.get_active()
-            )
+            client.core.set_torrent_remove_at_ratio(self.prev_torrent_id, self.chk_remove_at_ratio.get_active())
         if self.chk_move_completed.get_active() != self.prev_status["move_on_completed"]:
-            client.core.set_torrent_move_completed(
-                self.prev_torrent_id, self.chk_move_completed.get_active()
-            )
+            client.core.set_torrent_move_completed(self.prev_torrent_id, self.chk_move_completed.get_active())
         if self.chk_move_completed.get_active():
             path = self.move_completed_path_chooser.get_text()
             client.core.set_torrent_move_completed_path(self.prev_torrent_id, path)
         if self.chk_shared.get_active() != self.prev_status["shared"]:
-            client.core.set_torrents_shared(
-                self.prev_torrent_id, self.chk_shared.get_active()
-            )
+            client.core.set_torrents_shared(self.prev_torrent_id, self.chk_shared.get_active())
+
         self.button_apply.set_sensitive(False)
 
     def _on_chk_move_completed_toggled(self, widget):

--- a/deluge/ui/gtkui/path_combo_chooser.py
+++ b/deluge/ui/gtkui/path_combo_chooser.py
@@ -722,8 +722,7 @@ class StoredValuesPopup(StoredValuesList, PathChooserPopup):
         self.popup_buttonbox = self.builder.get_object("buttonbox")
 
         # Add signal handlers
-        self.signal_handlers["on_buttonbox_key_press_event"] = \
-            self.on_buttonbox_key_press_event
+        self.signal_handlers["on_buttonbox_key_press_event"] = self.on_buttonbox_key_press_event
         self.signal_handlers["on_stored_values_treeview_scroll_event"] = self.on_scroll_event
         self.signal_handlers["on_button_toggle_dropdown_scroll_event"] = self.on_scroll_event
         self.signal_handlers["on_entry_text_scroll_event"] = self.on_scroll_event
@@ -922,10 +921,8 @@ class PathAutoCompleter(object):
 
         self.signal_handlers["on_completion_popup_window_key_press_event"] = \
             self.on_completion_popup_window_key_press_event
-        self.signal_handlers["on_entry_text_delete_text"] = \
-            self.on_entry_text_delete_text
-        self.signal_handlers["on_entry_text_insert_text"] = \
-            self.on_entry_text_insert_text
+        self.signal_handlers["on_entry_text_delete_text"] = self.on_entry_text_delete_text
+        self.signal_handlers["on_entry_text_insert_text"] = self.on_entry_text_insert_text
         self.accelerator_string = gtk.accelerator_name(keysyms.Tab, 0)
 
     def on_entry_text_insert_text(self, entry, new_text, new_text_length, position):

--- a/deluge/ui/gtkui/preferences.py
+++ b/deluge/ui/gtkui/preferences.py
@@ -46,8 +46,7 @@ class Preferences(component.Component):
         component.Component.__init__(self, "Preferences")
         self.builder = gtk.Builder()
         self.builder.add_from_file(deluge.common.resource_filename(
-            "deluge.ui.gtkui", os.path.join("glade", "preferences_dialog.ui")
-        ))
+            "deluge.ui.gtkui", os.path.join("glade", "preferences_dialog.ui")))
         self.pref_dialog = self.builder.get_object("pref_dialog")
         self.pref_dialog.set_transient_for(component.get("MainWindow").window)
         self.pref_dialog.set_icon(get_deluge_icon())
@@ -90,25 +89,15 @@ class Preferences(component.Component):
         self.accounts_liststore.set_sort_column_id(ACCOUNTS_USERNAME, gtk.SORT_ASCENDING)
         self.accounts_listview = self.builder.get_object("accounts_listview")
         self.accounts_listview.append_column(
-            gtk.TreeViewColumn(
-                _("Username"), gtk.CellRendererText(), text=ACCOUNTS_USERNAME
-            )
-        )
+            gtk.TreeViewColumn(_("Username"), gtk.CellRendererText(), text=ACCOUNTS_USERNAME))
         self.accounts_listview.append_column(
-            gtk.TreeViewColumn(
-                _("Level"), gtk.CellRendererText(), text=ACCOUNTS_LEVEL
-            )
-        )
-        password_column = gtk.TreeViewColumn(
-            'password', gtk.CellRendererText(), text=ACCOUNTS_PASSWORD
-        )
+            gtk.TreeViewColumn(_("Level"), gtk.CellRendererText(), text=ACCOUNTS_LEVEL))
+        password_column = gtk.TreeViewColumn('password', gtk.CellRendererText(), text=ACCOUNTS_PASSWORD)
         self.accounts_listview.append_column(password_column)
         password_column.set_visible(False)
         self.accounts_listview.set_model(self.accounts_liststore)
 
-        self.accounts_listview.get_selection().connect(
-            "changed", self._on_accounts_selection_changed
-        )
+        self.accounts_listview.get_selection().connect("changed", self._on_accounts_selection_changed)
         self.accounts_frame = self.builder.get_object("AccountsFrame")
 
         # Setup plugin tab listview
@@ -120,20 +109,14 @@ class Preferences(component.Component):
         render = gtk.CellRendererToggle()
         render.connect("toggled", self.on_plugin_toggled)
         render.set_property("activatable", True)
-        self.plugin_listview.append_column(
-            gtk.TreeViewColumn(_("Enabled"), render, active=1))
-        self.plugin_listview.append_column(
-            gtk.TreeViewColumn(_("Plugin"), gtk.CellRendererText(), text=2))
+        self.plugin_listview.append_column(gtk.TreeViewColumn(_("Enabled"), render, active=1))
+        self.plugin_listview.append_column(gtk.TreeViewColumn(_("Plugin"), gtk.CellRendererText(), text=2))
 
         # Connect to the 'changed' event of TreeViewSelection to get selection
         # changes.
-        self.treeview.get_selection().connect(
-            "changed", self.on_selection_changed
-        )
+        self.treeview.get_selection().connect("changed", self.on_selection_changed)
 
-        self.plugin_listview.get_selection().connect(
-            "changed", self.on_plugin_selection_changed
-        )
+        self.plugin_listview.get_selection().connect("changed", self.on_plugin_selection_changed)
 
         self.builder.connect_signals({
             "on_pref_dialog_delete_event": self.on_pref_dialog_delete_event,
@@ -459,41 +442,28 @@ class Preferences(component.Component):
                 self.on_toggle(widget)
 
         # Downloads tab #
-        self.builder.get_object("chk_show_dialog").set_active(
-            self.gtkui_config["interactive_add"])
-        self.builder.get_object("chk_focus_dialog").set_active(
-            self.gtkui_config["focus_add_dialog"])
+        self.builder.get_object("chk_show_dialog").set_active(self.gtkui_config["interactive_add"])
+        self.builder.get_object("chk_focus_dialog").set_active(self.gtkui_config["focus_add_dialog"])
 
         # Interface tab #
-        self.builder.get_object("chk_use_tray").set_active(
-            self.gtkui_config["enable_system_tray"])
-        self.builder.get_object("chk_min_on_close").set_active(
-            self.gtkui_config["close_to_tray"])
-        self.builder.get_object("chk_start_in_tray").set_active(
-            self.gtkui_config["start_in_tray"])
-        self.builder.get_object("radio_appind").set_active(
-            self.gtkui_config["enable_appindicator"])
-        self.builder.get_object("chk_lock_tray").set_active(
-            self.gtkui_config["lock_tray"])
-        self.builder.get_object("radio_classic").set_active(
-            self.gtkui_config["classic_mode"])
-        self.builder.get_object("radio_thinclient").set_active(
-            not self.gtkui_config["classic_mode"])
-        self.builder.get_object("chk_show_rate_in_title").set_active(
-            self.gtkui_config["show_rate_in_title"])
+        self.builder.get_object("chk_use_tray").set_active(self.gtkui_config["enable_system_tray"])
+        self.builder.get_object("chk_min_on_close").set_active(self.gtkui_config["close_to_tray"])
+        self.builder.get_object("chk_start_in_tray").set_active(self.gtkui_config["start_in_tray"])
+        self.builder.get_object("radio_appind").set_active(self.gtkui_config["enable_appindicator"])
+        self.builder.get_object("chk_lock_tray").set_active(self.gtkui_config["lock_tray"])
+        self.builder.get_object("radio_classic").set_active(self.gtkui_config["classic_mode"])
+        self.builder.get_object("radio_thinclient").set_active(not self.gtkui_config["classic_mode"])
+        self.builder.get_object("chk_show_rate_in_title").set_active(self.gtkui_config["show_rate_in_title"])
         self.builder.get_object("chk_focus_main_window_on_add").set_active(
             self.gtkui_config["focus_main_window_on_add"])
-        self.builder.get_object("piecesbar_toggle").set_active(
-            self.gtkui_config["show_piecesbar"]
-        )
+        self.builder.get_object("piecesbar_toggle").set_active(self.gtkui_config["show_piecesbar"])
         self.__set_color("completed", from_config=True)
         self.__set_color("downloading", from_config=True)
         self.__set_color("waiting", from_config=True)
         self.__set_color("missing", from_config=True)
 
         # Other tab #
-        self.builder.get_object("chk_show_new_releases").set_active(
-            self.gtkui_config["show_new_releases"])
+        self.builder.get_object("chk_show_new_releases").set_active(self.gtkui_config["show_new_releases"])
 
         # Cache tab #
         if client.connected():
@@ -531,10 +501,8 @@ class Preferences(component.Component):
         new_gtkui_config = {}
 
         # Downloads tab #
-        new_gtkui_config["interactive_add"] = \
-            self.builder.get_object("chk_show_dialog").get_active()
-        new_gtkui_config["focus_add_dialog"] = \
-            self.builder.get_object("chk_focus_dialog").get_active()
+        new_gtkui_config["interactive_add"] = self.builder.get_object("chk_show_dialog").get_active()
+        new_gtkui_config["focus_add_dialog"] = self.builder.get_object("chk_focus_dialog").get_active()
 
         for state in ("missing", "waiting", "downloading", "completed"):
             color = self.builder.get_object("%s_color" % state).get_color()
@@ -542,100 +510,78 @@ class Preferences(component.Component):
                 color.red, color.green, color.blue
             ]
 
-        new_core_config["copy_torrent_file"] = \
-            self.builder.get_object("chk_copy_torrent_file").get_active()
-        new_core_config["del_copy_torrent_file"] = \
-            self.builder.get_object("chk_del_copy_torrent_file").get_active()
-        new_core_config["move_completed"] = \
-            self.builder.get_object("chk_move_completed").get_active()
+        new_core_config["copy_torrent_file"] = self.builder.get_object(
+            "chk_copy_torrent_file").get_active()
+        new_core_config["del_copy_torrent_file"] = self.builder.get_object(
+            "chk_del_copy_torrent_file").get_active()
+        new_core_config["move_completed"] = self.builder.get_object("chk_move_completed").get_active()
 
         new_core_config["download_location"] = self.download_location_path_chooser.get_text()
         new_core_config["move_completed_path"] = self.move_completed_path_chooser.get_text()
         new_core_config["torrentfiles_location"] = self.copy_torrent_files_path_chooser.get_text()
-        new_core_config["prioritize_first_last_pieces"] = \
-            self.builder.get_object("chk_prioritize_first_last_pieces").get_active()
-        new_core_config["sequential_download"] = \
-            self.builder.get_object("chk_sequential_download").get_active()
+        new_core_config["prioritize_first_last_pieces"] = self.builder.get_object(
+            "chk_prioritize_first_last_pieces").get_active()
+        new_core_config["sequential_download"] = self.builder.get_object(
+            "chk_sequential_download").get_active()
         new_core_config["add_paused"] = self.builder.get_object("chk_add_paused").get_active()
-        new_core_config["pre_allocate_storage"] = self.builder.get_object("chk_pre_allocation").get_active()
+        new_core_config["pre_allocate_storage"] = self.builder.get_object(
+            "chk_pre_allocation").get_active()
 
         # Network tab #
         listen_ports = [self.builder.get_object("spin_incoming_port").get_value_as_int()] * 2
         new_core_config["listen_ports"] = listen_ports
-        new_core_config["random_port"] = \
-            self.builder.get_object("chk_random_incoming_port").get_active()
+        new_core_config["random_port"] = self.builder.get_object("chk_random_incoming_port").get_active()
         outgoing_ports = (
             self.builder.get_object("spin_outgoing_port_min").get_value_as_int(),
             self.builder.get_object("spin_outgoing_port_max").get_value_as_int()
         )
         new_core_config["outgoing_ports"] = outgoing_ports
-        new_core_config["random_outgoing_ports"] = \
-            self.builder.get_object("chk_random_outgoing_ports").get_active()
+        new_core_config["random_outgoing_ports"] = self.builder.get_object(
+            "chk_random_outgoing_ports").get_active()
         incoming_address = self.builder.get_object("entry_interface").get_text().strip()
         if deluge.common.is_ip(incoming_address) or not incoming_address:
             new_core_config["listen_interface"] = incoming_address
         new_core_config["peer_tos"] = self.builder.get_object("entry_peer_tos").get_text()
         new_core_config["dht"] = self.builder.get_object("chk_dht").get_active()
         new_core_config["upnp"] = self.builder.get_object("chk_upnp").get_active()
-        new_core_config["natpmp"] = \
-            self.builder.get_object("chk_natpmp").get_active()
-        new_core_config["utpex"] = \
-            self.builder.get_object("chk_utpex").get_active()
-        new_core_config["lt_tex"] = \
-            self.builder.get_object("chk_lt_tex").get_active()
-        new_core_config["lsd"] = \
-            self.builder.get_object("chk_lsd").get_active()
-        new_core_config["enc_in_policy"] = \
-            self.builder.get_object("combo_encin").get_active()
-        new_core_config["enc_out_policy"] = \
-            self.builder.get_object("combo_encout").get_active()
-        new_core_config["enc_level"] = \
-            self.builder.get_object("combo_enclevel").get_active()
+        new_core_config["natpmp"] = self.builder.get_object("chk_natpmp").get_active()
+        new_core_config["utpex"] = self.builder.get_object("chk_utpex").get_active()
+        new_core_config["lt_tex"] = self.builder.get_object("chk_lt_tex").get_active()
+        new_core_config["lsd"] = self.builder.get_object("chk_lsd").get_active()
+        new_core_config["enc_in_policy"] = self.builder.get_object("combo_encin").get_active()
+        new_core_config["enc_out_policy"] = self.builder.get_object("combo_encout").get_active()
+        new_core_config["enc_level"] = self.builder.get_object("combo_enclevel").get_active()
 
         # Bandwidth tab #
-        new_core_config["max_connections_global"] = \
-            self.builder.get_object(
-                "spin_max_connections_global").get_value_as_int()
-        new_core_config["max_download_speed"] = \
-            self.builder.get_object("spin_max_download").get_value()
-        new_core_config["max_upload_speed"] = \
-            self.builder.get_object("spin_max_upload").get_value()
-        new_core_config["max_upload_slots_global"] = \
-            self.builder.get_object(
-                "spin_max_upload_slots_global").get_value_as_int()
-        new_core_config["max_half_open_connections"] = \
-            self.builder.get_object("spin_max_half_open_connections").get_value_as_int()
-        new_core_config["max_connections_per_second"] = \
-            self.builder.get_object(
-                "spin_max_connections_per_second").get_value_as_int()
-        new_core_config["max_connections_per_torrent"] = \
-            self.builder.get_object(
-                "spin_max_connections_per_torrent").get_value_as_int()
-        new_core_config["max_upload_slots_per_torrent"] = \
-            self.builder.get_object(
-                "spin_max_upload_slots_per_torrent").get_value_as_int()
-        new_core_config["max_upload_speed_per_torrent"] = \
-            self.builder.get_object(
-                "spin_max_upload_per_torrent").get_value()
-        new_core_config["max_download_speed_per_torrent"] = \
-            self.builder.get_object(
-                "spin_max_download_per_torrent").get_value()
-        new_core_config["ignore_limits_on_local_network"] = \
-            self.builder.get_object("chk_ignore_limits_on_local_network").get_active()
-        new_core_config["rate_limit_ip_overhead"] = \
-            self.builder.get_object("chk_rate_limit_ip_overhead").get_active()
+        new_core_config["max_connections_global"] = self.builder.get_object(
+            "spin_max_connections_global").get_value_as_int()
+        new_core_config["max_download_speed"] = self.builder.get_object("spin_max_download").get_value()
+        new_core_config["max_upload_speed"] = self.builder.get_object("spin_max_upload").get_value()
+        new_core_config["max_upload_slots_global"] = self.builder.get_object(
+            "spin_max_upload_slots_global").get_value_as_int()
+        new_core_config["max_half_open_connections"] = self.builder.get_object(
+            "spin_max_half_open_connections").get_value_as_int()
+        new_core_config["max_connections_per_second"] = self.builder.get_object(
+            "spin_max_connections_per_second").get_value_as_int()
+        new_core_config["max_connections_per_torrent"] = self.builder.get_object(
+            "spin_max_connections_per_torrent").get_value_as_int()
+        new_core_config["max_upload_slots_per_torrent"] = self.builder.get_object(
+            "spin_max_upload_slots_per_torrent").get_value_as_int()
+        new_core_config["max_upload_speed_per_torrent"] = self.builder.get_object(
+            "spin_max_upload_per_torrent").get_value()
+        new_core_config["max_download_speed_per_torrent"] = self.builder.get_object(
+            "spin_max_download_per_torrent").get_value()
+        new_core_config["ignore_limits_on_local_network"] = self.builder.get_object(
+            "chk_ignore_limits_on_local_network").get_active()
+        new_core_config["rate_limit_ip_overhead"] = self.builder.get_object(
+            "chk_rate_limit_ip_overhead").get_active()
 
         # Interface tab #
-        new_gtkui_config["enable_system_tray"] = \
-            self.builder.get_object("chk_use_tray").get_active()
-        new_gtkui_config["close_to_tray"] = \
-            self.builder.get_object("chk_min_on_close").get_active()
-        new_gtkui_config["start_in_tray"] = \
-            self.builder.get_object("chk_start_in_tray").get_active()
-        new_gtkui_config["enable_appindicator"] = \
-            self.builder.get_object("radio_appind").get_active()
-        new_gtkui_config["lock_tray"] = \
-            self.builder.get_object("chk_lock_tray").get_active()
+        new_gtkui_config["enable_system_tray"] = self.builder.get_object("chk_use_tray").get_active()
+        new_gtkui_config["close_to_tray"] = self.builder.get_object("chk_min_on_close").get_active()
+        new_gtkui_config["start_in_tray"] = self.builder.get_object("chk_start_in_tray").get_active()
+        new_gtkui_config["enable_appindicator"] = self.builder.get_object("radio_appind").get_active()
+        new_gtkui_config["lock_tray"] = self.builder.get_object("chk_lock_tray").get_active()
         passhex = sha(self.builder.get_object("txt_tray_password").get_text()).hexdigest()
         if passhex != "c07eb5a8c0dc7bb81c217b67f11c3b7a5e95ffd7":
             new_gtkui_config["tray_password"] = passhex
@@ -643,26 +589,22 @@ class Preferences(component.Component):
         new_gtkui_in_classic_mode = self.builder.get_object("radio_classic").get_active()
         new_gtkui_config["classic_mode"] = new_gtkui_in_classic_mode
 
-        new_gtkui_config["show_rate_in_title"] = \
-            self.builder.get_object("chk_show_rate_in_title").get_active()
-        new_gtkui_config["focus_main_window_on_add"] = \
-            self.builder.get_object("chk_focus_main_window_on_add").get_active()
+        new_gtkui_config["show_rate_in_title"] = self.builder.get_object(
+            "chk_show_rate_in_title").get_active()
+        new_gtkui_config["focus_main_window_on_add"] = self.builder.get_object(
+            "chk_focus_main_window_on_add").get_active()
 
         # Other tab #
-        new_gtkui_config["show_new_releases"] = \
-            self.builder.get_object("chk_show_new_releases").get_active()
-        new_core_config["send_info"] = \
-            self.builder.get_object("chk_send_info").get_active()
-        new_core_config["geoip_db_location"] = \
-            self.builder.get_object("entry_geoip").get_text()
+        new_gtkui_config["show_new_releases"] = self.builder.get_object(
+            "chk_show_new_releases").get_active()
+        new_core_config["send_info"] = self.builder.get_object("chk_send_info").get_active()
+        new_core_config["geoip_db_location"] = self.builder.get_object("entry_geoip").get_text()
 
         # Daemon tab #
-        new_core_config["daemon_port"] = \
-            self.builder.get_object("spin_daemon_port").get_value_as_int()
-        new_core_config["allow_remote"] = \
-            self.builder.get_object("chk_allow_remote_connections").get_active()
-        new_core_config["new_release_check"] = \
-            self.builder.get_object("chk_new_releases").get_active()
+        new_core_config["daemon_port"] = self.builder.get_object("spin_daemon_port").get_value_as_int()
+        new_core_config["allow_remote"] = self.builder.get_object(
+            "chk_allow_remote_connections").get_active()
+        new_core_config["new_release_check"] = self.builder.get_object("chk_new_releases").get_active()
 
         # Proxy tab #
         new_core_config["proxy"] = {}
@@ -671,7 +613,8 @@ class Preferences(component.Component):
         new_core_config["proxy"]["password"] = self.builder.get_object("entry_proxy_pass").get_text()
         new_core_config["proxy"]["hostname"] = self.builder.get_object("entry_proxy_host").get_text()
         new_core_config["proxy"]["port"] = self.builder.get_object("spin_proxy_port").get_value_as_int()
-        new_core_config["proxy"]["proxy_hostnames"] = self.builder.get_object("chk_proxy_host_resolve").get_active()
+        new_core_config["proxy"]["proxy_hostnames"] = self.builder.get_object(
+            "chk_proxy_host_resolve").get_active()
         new_core_config["proxy"]["proxy_peer_connections"] = self.builder.get_object(
             "chk_proxy_peer_conn").get_active()
         new_core_config["i2p_proxy"] = {}
@@ -680,36 +623,29 @@ class Preferences(component.Component):
         new_core_config["anonymous_mode"] = self.builder.get_object("chk_anonymous_mode").get_active()
 
         # Queue tab #
-        new_core_config["queue_new_to_top"] = \
-            self.builder.get_object("chk_queue_new_top").get_active()
-        new_core_config["max_active_seeding"] = \
-            self.builder.get_object("spin_seeding").get_value_as_int()
-        new_core_config["max_active_downloading"] = \
-            self.builder.get_object("spin_downloading").get_value_as_int()
-        new_core_config["max_active_limit"] = \
-            self.builder.get_object("spin_active").get_value_as_int()
-        new_core_config["dont_count_slow_torrents"] = \
-            self.builder.get_object("chk_dont_count_slow_torrents").get_active()
-        new_core_config["auto_manage_prefer_seeds"] = \
-            self.builder.get_object("chk_auto_manage_prefer_seeds").get_active()
-        new_core_config["stop_seed_at_ratio"] = \
-            self.builder.get_object("chk_share_ratio").get_active()
-        new_core_config["remove_seed_at_ratio"] = \
-            self.builder.get_object("radio_remove_ratio").get_active()
-        new_core_config["stop_seed_ratio"] = \
-            self.builder.get_object("spin_share_ratio").get_value()
-        new_core_config["share_ratio_limit"] = \
-            self.builder.get_object("spin_share_ratio_limit").get_value()
-        new_core_config["seed_time_ratio_limit"] = \
-            self.builder.get_object("spin_seed_time_ratio_limit").get_value()
-        new_core_config["seed_time_limit"] = \
-            self.builder.get_object("spin_seed_time_limit").get_value()
+        new_core_config["queue_new_to_top"] = self.builder.get_object("chk_queue_new_top").get_active()
+        new_core_config["max_active_seeding"] = self.builder.get_object(
+            "spin_seeding").get_value_as_int()
+        new_core_config["max_active_downloading"] = self.builder.get_object(
+            "spin_downloading").get_value_as_int()
+        new_core_config["max_active_limit"] = self.builder.get_object("spin_active").get_value_as_int()
+        new_core_config["dont_count_slow_torrents"] = self.builder.get_object(
+            "chk_dont_count_slow_torrents").get_active()
+        new_core_config["auto_manage_prefer_seeds"] = self.builder.get_object(
+            "chk_auto_manage_prefer_seeds").get_active()
+        new_core_config["stop_seed_at_ratio"] = self.builder.get_object("chk_share_ratio").get_active()
+        new_core_config["remove_seed_at_ratio"] = self.builder.get_object(
+            "radio_remove_ratio").get_active()
+        new_core_config["stop_seed_ratio"] = self.builder.get_object("spin_share_ratio").get_value()
+        new_core_config["share_ratio_limit"] = self.builder.get_object(
+            "spin_share_ratio_limit").get_value()
+        new_core_config["seed_time_ratio_limit"] = self.builder.get_object(
+            "spin_seed_time_ratio_limit").get_value()
+        new_core_config["seed_time_limit"] = self.builder.get_object("spin_seed_time_limit").get_value()
 
         # Cache tab #
-        new_core_config["cache_size"] = \
-            self.builder.get_object("spin_cache_size").get_value_as_int()
-        new_core_config["cache_expiry"] = \
-            self.builder.get_object("spin_cache_expiry").get_value_as_int()
+        new_core_config["cache_size"] = self.builder.get_object("spin_cache_size").get_value_as_int()
+        new_core_config["cache_expiry"] = self.builder.get_object("spin_cache_expiry").get_value_as_int()
 
         # Run plugin hook to apply preferences
         component.get("PluginManager").run_on_apply_prefs()
@@ -774,8 +710,10 @@ class Preferences(component.Component):
                     component.get("MainWindow").quit(shutdown=shutdown_daemon)
                 else:
                     self.gtkui_config["classic_mode"] = not new_gtkui_in_classic_mode
-                    self.builder.get_object("radio_classic").set_active(self.gtkui_config["classic_mode"])
-                    self.builder.get_object("radio_thinclient").set_active(not self.gtkui_config["classic_mode"])
+                    self.builder.get_object("radio_classic").set_active(
+                        self.gtkui_config["classic_mode"])
+                    self.builder.get_object("radio_thinclient").set_active(
+                        not self.gtkui_config["classic_mode"])
             dialog = YesNoDialog(
                 _("Switching client mode..."),
                 _("Your current session will be stopped. Do you wish to continue?")
@@ -915,9 +853,7 @@ class Preferences(component.Component):
         client.core.test_listen_port().addCallback(on_get_test)
         # XXX: Consider using gtk.Spinner() instead of the loading gif
         #      It requires gtk.ver > 2.12
-        self.builder.get_object("port_img").set_from_file(
-            deluge.common.get_pixmap('loading.gif')
-        )
+        self.builder.get_object("port_img").set_from_file(deluge.common.get_pixmap('loading.gif'))
         self.builder.get_object("port_img").show()
         client.force_call()
 
@@ -958,8 +894,7 @@ class Preferences(component.Component):
             _("Select the Plugin"),
             self.pref_dialog,
             gtk.FILE_CHOOSER_ACTION_OPEN,
-            buttons=(gtk.STOCK_CANCEL, gtk.RESPONSE_CANCEL, gtk.STOCK_OPEN,
-                     gtk.RESPONSE_OK)
+            buttons=(gtk.STOCK_CANCEL, gtk.RESPONSE_CANCEL, gtk.STOCK_OPEN, gtk.RESPONSE_OK)
         )
 
         chooser.set_transient_for(self.pref_dialog)
@@ -1082,15 +1017,9 @@ class Preferences(component.Component):
 
         for account in known_accounts:
             accounts_iter = self.accounts_liststore.append()
-            self.accounts_liststore.set_value(
-                accounts_iter, ACCOUNTS_USERNAME, account['username']
-            )
-            self.accounts_liststore.set_value(
-                accounts_iter, ACCOUNTS_LEVEL, account['authlevel']
-            )
-            self.accounts_liststore.set_value(
-                accounts_iter, ACCOUNTS_PASSWORD, account['password']
-            )
+            self.accounts_liststore.set_value(accounts_iter, ACCOUNTS_USERNAME, account['username'])
+            self.accounts_liststore.set_value(accounts_iter, ACCOUNTS_LEVEL, account['authlevel'])
+            self.accounts_liststore.set_value(accounts_iter, ACCOUNTS_PASSWORD, account['password'])
 
     def _on_accounts_selection_changed(self, treeselection):
         log.debug("_on_accounts_selection_changed")
@@ -1106,10 +1035,7 @@ class Preferences(component.Component):
             self.builder.get_object("accounts_delete").set_sensitive(False)
 
     def _on_accounts_add_clicked(self, widget):
-        dialog = AccountDialog(
-            levels_mapping=client.auth_levels_mapping,
-            parent=self.pref_dialog
-        )
+        dialog = AccountDialog(levels_mapping=client.auth_levels_mapping, parent=self.pref_dialog)
 
         def dialog_finished(response_id):
             username = dialog.get_username()
@@ -1118,15 +1044,9 @@ class Preferences(component.Component):
 
             def add_ok(rv):
                 accounts_iter = self.accounts_liststore.append()
-                self.accounts_liststore.set_value(
-                    accounts_iter, ACCOUNTS_USERNAME, username
-                )
-                self.accounts_liststore.set_value(
-                    accounts_iter, ACCOUNTS_LEVEL, authlevel
-                )
-                self.accounts_liststore.set_value(
-                    accounts_iter, ACCOUNTS_PASSWORD, password
-                )
+                self.accounts_liststore.set_value(accounts_iter, ACCOUNTS_USERNAME, username)
+                self.accounts_liststore.set_value(accounts_iter, ACCOUNTS_LEVEL, authlevel)
+                self.accounts_liststore.set_value(accounts_iter, ACCOUNTS_PASSWORD, password)
 
             def add_fail(failure):
                 if failure.type == AuthManagerError:
@@ -1253,27 +1173,20 @@ class Preferences(component.Component):
     def __set_color(self, state, from_config=False):
         if from_config:
             color = gtk.gdk.Color(*self.gtkui_config["pieces_color_%s" % state])
-            log.debug("Setting %r color state from config to %s", state,
-                      (color.red, color.green, color.blue))
+            log.debug("Setting %r color state from config to %s", state, (color.red, color.green, color.blue))
             self.builder.get_object("%s_color" % state).set_color(color)
         else:
             color = self.builder.get_object("%s_color" % state).get_color()
-            log.debug("Setting %r color state to %s", state,
-                      (color.red, color.green, color.blue))
-            self.gtkui_config["pieces_color_%s" % state] = [
-                color.red, color.green, color.blue
-            ]
+            log.debug("Setting %r color state to %s", state, (color.red, color.green, color.blue))
+            self.gtkui_config["pieces_color_%s" % state] = [color.red, color.green, color.blue]
             self.gtkui_config.save()
             self.gtkui_config.apply_set_functions("pieces_colors")
 
         self.builder.get_object("revert_color_%s" % state).set_sensitive(
-            [color.red, color.green, color.blue] != self.COLOR_DEFAULTS[state]
-        )
+            [color.red, color.green, color.blue] != self.COLOR_DEFAULTS[state])
 
     def __revert_color(self, state, from_config=False):
         log.debug("Reverting %r color state", state)
-        self.builder.get_object("%s_color" % state).set_color(
-            gtk.gdk.Color(*self.COLOR_DEFAULTS[state])
-        )
+        self.builder.get_object("%s_color" % state).set_color(gtk.gdk.Color(*self.COLOR_DEFAULTS[state]))
         self.builder.get_object("revert_color_%s" % state).set_sensitive(False)
         self.gtkui_config.apply_set_functions("pieces_colors")

--- a/deluge/ui/gtkui/preferences.py
+++ b/deluge/ui/gtkui/preferences.py
@@ -344,9 +344,8 @@ class Preferences(component.Component):
             "chk_sequential_download": ("active", "sequential_download"),
             "chk_add_paused": ("active", "add_paused"),
             "active_port_label": ("text", lambda: str(self.active_port)),
-            "spin_port_min": ("value", lambda: self.core_config["listen_ports"][0]),
-            "spin_port_max": ("value", lambda: self.core_config["listen_ports"][1]),
-            "chk_random_port": ("active", "random_port"),
+            "spin_incoming_port": ("value", lambda: self.core_config["listen_ports"][0]),
+            "chk_random_incoming_port": ("active", "random_port"),
             "spin_outgoing_port_min": ("value", lambda: self.core_config["outgoing_ports"][0]),
             "spin_outgoing_port_max": ("value", lambda: self.core_config["outgoing_ports"][1]),
             "chk_random_outgoing_ports": ("active", "random_outgoing_ports"),
@@ -561,13 +560,10 @@ class Preferences(component.Component):
         new_core_config["pre_allocate_storage"] = self.builder.get_object("chk_pre_allocation").get_active()
 
         # Network tab #
-        listen_ports = (
-            self.builder.get_object("spin_port_min").get_value_as_int(),
-            self.builder.get_object("spin_port_max").get_value_as_int()
-        )
+        listen_ports = [self.builder.get_object("spin_incoming_port").get_value_as_int()] * 2
         new_core_config["listen_ports"] = listen_ports
         new_core_config["random_port"] = \
-            self.builder.get_object("chk_random_port").get_active()
+            self.builder.get_object("chk_random_incoming_port").get_active()
         outgoing_ports = (
             self.builder.get_object("spin_outgoing_port_min").get_value_as_int(),
             self.builder.get_object("spin_outgoing_port_max").get_value_as_int()
@@ -842,8 +838,7 @@ class Preferences(component.Component):
 
         dependents = {
             "chk_show_dialog": {"chk_focus_dialog": True},
-            "chk_random_port": {"spin_port_min": False,
-                                "spin_port_max": False},
+            "chk_random_incoming_port": {"spin_incoming_port": False},
             "chk_random_outgoing_ports": {"spin_outgoing_port_min": False,
                                           "spin_outgoing_port_max": False},
             "chk_use_tray": {"radio_appind": True,

--- a/deluge/ui/gtkui/torrentview.py
+++ b/deluge/ui/gtkui/torrentview.py
@@ -636,8 +636,8 @@ class TorrentView(ListView, component.Component):
             row = self.model_filter.get_iter(path[0])
 
             if self.get_selected_torrents():
-                if self.model_filter.get_value(row, self.columns["torrent_id"].column_indices[0]) \
-                        not in self.get_selected_torrents():
+                if (self.model_filter.get_value(row, self.columns["torrent_id"].column_indices[0])
+                        not in self.get_selected_torrents()):
                     self.treeview.get_selection().unselect_all()
                     self.treeview.get_selection().select_iter(row)
             else:


### PR DESCRIPTION
There is an discussion for these changes in PR #8 

 * [#2133](http://dev.deluge-torrent.org/ticket/2133) Add flags for port reuse and disable binding to system port.
 * [#2122](http://dev.deluge-torrent.org/ticket/2122) For random port, use single port and store it for reuse.
 * [#2343](http://dev.deluge-torrent.org/ticket/2343) Fix 'Invalid Arg' from listen_on, likely due to whitespace as interface value.
 * Consolidate listen_on and outgoing_port into single '__set...' methods.

ToDo:
- [x] Modify UIs to display on a single incoming port option to user
