### PR TITLE
Libtorrent 1.1 compatibility

### DIFF
--- a/deluge/core/preferencesmanager.py
+++ b/deluge/core/preferencesmanager.py
@@ -22,6 +22,8 @@ from deluge.event import ConfigValueChangedEvent
 
 log = logging.getLogger(__name__)
 
+lt_1_1_compat = deluge.common.VersionSplit(lt.version) >= deluge.common.VersionSplit("1.1.0.0")
+
 DEFAULT_PREFS = {
     "send_info": False,
     "info_sent": 0.0,
@@ -328,10 +330,16 @@ class PreferencesManager(component.Component):
 
     def _on_set_share_ratio_limit(self, key, value):
         log.debug("%s set to %s..", key, value)
+        if lt_1_1_compat:
+            # libtorrent 1.1 wants an integer with 100 equalling 1.0
+            value = int(value * 100)
         self.session_set_setting("share_ratio_limit", value)
 
     def _on_set_seed_time_ratio_limit(self, key, value):
         log.debug("%s set to %s..", key, value)
+        if lt_1_1_compat:
+            # libtorrent 1.1 wants an integer with 100 equalling 1.0
+            value = int(value * 100)
         self.session_set_setting("seed_time_ratio_limit", value)
 
     def _on_set_seed_time_limit(self, key, value):

--- a/deluge/core/preferencesmanager.py
+++ b/deluge/core/preferencesmanager.py
@@ -215,8 +215,12 @@ class PreferencesManager(component.Component):
 
     def _on_set_peer_tos(self, key, value):
         log.debug("setting peer_tos to: %s", value)
+        if lt_1_1_compat:
+            value = int(value, 16)
+        else:
+            value = chr(int(value, 16))
         try:
-            self.session_set_setting("peer_tos", int(value, 16))
+            self.session_set_setting("peer_tos", value)
         except ValueError as ex:
             log.debug("Invalid tos byte: %s", ex)
             return

--- a/deluge/core/preferencesmanager.py
+++ b/deluge/core/preferencesmanager.py
@@ -214,7 +214,7 @@ class PreferencesManager(component.Component):
     def _on_set_peer_tos(self, key, value):
         log.debug("setting peer_tos to: %s", value)
         try:
-            self.session_set_setting("peer_tos", chr(int(value, 16)))
+            self.session_set_setting("peer_tos", int(value, 16))
         except ValueError as ex:
             log.debug("Invalid tos byte: %s", ex)
             return

--- a/deluge/core/torrentmanager.py
+++ b/deluge/core/torrentmanager.py
@@ -1352,7 +1352,9 @@ class TorrentManager(component.Component):
             # Ask libtorrent for status update
             self.torrents_status_requests.insert(0, (d, torrent_ids, keys, diff))
             if lt_1_1_compat:
-                self.session.post_torrent_updates(0)
+                # libtorrent 1.1 takes a combination of status_flags_t`s here
+                # like torrent_handle::status()
+                self.session.post_torrent_updates(0xffffffff)
             else:
                 self.session.post_torrent_updates()
         return d

--- a/deluge/core/torrentmanager.py
+++ b/deluge/core/torrentmanager.py
@@ -23,7 +23,7 @@ from twisted.internet.task import LoopingCall
 
 import deluge.component as component
 from deluge._libtorrent import lt
-from deluge.common import decode_string, get_magnet_info, utf8_encoded
+from deluge.common import decode_string, get_magnet_info, utf8_encoded, VersionSplit
 from deluge.configmanager import ConfigManager, get_config_dir
 from deluge.core.authmanager import AUTH_LEVEL_ADMIN
 from deluge.core.torrent import Torrent, TorrentOptions, sanitize_filepath
@@ -33,6 +33,8 @@ from deluge.event import (ExternalIPEvent, PreTorrentRemovedEvent, SessionStarte
                           TorrentResumedEvent)
 
 log = logging.getLogger(__name__)
+
+lt_1_1_compat = VersionSplit(lt.version) >= VersionSplit("1.1.0.0")
 
 
 class TorrentState:  # pylint: disable=old-style-class
@@ -1349,5 +1351,8 @@ class TorrentManager(component.Component):
         else:
             # Ask libtorrent for status update
             self.torrents_status_requests.insert(0, (d, torrent_ids, keys, diff))
-            self.session.post_torrent_updates()
+            if lt_1_1_compat:
+                self.session.post_torrent_updates(0)
+            else:
+                self.session.post_torrent_updates()
         return d


### PR DESCRIPTION
Fixed a few settings and the call to `post_torrent_updates`. Latter has a default value in the C++ API (`0xffffffff`) but not in the Python API. It would support the same flags as `torrent_handle::status(int flags)` but I didn't see an immediate way to do something useful with that.

I tried with lt 1.1.0 and 1.0.9 and it seems to work for me so far.