### PR TITLE
[Docs] Clean module sources dir before generating docs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -186,7 +186,10 @@ whitelist_externals =
 [testenv:docs]
 sitepackages = {[docsbase]sitepackages}
 deps = {[docsbase]deps}
+whitelist_externals =
+    bash
 commands =
+    bash -c 'rm -f docs/source/modules/*.rst'
     python -c "print '> sphinx-apidoc --force -o docs/source/modules/ deluge deluge/plugins\n'\
         '> sphinx-build -v -E -T -b html -d docs/build/doctrees docs/source docs/build/html';\
         import subprocess, sys; proc = subprocess.Popen(\


### PR DESCRIPTION
If old and outdated sources are present in docs/sources/modules,
python setup.py build_docs will fail to generate docs.