### PR TITLE
[Console] Fix to console argument parsing

### DIFF
--- a/deluge/ui/console/console.py
+++ b/deluge/ui/console/console.py
@@ -7,12 +7,13 @@
 # the additional special exception to link portions of this program with the OpenSSL library.
 # See LICENSE for more details.
 #
+from __future__ import print_function
 
 import logging
 import os
 
 import deluge.common
-from deluge.ui.baseargparser import DelugeTextHelpFormatter
+from deluge.ui.baseargparser import BaseArgParser, DelugeTextHelpFormatter
 from deluge.ui.console import UI_PATH
 from deluge.ui.ui import UI
 
@@ -79,6 +80,11 @@ class Console(UI):
             self.console_cmds[c].add_subparser(subparsers)
 
     def start(self):
+        if self.ui_args is None:
+            # Started directly by deluge-console script so must find the UI args manually
+            options, remaining = BaseArgParser(common_help=False).parse_known_args()
+            self.ui_args = remaining
+
         i = self.console_parser.find_subcommand(args=self.ui_args)
         self.console_parser.subcommand = False
         self.parser.subcommand = False if i == -1 else True

--- a/deluge/ui/console/console.py
+++ b/deluge/ui/console/console.py
@@ -54,7 +54,7 @@ class Console(UI):
     cmd_description = """Console or command-line user interface"""
 
     def __init__(self, *args, **kwargs):
-        super(Console, self).__init__(*args, **kwargs)
+        super(Console, self).__init__("console", *args, **kwargs)
 
         group = self.parser.add_argument_group(_("Console Options"), "These daemon connect options will be "
                                                "used for commands, or if console ui autoconnect is enabled.")

--- a/deluge/ui/console/main.py
+++ b/deluge/ui/console/main.py
@@ -33,7 +33,7 @@ from deluge.ui.sessionproxy import SessionProxy
 log = logging.getLogger(__name__)
 
 
-class ConsoleCommandParser(argparse.ArgumentParser):
+class ConsoleBaseParser(argparse.ArgumentParser):
 
     def format_help(self):
         """
@@ -44,11 +44,14 @@ class ConsoleCommandParser(argparse.ArgumentParser):
         # Handle epilog manually to keep the text formatting
         epilog = self.epilog
         self.epilog = ""
-        help_str = super(ConsoleCommandParser, self).format_help()
+        help_str = super(ConsoleBaseParser, self).format_help()
         if epilog is not None:
             help_str += epilog
         self.epilog = epilog
         return help_str
+
+
+class ConsoleCommandParser(ConsoleBaseParser):
 
     def _split_args(self, args):
         command_options = []
@@ -71,6 +74,20 @@ class ConsoleCommandParser(argparse.ArgumentParser):
         return command_options
 
     def parse_args(self, args=None):
+        """Parse known UI args and handle common and process group options.
+
+            Notes:
+                If started by deluge entry script this has already been done.
+
+            Args:
+                args (list, optional): The arguments to parse.
+
+            Returns:
+                argparse.Namespace: The parsed arguments.
+        """
+        from deluge.ui.ui_entry import AMBIGUOUS_CMD_ARGS
+        self.base_parser.parse_known_ui_args(args, withhold=AMBIGUOUS_CMD_ARGS)
+
         multi_command = self._split_args(args)
         # If multiple commands were passed to console
         if multi_command:
@@ -103,7 +120,7 @@ class ConsoleCommandParser(argparse.ArgumentParser):
         return options
 
 
-class OptionParser(ConsoleCommandParser):
+class OptionParser(ConsoleBaseParser):
 
     def __init__(self, **kwargs):
         super(OptionParser, self).__init__(**kwargs)

--- a/deluge/ui/ui.py
+++ b/deluge/ui/ui.py
@@ -31,10 +31,10 @@ class UI(object):
     """
     cmd_description = """Override with command description"""
 
-    def __init__(self, name="gtk", **kwargs):
+    def __init__(self, name, **kwargs):
         self.__name = name
         self.ui_args = kwargs.pop("ui_args", None)
-        lang.setup_translations(setup_pygtk=(name == "gtk"))
+        lang.setup_translations()
         self.__parser = BaseArgParser(**kwargs)
 
     def parse_args(self, parser, args=None):

--- a/deluge/ui/ui_entry.py
+++ b/deluge/ui/ui_entry.py
@@ -29,6 +29,8 @@ DEFAULT_PREFS = {
     "default_ui": "gtk"
 }
 
+AMBIGUOUS_CMD_ARGS = ("-h", "--help", "-v", "-V", "--version")
+
 
 def start_ui():
     """Entry point for ui script"""
@@ -49,10 +51,8 @@ def start_ui():
     # Setup parser with Common Options and add UI Options group.
     parser = add_ui_options_group(BaseArgParser())
 
-    ambiguous_args = ["-h", "--help", "-v", "-V", "--version"]
-    # Parse arguments without help/version as this is handled later.
-    args = [a for a in sys.argv if a not in ambiguous_args]
-    options = parser.parse_known_ui_args(args)
+    # Parse and handle common/process group options
+    options = parser.parse_known_ui_args(sys.argv, withhold=AMBIGUOUS_CMD_ARGS)
 
     config = deluge.configmanager.ConfigManager("ui.conf", DEFAULT_PREFS)
     log = logging.getLogger(__name__)
@@ -86,7 +86,7 @@ def start_ui():
         subactions[-1].dest = "%s %s" % (prefix, ui)
 
     # Insert a default UI subcommand unless one of the ambiguous_args are specified
-    parser.set_default_subparser(default_ui, abort_opts=ambiguous_args)
+    parser.set_default_subparser(default_ui, abort_opts=AMBIGUOUS_CMD_ARGS)
 
     # Only parse known arguments to leave the UIs to show a help message if parsing fails.
     options, remaining = parser.parse_known_args()


### PR DESCRIPTION
When starting console with './deluge-console', providing
loggin level '-L info' would fail to parse as it identified
'info' as a subcommand.