### PR TITLE
[Console] Fix bug when parsing UI commands

### DIFF
--- a/deluge/tests/test_ui_entry.py
+++ b/deluge/tests/test_ui_entry.py
@@ -9,6 +9,7 @@ import sys
 import mock
 import pytest
 
+import deluge
 import deluge.component as component
 import deluge.ui.console
 import deluge.ui.web.server
@@ -69,6 +70,25 @@ class DelugeEntryTestCase(BaseTestCase):
         with mock.patch("deluge.ui.console.main.ConsoleUI"):
             # Just test that no exception is raised
             ui_entry.start_ui()
+
+    def test_start_with_log_level(self):
+        _level = []
+
+        def setup_logger(level="error", filename=None, filemode="w", logrotate=None):
+            _level.append(level)
+
+        self.patch(deluge.log, "setup_logger", setup_logger)
+        self.patch(sys, "argv", ["./deluge", "-L", "info"])
+
+        config = deluge.configmanager.ConfigManager("ui.conf", ui_entry.DEFAULT_PREFS)
+        config.config["default_ui"] = "console"
+        config.save()
+
+        with mock.patch("deluge.ui.console.main.ConsoleUI"):
+            # Just test that no exception is raised
+            ui_entry.start_ui()
+
+        self.assertEqual(_level[0], "info")
 
 
 @pytest.mark.gtkui

--- a/deluge/ui/baseargparser.py
+++ b/deluge/ui/baseargparser.py
@@ -17,7 +17,6 @@ import textwrap
 import deluge.log
 from deluge import common
 from deluge.configmanager import get_config_dir, set_config_dir
-from deluge.log import setup_logger
 
 
 def find_subcommand(self, args=None):
@@ -31,7 +30,7 @@ def find_subcommand(self, args=None):
 
     """
     subcommand_found = -1
-    test_args = args if args else sys.argv[1:]
+    test_args = args if args is not None else sys.argv[1:]
 
     for x in self._subparsers._actions:
         if not isinstance(x, argparse._SubParsersAction):
@@ -214,8 +213,8 @@ class BaseArgParser(argparse.ArgumentParser):
                 logrotate = common.parse_human_size(options.logrotate)
 
             # Setup the logger
-            setup_logger(level=options.loglevel, filename=options.logfile, filemode=logfile_mode,
-                         logrotate=logrotate)
+            deluge.log.setup_logger(level=options.loglevel, filename=options.logfile, filemode=logfile_mode,
+                                    logrotate=logrotate)
 
             if options.config:
                 if not set_config_dir(options.config):


### PR DESCRIPTION
Command line arguments like "-L info" were incorrectly
identified as console subcommands which caused parsing
to fail.