### PR TITLE
[UI] Fix json encoding error

### DIFF
--- a/deluge/ui/web/json_api.py
+++ b/deluge/ui/web/json_api.py
@@ -210,7 +210,7 @@ class JSON(resource.Resource, component.Component):
     def _send_response(self, request, response):
         if request._disconnected:
             return ""
-        response = json.dumps(response)
+        response = json.dumps(response, ensure_ascii=False)
         request.setHeader("content-type", "application/x-json")
         request.write(compress(response, request))
         request.finish()


### PR DESCRIPTION
some torrent content's encoding can not be `json.dumps`  
so `json.dumps` should ignore this errors.

