### PR TITLE
[#2900] Fix Error loading torrent: invalid bencoded value

### DIFF
--- a/deluge/bencode.py
+++ b/deluge/bencode.py
@@ -15,6 +15,10 @@
 from types import DictType, IntType, ListType, LongType, StringType, TupleType
 
 
+class BTFailure(Exception):
+    pass
+
+
 def decode_int(x, f):
     f += 1
     newf = x.index('e', f)
@@ -71,9 +75,7 @@ def bdecode(x):
     try:
         r, l = decode_func[x[0]](x, 0)
     except (IndexError, KeyError, ValueError):
-        raise Exception("not a valid bencoded string")
-    if l != len(x):
-        raise Exception("invalid bencoded value (data after valid prefix)")
+        raise BTFailure("not a valid bencoded string")
 
     return r
 

--- a/deluge/tests/common.py
+++ b/deluge/tests/common.py
@@ -32,6 +32,10 @@ def setup_test_logger(level="info", prefix="deluge"):
     deluge.log.setup_logger(level, filename="%s.log" % prefix, twisted_observer=False)
 
 
+def get_test_data_file(filename):
+    return os.path.join(os.path.join(os.path.dirname(__file__), "data"), filename)
+
+
 def todo_test(caller):
     # If we are using the delugereporter we can set todo mark on the test
     # Without the delugereporter the todo would print a stack trace, so in

--- a/deluge/tests/data/filehash_field.torrent
+++ b/deluge/tests/data/filehash_field.torrent
@@ -1,0 +1,2 @@
+d13:creation datei1476342472e4:infod5:filesld4:ed2k16:2M2Õ³&šïXE	†18:filehash20:f»4^S96PâöÕRãÑ“6:lengthi54e4:pathl8:tull.txteed4:ed2k16:à_Gà‚ÂLŸ@”8:filehash20:ºvê¤æXä™dÓ/§n1Ş¸36:lengthi54e4:pathl56:é‚„åœ¨ä¸€å€‹äººç„¡èŠå—~é‚„ä¸è¶•ç·Šä¸Šä¾†èŠå¤©ç¾.txteee4:name16:torrent_filehash12:piece lengthi32768e6:pieces20:G@g\˜&\fB©
+µØee

--- a/deluge/tests/test_ui_common.py
+++ b/deluge/tests/test_ui_common.py
@@ -32,3 +32,14 @@ class UICommonTestCase(unittest.TestCase):
         self.assertTrue("Ascii title.mkv" in files)
         self.assertTrue("\xe0\xa6\xb8\xe0\xa7\x81\xe0\xa6\x95\xe0\xa7\x81\xe0\xa6"
                         "\xae\xe0\xa6\xbe\xe0\xa6\xb0 \xe0\xa6\xb0\xe0\xa6\xbe\xe0\xa7\x9f.mkv" in files)
+
+    def test_torrent_info_json_dump(self):
+        # This torrent file contains an uncommon field 'filehash' which must be hex
+        # encoded to allow dumping the torrent info to json. Otherwise it will fail with:
+        # UnicodeDecodeError: 'utf8' codec can't decode byte 0xe5 in position 0: invalid continuation byte
+        filename = common.get_test_data_file("filehash_field.torrent")
+        ti = TorrentInfo(filename, 2)
+        files = ti.files_tree["contents"]["torrent_filehash"]["contents"]
+
+        self.assertTrue("還在一個人無聊嗎~還不趕緊上來聊天美.txt" in files)
+        json_lib.dumps(ti.as_dict("name", "info_hash", "files_tree"))

--- a/deluge/ui/common.py
+++ b/deluge/ui/common.py
@@ -74,7 +74,7 @@ class TorrentInfo(object):
             with open(filename, "rb") as _file:
                 self.__m_filedata = _file.read()
             self.__m_metadata = bencode.bdecode(self.__m_filedata)
-        except Exception as ex:
+        except bencode.BTFailure as ex:
             log.warning("Unable to open %s: %s", filename, ex)
             raise ex
 


### PR DESCRIPTION
Proposed fix is to revert upstream fix in bencode.py

Issues:
- [ ] The included torrent does not produce the bencode error