### PR TITLE
[UI] Fix ZeroDivisionError at pieces bar update

### DIFF
--- a/deluge/ui/gtkui/piecesbar.py
+++ b/deluge/ui/gtkui/piecesbar.py
@@ -73,12 +73,12 @@ class PiecesBar(gtk.DrawingArea):
         # Restrict Cairo to the exposed area; avoid extra work
         self.__roundcorners_clipping()
 
-        if not self.__pieces and self.__num_pieces is not None:
+        if self.__pieces:
+            self.__draw_pieces()
+        elif self.__num_pieces:
             # Special case. Completed torrents do not send any pieces in their
             # status.
             self.__draw_pieces_completed()
-        elif self.__pieces:
-            self.__draw_pieces()
 
         self.__draw_progress_overlay()
         self.__write_text()


### PR DESCRIPTION
I was getting the following traceback before. I was unable to pinpoint the exact circumstances under which this bug occurs.

```
Traceback (most recent call last):
  File "c:\users\Giorgos\downloads\portable\deluge\deluge\ui\gtkui\piecesbar.py", line 79, in do_expose_event
    self.__draw_pieces_completed()
  File "c:\users\Giorgos\downloads\portable\deluge\deluge\ui\gtkui\piecesbar.py", line 152, in __draw_pieces_completed
    piece_width = self.__width * 1.0 / self.__num_pieces
ZeroDivisionError: float division by zero
```