### PR TITLE
[#2861] [Core] Add support for python-geoip

### DIFF
--- a/DEPENDS
+++ b/DEPENDS
@@ -1,5 +1,5 @@
 === Core ===
- * libtorrent (rasterbar) >= 0.16.7
+ * libtorrent (rasterbar) >= 1.0.7
  * python >= 2.6
  * setuptools
  * twisted >= 11.1
@@ -7,6 +7,7 @@
  * pyxdg
  * chardet
  * gettext
+ * python-geoip (optional)
  * geoip-database (optional)
  * setproctitle (optional)
  * pillow (optional)

--- a/deluge/core/core.py
+++ b/deluge/core/core.py
@@ -96,6 +96,9 @@ class Core(component.Component):
         self.external_ip = None
         self.eventmanager.register_event_handler("ExternalIPEvent", self._on_external_ip_event)
 
+        # GeoIP instance with db loaded
+        self.geoip_instance = None
+
         # Get the core config
         self.config = ConfigManager("core.conf")
         self.config.save()

--- a/deluge/core/torrent.py
+++ b/deluge/core/torrent.py
@@ -791,14 +791,14 @@ class Torrent(object):
             if peer.flags & peer.connecting or peer.flags & peer.handshake:
                 continue
 
-            client = decode_string(str(peer.client))
-            # Make country a proper string
-            country = str()
-            for char in peer.country:
-                if not char.isalpha():
-                    country += " "
-                else:
-                    country += char
+            client = decode_string(peer.client)
+
+            try:
+                country = component.get("Core").geoip_instance.country_code_by_addr(peer.ip[0])
+            except AttributeError:
+                country = ""
+            else:
+                country = "".join([char if char.isalpha() else " " for char in country])
 
             ret.append({
                 "client": client,

--- a/deluge/ui/gtkui/peers_tab.py
+++ b/deluge/ui/gtkui/peers_tab.py
@@ -214,7 +214,7 @@ class PeersTab(Tab):
         component.get("SessionProxy").get_torrent_status(torrent_id, ["peers"]).addCallback(self._on_get_torrent_status)
 
     def get_flag_pixbuf(self, country):
-        if country == "  ":
+        if not country.strip():
             return None
 
         if country not in self.cached_flag_pixbufs:


### PR DESCRIPTION
 * libtorrent >= 1.1 dropped support for GeoIP so this add support
   using MaxMind GeoIP Legacy Python Extension API.
 * It is known by the following package names:
       * Maxmind: geoip-api-python
       * Linux: python-geoip
       * PyPi: GeoIP