### PR TITLE
[#2885] [CORE] Fix Unable to scrape tracker

### DIFF
--- a/deluge/core/torrent.py
+++ b/deluge/core/torrent.py
@@ -982,10 +982,10 @@ class Torrent(object):
 
         return True
 
-    def scrape_tracker(self):
+    def scrape_tracker(self, idx=-1):
         """Scrape the tracker"""
         try:
-            self.handle.scrape_tracker()
+            self.handle.scrape_tracker(idx)
         except Exception, e:
             log.debug("Unable to scrape tracker: %s", e)
             return False


### PR DESCRIPTION
This fixes the following issue:

Python argument types in
  torrent_handle.scrape_tracker(torrent_handle)
did not match C++ signature:
  scrape_tracker(libtorrent::torrent_handle {lvalue}, int)