### PR TITLE
Check if libtorrent supports load_country_db before usage

### DIFF
--- a/deluge/core/preferencesmanager.py
+++ b/deluge/core/preferencesmanager.py
@@ -443,7 +443,7 @@ class PreferencesManager(component.Component):
         else:
             log.warning("Unable to find GeoIP database file!")
 
-        if geoip_db:
+        if geoip_db and hasattr(self.session, "load_country_db"):
             try:
                 self.session.load_country_db(str(geoip_db))
             except RuntimeError as ex:


### PR DESCRIPTION
Fixes an uncaught exception with lt 1.1.1:
```
  File "/usr/lib/python2.7/site-packages/deluge/core/preferencesmanager.py", line 448, in _on_set_geoip_db_location
    self.session.load_country_db(str(geoip_db))
exceptions.AttributeError: 'session' object has no attribute 'load_country_db'
```