### PR TITLE
Feature/python3 support

### DIFF
--- a/deluge/common.py
+++ b/deluge/common.py
@@ -8,6 +8,7 @@
 #
 
 """Common functions for various parts of Deluge to use."""
+from __future__ import print_function
 
 import base64
 import functools
@@ -1047,14 +1048,14 @@ def run_profiled(func, *args, **kwargs):
             if output_file:
                 profiler.dump_stats(output_file)
                 log.info("Profile stats saved to %s", output_file)
-                print "Profile stats saved to %s" % output_file
+                print("Profile stats saved to %s" % output_file)
             else:
                 import pstats
                 import StringIO
                 strio = StringIO.StringIO()
                 ps = pstats.Stats(profiler, stream=strio).sort_stats('cumulative')
                 ps.print_stats()
-                print strio.getvalue()
+                print(strio.getvalue())
 
         try:
             return profiler.runcall(func, *args)

--- a/deluge/common.py
+++ b/deluge/common.py
@@ -8,7 +8,7 @@
 #
 
 """Common functions for various parts of Deluge to use."""
-from __future__ import print_function
+from __future__ import division, print_function
 
 import base64
 import functools
@@ -321,16 +321,16 @@ def fsize(fsize_b, precision=1, shortform=False):
 
     # Bigger than 1 TiB
     if fsize_b >= 1099511627776:
-        return "%.*f %s" % (precision, fsize_b / 1099511627776.0, tib_txt_short if shortform else tib_txt)
+        return "%.*f %s" % (precision, fsize_b / 1099511627776, tib_txt_short if shortform else tib_txt)
     # Bigger than 1 GiB
     elif fsize_b >= 1073741824:
-        return "%.*f %s" % (precision, fsize_b / 1073741824.0, gib_txt_short if shortform else gib_txt)
+        return "%.*f %s" % (precision, fsize_b / 1073741824, gib_txt_short if shortform else gib_txt)
     # Bigger than 1 MiB
     elif fsize_b >= 1048576:
-        return "%.*f %s" % (precision, fsize_b / 1048576.0, mib_txt_short if shortform else mib_txt)
+        return "%.*f %s" % (precision, fsize_b / 1048576, mib_txt_short if shortform else mib_txt)
     # Bigger than 1 KiB
     elif fsize_b >= 1024:
-        return "%.*f %s" % (precision, fsize_b / 1024.0, kib_txt_short if shortform else kib_txt)
+        return "%.*f %s" % (precision, fsize_b / 1024, kib_txt_short if shortform else kib_txt)
     else:
         return "%d %s" % (fsize_b, byte_txt)
 
@@ -376,16 +376,16 @@ def fspeed(bps, precision=1, shortform=False):
 
     """
 
-    fspeed_kb = bps / 1024.0
+    fspeed_kb = bps / 1024
     if fspeed_kb < 1024:
         return "%.*f %s" % (precision, fspeed_kb, _("K/s") if shortform else _("KiB/s"))
-    fspeed_mb = fspeed_kb / 1024.0
+    fspeed_mb = fspeed_kb / 1024
     if fspeed_mb < 1024:
         return "%.*f %s" % (precision, fspeed_mb, _("M/s") if shortform else _("MiB/s"))
-    fspeed_gb = fspeed_mb / 1024.0
+    fspeed_gb = fspeed_mb / 1024
     if fspeed_gb < 1024:
         return "%.*f %s" % (precision, fspeed_gb, _("G/s") if shortform else _("GiB/s"))
-    fspeed_tb = fspeed_gb / 1024.0
+    fspeed_tb = fspeed_gb / 1024
     return "%.*f %s" % (precision, fspeed_tb, _("T/s") if shortform else _("TiB/s"))
 
 
@@ -433,23 +433,23 @@ def ftime(seconds):
         return ""
     if seconds < 60:
         return '%ds' % (seconds)
-    minutes = seconds / 60
+    minutes = seconds // 60
     if minutes < 60:
         seconds = seconds % 60
         return '%dm %ds' % (minutes, seconds)
-    hours = minutes / 60
+    hours = minutes // 60
     if hours < 24:
         minutes = minutes % 60
         return '%dh %dm' % (hours, minutes)
-    days = hours / 24
+    days = hours // 24
     if days < 7:
         hours = hours % 24
         return '%dd %dh' % (days, hours)
-    weeks = days / 7
+    weeks = days // 7
     if weeks < 52:
         days = days % 7
         return '%dw %dd' % (weeks, days)
-    years = weeks / 52
+    years = weeks // 52
     weeks = weeks % 52
     return '%dy %dw' % (years, weeks)
 

--- a/deluge/component.py
+++ b/deluge/component.py
@@ -298,7 +298,7 @@ class ComponentRegistry(object):
         """
         # Start all the components if names is empty
         if not names:
-            names = self.components.keys()
+            names = list(self.components)
         elif isinstance(names, str):
             names = [names]
 
@@ -332,7 +332,7 @@ class ComponentRegistry(object):
 
         """
         if not names:
-            names = self.components.keys()
+            names = list(self.components)
         elif isinstance(names, str):
             names = [names]
 
@@ -370,7 +370,7 @@ class ComponentRegistry(object):
 
         """
         if not names:
-            names = self.components.keys()
+            names = list(self.components)
         elif isinstance(names, str):
             names = [names]
 
@@ -396,7 +396,7 @@ class ComponentRegistry(object):
 
         """
         if not names:
-            names = self.components.keys()
+            names = list(self.components)
         elif isinstance(names, str):
             names = [names]
 
@@ -421,7 +421,7 @@ class ComponentRegistry(object):
         def on_stopped(result):
             return DeferredList([comp._component_shutdown() for comp in self.components.values()])
 
-        return self.stop(self.components.keys()).addCallback(on_stopped)
+        return self.stop(list(self.components)).addCallback(on_stopped)
 
     def update(self):
         """Update all Components that are in a Started state."""

--- a/deluge/config.py
+++ b/deluge/config.py
@@ -125,7 +125,7 @@ class Config(object):
         self._save_timer = None
 
         if defaults:
-            for key, value in defaults.iteritems():
+            for key, value in defaults.items():
                 self.set_item(key, value)
 
         # Load the config from file in the config_dir
@@ -363,7 +363,7 @@ what is currently in the config and it could not convert the value
 
         """
         log.debug("Calling all set functions..")
-        for key, value in self.__set_functions.iteritems():
+        for key, value in self.__set_functions.items():
             for func in value:
                 func(key, self.__config[key])
 

--- a/deluge/configmanager.py
+++ b/deluge/configmanager.py
@@ -88,7 +88,7 @@ class _ConfigManager(object):
         """Get a reference to the Config object for this filename"""
         log.debug("Getting config '%s'", config_file)
         # Create the config object if not already created
-        if config_file not in self.config_files.keys():
+        if config_file not in self.config_files:
             self.config_files[config_file] = Config(config_file, defaults, self.config_directory)
 
         return self.config_files[config_file]

--- a/deluge/core/authmanager.py
+++ b/deluge/core/authmanager.py
@@ -29,7 +29,7 @@ AUTH_LEVELS_MAPPING = {
 }
 
 AUTH_LEVELS_MAPPING_REVERSE = {}
-for key, value in AUTH_LEVELS_MAPPING.iteritems():
+for key, value in AUTH_LEVELS_MAPPING.items():
     AUTH_LEVELS_MAPPING_REVERSE[value] = key
 
 

--- a/deluge/core/core.py
+++ b/deluge/core/core.py
@@ -8,6 +8,8 @@
 # See LICENSE for more details.
 #
 
+from __future__ import division
+
 import base64
 import glob
 import logging
@@ -413,13 +415,12 @@ class Core(component.Component):
 
         # Add in a couple ratios
         try:
-            cache["write_hit_ratio"] = float((cache["blocks_written"] -
-                                              cache["writes"])) / float(cache["blocks_written"])
+            cache["write_hit_ratio"] = (cache["blocks_written"] - cache["writes"]) / cache["blocks_written"]
         except ZeroDivisionError:
             cache["write_hit_ratio"] = 0.0
 
         try:
-            cache["read_hit_ratio"] = float(cache["blocks_read_hit"]) / float(cache["blocks_read"])
+            cache["read_hit_ratio"] = cache["blocks_read_hit"] / cache["blocks_read"]
         except ZeroDivisionError:
             cache["read_hit_ratio"] = 0.0
 

--- a/deluge/core/core.py
+++ b/deluge/core/core.py
@@ -505,7 +505,7 @@ class Core(component.Component):
             status_dict, plugin_keys = args
             # Ask the plugin manager to fill in the plugin keys
             if len(plugin_keys) > 0:
-                for key in status_dict.keys():
+                for key in status_dict:
                     status_dict[key].update(self.pluginmanager.get_status(key, plugin_keys))
             return status_dict
         d.addCallback(add_plugin_fields)
@@ -544,7 +544,7 @@ class Core(component.Component):
     def set_config(self, config):
         """Set the config with values from dictionary"""
         # Load all the values into the configuration
-        for key in config.keys():
+        for key in config:
             if self.read_only_config_keys and key in self.read_only_config_keys:
                 continue
             if isinstance(config[key], basestring):

--- a/deluge/core/filtermanager.py
+++ b/deluge/core/filtermanager.py
@@ -173,7 +173,7 @@ class FilterManager(component.Component):
         # Leftover filter arguments, default filter on status fields.
         for torrent_id in list(torrent_ids):
             status = self.core.create_torrent_status(torrent_id, torrent_keys, plugin_keys)
-            for field, values in filter_dict.iteritems():
+            for field, values in filter_dict.items():
                 if field in status and status[field] in values:
                     continue
                 elif torrent_id in torrent_ids:
@@ -212,7 +212,7 @@ class FilterManager(component.Component):
         # Return a dict of tuples:
         sorted_items = {}
         for field in tree_keys:
-            sorted_items[field] = sorted(items[field].iteritems())
+            sorted_items[field] = sorted(items[field].items())
 
         if "state" in tree_keys:
             sorted_items["state"].sort(self._sort_state_items)

--- a/deluge/core/filtermanager.py
+++ b/deluge/core/filtermanager.py
@@ -169,7 +169,7 @@ class FilterManager(component.Component):
         if not filter_dict:
             return torrent_ids
 
-        torrent_keys, plugin_keys = self.torrents.separate_keys(filter_dict.keys(), torrent_ids)
+        torrent_keys, plugin_keys = self.torrents.separate_keys(list(filter_dict), torrent_ids)
         # Leftover filter arguments, default filter on status fields.
         for torrent_id in list(torrent_ids):
             status = self.core.create_torrent_status(torrent_id, torrent_keys, plugin_keys)
@@ -186,7 +186,7 @@ class FilterManager(component.Component):
         for use in sidebar.
         """
         torrent_ids = self.torrents.get_torrent_list()
-        tree_keys = list(self.tree_fields.keys())
+        tree_keys = list(self.tree_fields)
         if hide_cat:
             for cat in hide_cat:
                 tree_keys.remove(cat)

--- a/deluge/core/pluginmanager.py
+++ b/deluge/core/pluginmanager.py
@@ -46,7 +46,7 @@ class PluginManager(deluge.pluginmanagerbase.PluginManagerBase, component.Compon
         self.stop()
 
     def update_plugins(self):
-        for plugin in self.plugins.keys():
+        for plugin in self.plugins:
             if hasattr(self.plugins[plugin], "update"):
                 try:
                     self.plugins[plugin].update()
@@ -82,7 +82,7 @@ class PluginManager(deluge.pluginmanagerbase.PluginManagerBase, component.Compon
         """Return the value of status fields for the selected torrent_id."""
         status = {}
         if len(fields) == 0:
-            fields = self.status_fields.keys()
+            fields = list(self.status_fields)
         for field in fields:
             try:
                 status[field] = self.status_fields[field](torrent_id)

--- a/deluge/core/rpcserver.py
+++ b/deluge/core/rpcserver.py
@@ -429,7 +429,7 @@ class RPCServer(component.Component):
         :returns: the exported methods
         :rtype: list
         """
-        return self.factory.methods.keys()
+        return list(self.factory.methods)
 
     def get_session_id(self):
         """

--- a/deluge/core/torrent.py
+++ b/deluge/core/torrent.py
@@ -160,7 +160,7 @@ class TorrentOptions(dict):
             "super_seeding": "super_seeding",
             "priority": "priority",
         }
-        for opt_k, conf_k in options_conf_map.iteritems():
+        for opt_k, conf_k in options_conf_map.items():
             self[opt_k] = config[conf_k]
         self["file_priorities"] = []
         self["mapped_files"] = {}
@@ -1323,7 +1323,7 @@ class Torrent(object):
             torrent.waiting_on_folder_rename = [_dir for _dir in torrent.waiting_on_folder_rename if _dir]
             component.get("TorrentManager").save_resume_data((self.torrent_id,))
 
-        d = DeferredList(wait_on_folder.values())
+        d = DeferredList(list(wait_on_folder.values()))
         d.addBoth(on_folder_rename_complete, self, folder, new_folder)
         return d
 

--- a/deluge/core/torrent.py
+++ b/deluge/core/torrent.py
@@ -940,7 +940,7 @@ class Torrent(object):
             self.update_status(self.handle.status())
 
         if all_keys:
-            keys = self.status_funcs.keys()
+            keys = list(self.status_funcs)
 
         status_dict = {}
 
@@ -1360,7 +1360,7 @@ class Torrent(object):
 
         If the key is no longer valid, the dict will be deleted.
         """
-        for key in self.prev_status.keys():
+        for key in self.prev_status:
             if not self.rpcserver.is_session_valid(key):
                 del self.prev_status[key]
 

--- a/deluge/core/torrent.py
+++ b/deluge/core/torrent.py
@@ -19,7 +19,7 @@ from __future__ import division
 import logging
 import os
 import socket
-from itertools import izip
+from future_builtins import zip  # pylint: disable=redefined-builtin
 from urlparse import urlparse
 
 from twisted.internet.defer import Deferred, DeferredList
@@ -829,7 +829,7 @@ class Torrent(object):
         if not self.has_metadata:
             return 0.0
         return [progress / _file.size if _file.size else 0.0 for progress, _file in
-                izip(self.handle.file_progress(), self.torrent_info.files())]
+                zip(self.handle.file_progress(), self.torrent_info.files())]
 
     def get_tracker_host(self):
         """Get the hostname of the currently connected tracker.
@@ -1370,7 +1370,7 @@ class Torrent(object):
             pieces = None
         else:
             pieces = []
-            for piece, avail_piece in izip(self.status.pieces, self.handle.piece_availability()):
+            for piece, avail_piece in zip(self.status.pieces, self.handle.piece_availability()):
                 if piece:
                     pieces.append(3)  # Completed.
                 elif avail_piece:

--- a/deluge/core/torrentmanager.py
+++ b/deluge/core/torrentmanager.py
@@ -197,7 +197,7 @@ class TorrentManager(component.Component):
             archive_file("torrents.state")
             archive_file("torrents.fastresume")
         else:
-            with file(self.temp_file, 'a'):
+            with open(self.temp_file, 'a'):
                 os.utime(self.temp_file, None)
 
         # Try to load the state from file

--- a/deluge/core/torrentmanager.py
+++ b/deluge/core/torrentmanager.py
@@ -266,7 +266,7 @@ class TorrentManager(component.Component):
             list: A list of torrent_ids.
 
         """
-        torrent_ids = self.torrents.keys()
+        torrent_ids = list(self.torrents)
         if component.get("RPCServer").get_session_auth_level() == AUTH_LEVEL_ADMIN:
             return torrent_ids
 
@@ -924,25 +924,25 @@ class TorrentManager(component.Component):
     def on_set_max_connections_per_torrent(self, key, value):
         """Sets the per-torrent connection limit"""
         log.debug("max_connections_per_torrent set to %s...", value)
-        for key in self.torrents.keys():
+        for key in self.torrents:
             self.torrents[key].set_max_connections(value)
 
     def on_set_max_upload_slots_per_torrent(self, key, value):
         """Sets the per-torrent upload slot limit"""
         log.debug("max_upload_slots_per_torrent set to %s...", value)
-        for key in self.torrents.keys():
+        for key in self.torrents:
             self.torrents[key].set_max_upload_slots(value)
 
     def on_set_max_upload_speed_per_torrent(self, key, value):
         """Sets the per-torrent upload speed limit"""
         log.debug("max_upload_speed_per_torrent set to %s...", value)
-        for key in self.torrents.keys():
+        for key in self.torrents:
             self.torrents[key].set_max_upload_speed(value)
 
     def on_set_max_download_speed_per_torrent(self, key, value):
         """Sets the per-torrent download speed limit"""
         log.debug("max_download_speed_per_torrent set to %s...", value)
-        for key in self.torrents.keys():
+        for key in self.torrents:
             self.torrents[key].set_max_download_speed(value)
 
     # --- Alert handlers ---
@@ -1301,7 +1301,7 @@ class TorrentManager(component.Component):
         if self.torrents:
             for torrent_id in torrent_ids:
                 if torrent_id in self.torrents:
-                    status_keys = self.torrents[torrent_id].status_funcs.keys()
+                    status_keys = list(self.torrents[torrent_id].status_funcs)
                     leftover_keys = list(set(keys) - set(status_keys))
                     torrent_keys = list(set(keys) - set(leftover_keys))
                     return torrent_keys, leftover_keys

--- a/deluge/core/torrentmanager.py
+++ b/deluge/core/torrentmanager.py
@@ -746,7 +746,7 @@ class TorrentManager(component.Component):
 
         """
         if torrent_ids is None:
-            torrent_ids = (t[0] for t in self.torrents.iteritems() if t[1].handle.need_save_resume_data())
+            torrent_ids = (t[0] for t in self.torrents.items() if t[1].handle.need_save_resume_data())
 
         def on_torrent_resume_save(dummy_result, torrent_id):
             """Recieved torrent resume_data alert so remove from waiting list"""
@@ -918,7 +918,7 @@ class TorrentManager(component.Component):
 
     def cleanup_torrents_prev_status(self):
         """Run cleanup_prev_status for each registered torrent"""
-        for torrent in self.torrents.iteritems():
+        for torrent in self.torrents.items():
             torrent[1].cleanup_prev_status()
 
     def on_set_max_connections_per_torrent(self, key, value):

--- a/deluge/maketorrent.py
+++ b/deluge/maketorrent.py
@@ -7,6 +7,8 @@
 # See LICENSE for more details.
 #
 
+from __future__ import division
+
 import os
 import sys
 from hashlib import sha1 as sha
@@ -102,11 +104,11 @@ class TorrentMetadata(object):
         else:
             # We need to calculate a piece size
             piece_size = 16384
-            while (datasize / piece_size) > 1024 and piece_size < (8192 * 1024):
+            while (datasize // piece_size) > 1024 and piece_size < (8192 * 1024):
                 piece_size *= 2
 
         # Calculate the number of pieces we will require for the data
-        num_pieces = datasize / piece_size
+        num_pieces = datasize // piece_size
         if datasize % piece_size:
             num_pieces += 1
 

--- a/deluge/metafile.py
+++ b/deluge/metafile.py
@@ -95,7 +95,7 @@ def make_meta_file(path, url, piece_length, progress=None, title=None, comment=N
     info = makeinfo(path, piece_length, progress, name, content_type, private)
 
     # check_info(info)
-    h = file(f, 'wb')
+    h = open(f, 'wb')
 
     data['info'] = info
     if title:
@@ -184,7 +184,7 @@ def makeinfo(path, piece_length, progress, name=None, content_type=None, private
                            'content_type': content_type})  # HEREDAVE. bad for batch!
             else:
                 fs.append({'length': size, 'path': p2})
-            h = file(f, 'rb')
+            h = open(f, 'rb')
             while pos < size:
                 a = min(size - pos, piece_length - done)
                 sh.update(h.read(a))
@@ -224,7 +224,7 @@ def makeinfo(path, piece_length, progress, name=None, content_type=None, private
 
         pieces = []
         p = 0
-        h = file(path, 'rb')
+        h = open(path, 'rb')
         while p < size:
             x = h.read(min(piece_length, size - p))
             pieces.append(sha(x).digest())

--- a/deluge/metafile.py
+++ b/deluge/metafile.py
@@ -11,6 +11,8 @@
 # See LICENSE for more details.
 #
 
+from __future__ import division
+
 import logging
 import os.path
 import sys
@@ -169,7 +171,7 @@ def makeinfo(path, piece_length, progress, name=None, content_type=None, private
             totalsize += os.path.getsize(f)
         if totalsize >= piece_length:
             import math
-            num_pieces = math.ceil(float(totalsize) / float(piece_length))
+            num_pieces = math.ceil(totalsize / piece_length)
         else:
             num_pieces = 1
 
@@ -216,7 +218,7 @@ def makeinfo(path, piece_length, progress, name=None, content_type=None, private
     else:
         size = os.path.getsize(path)
         if size >= piece_length:
-            num_pieces = size / piece_length
+            num_pieces = size // piece_length
         else:
             num_pieces = 1
 

--- a/deluge/pluginmanagerbase.py
+++ b/deluge/pluginmanagerbase.py
@@ -74,7 +74,7 @@ class PluginManagerBase(object):
 
     def disable_plugins(self):
         # Disable all plugins that are enabled
-        for key in self.plugins.keys():
+        for key in self.plugins:
             self.disable_plugin(key)
 
     def __getitem__(self, key):
@@ -86,7 +86,7 @@ class PluginManagerBase(object):
 
     def get_enabled_plugins(self):
         """Returns a list of enabled plugins"""
-        return self.plugins.keys()
+        return list(self.plugins)
 
     def scan_for_plugins(self):
         """Scans for available plugins"""
@@ -243,14 +243,14 @@ class PluginManagerBase(object):
         for line in self.pkg_env[name][0].get_metadata("PKG-INFO").splitlines():
             if not line:
                 continue
-            if line[0] in ' \t' and (len(line.split(":", 1)) == 1 or line.split(":", 1)[0] not in info.keys()):
+            if line[0] in ' \t' and (len(line.split(":", 1)) == 1 or line.split(":", 1)[0] not in info):
                 # This is a continuation
                 cont_lines.append(line.strip())
             else:
                 if cont_lines:
                     info[last_header] = "\n".join(cont_lines).strip()
                     cont_lines = []
-                if line.split(":", 1)[0] in info.keys():
+                if line.split(":", 1)[0] in info:
                     last_header = line.split(":", 1)[0]
                     info[last_header] = line.split(":", 1)[1].strip()
         return info

--- a/deluge/plugins/AutoAdd/deluge/plugins/autoadd/core.py
+++ b/deluge/plugins/AutoAdd/deluge/plugins/autoadd/core.py
@@ -131,9 +131,9 @@ class Core(CorePluginBase):
             for w_id, w in self.watchdirs.iteritems():
                 if options["abspath"] == w["abspath"] and watchdir_id != w_id:
                     raise Exception("Path is already being watched.")
-        for key in options.keys():
+        for key in options:
             if key not in OPTIONS_AVAILABLE:
-                if key not in [key2 + "_toggle" for key2 in OPTIONS_AVAILABLE.iterkeys()]:
+                if key not in [key2 + "_toggle" for key2 in OPTIONS_AVAILABLE]:
                     raise Exception("autoadd: Invalid options key:%s" % key)
         # disable the watch loop if it was active
         if watchdir_id in self.update_timers:
@@ -360,7 +360,7 @@ class Core(CorePluginBase):
     def set_config(self, config):
         """Sets the config dictionary."""
         config = self._make_unicode(config)
-        for key in config.keys():
+        for key in config:
             self.config[key] = config[key]
         self.config.save()
         component.get("EventManager").emit(AutoaddOptionsChangedEvent())
@@ -386,7 +386,7 @@ class Core(CorePluginBase):
                 watchdirs[watchdir_id] = watchdir
 
         log.debug("Current logged in user %s is not an ADMIN, send only "
-                  "his watchdirs: %s", session_user, watchdirs.keys())
+                  "his watchdirs: %s", session_user, list(watchdirs))
         return watchdirs
 
     def _make_unicode(self, options):
@@ -434,7 +434,7 @@ class Core(CorePluginBase):
         component.get("EventManager").emit(AutoaddOptionsChangedEvent())
 
     def __migrate_config_1_to_2(self, config):
-        for watchdir_id in config["watchdirs"].iterkeys():
+        for watchdir_id in config["watchdirs"]:
             config["watchdirs"][watchdir_id]["owner"] = "localclient"
         return config
 

--- a/deluge/plugins/AutoAdd/deluge/plugins/autoadd/core.py
+++ b/deluge/plugins/AutoAdd/deluge/plugins/autoadd/core.py
@@ -99,7 +99,7 @@ class Core(CorePluginBase):
 
     def enable_looping(self):
         # Enable all looping calls for enabled watchdirs here
-        for watchdir_id, watchdir in self.watchdirs.iteritems():
+        for watchdir_id, watchdir in self.watchdirs.items():
             if watchdir["enabled"]:
                 self.enable_watchdir(watchdir_id)
 
@@ -108,7 +108,7 @@ class Core(CorePluginBase):
         component.get("EventManager").deregister_event_handler(
             "PreTorrentRemovedEvent", self.__on_pre_torrent_removed
         )
-        for loopingcall in self.update_timers.itervalues():
+        for loopingcall in self.update_timers.values():
             loopingcall.stop()
         self.config.save()
 
@@ -128,7 +128,7 @@ class Core(CorePluginBase):
             check_input(
                 os.path.isdir(options["abspath"]), _("Path does not exist.")
             )
-            for w_id, w in self.watchdirs.iteritems():
+            for w_id, w in self.watchdirs.items():
                 if options["abspath"] == w["abspath"] and watchdir_id != w_id:
                     raise Exception("Path is already being watched.")
         for key in options:
@@ -223,7 +223,7 @@ class Core(CorePluginBase):
             watchdir["stop_ratio_toggle"] = watchdir["stop_at_ratio_toggle"]
         # We default to True when reading _toggle values, so a config
         # without them is valid, and applies all its settings.
-        for option, value in watchdir.iteritems():
+        for option, value in watchdir.items():
             if OPTIONS_AVAILABLE.get(option):
                 if watchdir.get(option + "_toggle", True) or option in ["owner", "seed_mode"]:
                     opts[option] = value
@@ -381,7 +381,7 @@ class Core(CorePluginBase):
             return self.watchdirs
 
         watchdirs = {}
-        for watchdir_id, watchdir in self.watchdirs.iteritems():
+        for watchdir_id, watchdir in self.watchdirs.items():
             if watchdir.get("owner", "localclient") == session_user:
                 watchdirs[watchdir_id] = watchdir
 
@@ -409,7 +409,7 @@ class Core(CorePluginBase):
             os.access(abswatchdir, os.R_OK | os.W_OK),
             "You must have read and write access to watch folder."
         )
-        if abswatchdir in [wd["abspath"] for wd in self.watchdirs.itervalues()]:
+        if abswatchdir in [wd["abspath"] for wd in self.watchdirs.values()]:
             raise Exception("Path is already being watched.")
         options.setdefault("enabled", False)
         options["abspath"] = abswatchdir
@@ -447,7 +447,7 @@ class Core(CorePluginBase):
                         torrent_id)
             return
         torrent_fname = torrent.filename
-        for watchdir in self.watchdirs.itervalues():
+        for watchdir in self.watchdirs.values():
             if not watchdir.get("copy_torrent_toggle", False):
                 # This watchlist does copy torrents
                 continue

--- a/deluge/plugins/AutoAdd/deluge/plugins/autoadd/gtkui.py
+++ b/deluge/plugins/AutoAdd/deluge/plugins/autoadd/gtkui.py
@@ -401,7 +401,7 @@ class GtkUI(GtkPluginBase):
 
     def create_model(self):
         store = gtk.ListStore(str, bool, str, str)
-        for watchdir_id, watchdir in self.watchdirs.iteritems():
+        for watchdir_id, watchdir in self.watchdirs.items():
             store.append([
                 watchdir_id, watchdir['enabled'],
                 watchdir.get('owner', 'localclient'), watchdir['path']
@@ -474,7 +474,7 @@ class GtkUI(GtkPluginBase):
 
     def on_apply_prefs(self):
         log.debug("applying prefs for AutoAdd")
-        for watchdir_id, watchdir in self.watchdirs.iteritems():
+        for watchdir_id, watchdir in self.watchdirs.items():
             client.autoadd.set_options(watchdir_id, watchdir)
 
     def on_show_prefs(self):
@@ -488,7 +488,7 @@ class GtkUI(GtkPluginBase):
         log.trace("Got whatchdirs from core: %s", watchdirs)
         self.watchdirs = watchdirs or {}
         self.store.clear()
-        for watchdir_id, watchdir in self.watchdirs.iteritems():
+        for watchdir_id, watchdir in self.watchdirs.items():
             self.store.append([
                 watchdir_id, watchdir['enabled'],
                 watchdir.get('owner', 'localclient'), watchdir['path']

--- a/deluge/plugins/Blocklist/deluge/plugins/blocklist/core.py
+++ b/deluge/plugins/Blocklist/deluge/plugins/blocklist/core.py
@@ -168,7 +168,7 @@ class Core(CorePluginBase):
 
         """
         needs_blocklist_import = False
-        for key in config.keys():
+        for key in config:
             if key == 'whitelisted':
                 saved = set(self.config[key])
                 update = set(config[key])

--- a/deluge/plugins/Blocklist/deluge/plugins/blocklist/core.py
+++ b/deluge/plugins/Blocklist/deluge/plugins/blocklist/core.py
@@ -8,6 +8,8 @@
 # See LICENSE for more details.
 #
 
+from __future__ import division
+
 import logging
 import os
 import shutil
@@ -288,7 +290,7 @@ class Core(CorePluginBase):
         """
         def on_retrieve_data(data, current_length, total_length):
             if total_length:
-                fp = float(current_length) / total_length
+                fp = current_length / total_length
                 if fp > 1.0:
                     fp = 1.0
             else:

--- a/deluge/plugins/Blocklist/deluge/plugins/blocklist/peerguardian.py
+++ b/deluge/plugins/Blocklist/deluge/plugins/blocklist/peerguardian.py
@@ -47,7 +47,7 @@ class PGReader(object):
         if ver != 1 and ver != 2:
             raise PGException(_("Invalid version") + " %d" % ver)
 
-    def next(self):
+    def __next__(self):
         # Skip over the string
         buf = -1
         while buf != 0:
@@ -63,6 +63,9 @@ class PGReader(object):
         end = socket.inet_ntoa(buf)
 
         return (start, end)
+
+    # Python 2 compatibility
+    next = __next__
 
     def close(self):
         self.fd.close()

--- a/deluge/plugins/Execute/deluge/plugins/execute/core.py
+++ b/deluge/plugins/Execute/deluge/plugins/execute/core.py
@@ -133,7 +133,7 @@ class Core(CorePluginBase):
     def disable(self):
         self.config.save()
         event_manager = component.get("EventManager")
-        for event, handler in self.registered_events.iteritems():
+        for event, handler in self.registered_events.items():
             event_manager.deregister_event_handler(event, handler)
         log.debug("Execute core plugin disabled!")
 

--- a/deluge/plugins/Extractor/deluge/plugins/extractor/core.py
+++ b/deluge/plugins/Extractor/deluge/plugins/extractor/core.py
@@ -157,7 +157,7 @@ class Core(CorePluginBase):
     @export
     def set_config(self, config):
         "sets the config dictionary"
-        for key in config.keys():
+        for key in config:
             self.config[key] = config[key]
         self.config.save()
 

--- a/deluge/plugins/Label/deluge/plugins/label/core.py
+++ b/deluge/plugins/Label/deluge/plugins/label/core.py
@@ -107,8 +107,8 @@ class Core(CorePluginBase):
         pass
 
     def init_filter_dict(self):
-        filter_dict = dict([(label, 0) for label in self.labels.keys()])
-        filter_dict['All'] = len(self.torrents.keys())
+        filter_dict = dict([(label, 0) for label in self.labels])
+        filter_dict['All'] = len(self.torrents)
         return filter_dict
 
     # Plugin hooks #
@@ -142,8 +142,8 @@ class Core(CorePluginBase):
         *add any new keys in OPTIONS_DEFAULTS
         *set all None values to default <-fix development config
         """
-        log.debug(self.labels.keys())
-        for key in self.labels.keys():
+        log.debug(list(self.labels))
+        for key in self.labels:
             options = dict(OPTIONS_DEFAULTS)
             options.update(self.labels[key])
             self.labels[key] = options
@@ -159,7 +159,7 @@ class Core(CorePluginBase):
 
     @export
     def get_labels(self):
-        return sorted(self.labels.keys())
+        return sorted(self.labels)
 
     # Labels:
     @export
@@ -259,7 +259,7 @@ class Core(CorePluginBase):
         }
         """
         check_input(label_id in self.labels, _("Unknown Label"))
-        for key in options_dict.keys():
+        for key in options_dict:
             if key not in OPTIONS_DEFAULTS:
                 raise Exception("label: Invalid options_dict key:%s" % key)
 

--- a/deluge/plugins/Label/deluge/plugins/label/core.py
+++ b/deluge/plugins/Label/deluge/plugins/label/core.py
@@ -118,7 +118,7 @@ class Core(CorePluginBase):
         log.debug("post_torrent_add")
         torrent = self.torrents[torrent_id]
 
-        for label_id, options in self.labels.iteritems():
+        for label_id, options in self.labels.items():
             if options["auto_add"]:
                 if self._has_auto_match(torrent, options):
                     self.set_torrent(torrent_id, label_id)
@@ -132,7 +132,7 @@ class Core(CorePluginBase):
     # Utils #
     def clean_config(self):
         """remove invalid data from config-file"""
-        for torrent_id, label_id in list(self.torrent_labels.iteritems()):
+        for torrent_id, label_id in list(self.torrent_labels.items()):
             if (label_id not in self.labels) or (torrent_id not in self.torrents):
                 log.debug("label: rm %s:%s", torrent_id, label_id)
                 del self.torrent_labels[torrent_id]
@@ -266,14 +266,14 @@ class Core(CorePluginBase):
         self.labels[label_id].update(options_dict)
 
         # apply
-        for torrent_id, label in self.torrent_labels.iteritems():
+        for torrent_id, label in self.torrent_labels.items():
             if label_id == label and torrent_id in self.torrents:
                 self._set_torrent_options(torrent_id, label_id)
 
         # auto add
         options = self.labels[label_id]
         if options["auto_add"]:
-            for torrent_id, torrent in self.torrents.iteritems():
+            for torrent_id, torrent in self.torrents.items():
                 if self._has_auto_match(torrent, options):
                     self.set_torrent(torrent_id, label_id)
 

--- a/deluge/plugins/Label/deluge/plugins/label/gtkui/sidebar_menu.py
+++ b/deluge/plugins/Label/deluge/plugins/label/gtkui/sidebar_menu.py
@@ -172,7 +172,7 @@ class OptionsDialog(object):
         self.dialog.run()
 
     def load_options(self, options):
-        log.debug(options.keys())
+        log.debug(list(options))
 
         for spin_id in self.spin_ids + self.spin_int_ids:
             self.glade.get_widget(spin_id).set_value(options[spin_id])

--- a/deluge/plugins/Notifications/deluge/plugins/notifications/common.py
+++ b/deluge/plugins/Notifications/deluge/plugins/notifications/common.py
@@ -47,8 +47,8 @@ class CustomNotifications(object):
         pass
 
     def disable(self):
-        for kind in self.custom_notifications.iterkeys():
-            for eventtype in self.custom_notifications[kind].copy().iterkeys():
+        for kind in self.custom_notifications:
+            for eventtype in self.custom_notifications[kind].copy():
                 wrapper, handler = self.custom_notifications[kind][eventtype]
                 self._deregister_custom_provider(kind, eventtype)
 

--- a/deluge/plugins/Notifications/deluge/plugins/notifications/core.py
+++ b/deluge/plugins/Notifications/deluge/plugins/notifications/core.py
@@ -80,7 +80,7 @@ class CoreNotifications(CustomNotifications):
 
     def get_handled_events(self):
         handled_events = []
-        for evt in sorted(known_events.keys()):
+        for evt in sorted(known_events):
             if known_events[evt].__module__.startswith('deluge.event'):
                 if evt not in ('TorrentFinishedEvent',):
                     # Skip all un-handled built-in events
@@ -204,7 +204,7 @@ class Core(CorePluginBase, CoreNotifications):
     @export
     def set_config(self, config):
         "sets the config dictionary"
-        for key in config.keys():
+        for key in config:
             self.config[key] = config[key]
         self.config.save()
 

--- a/deluge/plugins/Scheduler/deluge/plugins/scheduler/core.py
+++ b/deluge/plugins/Scheduler/deluge/plugins/scheduler/core.py
@@ -146,7 +146,7 @@ class Core(CorePluginBase):
     @export()
     def set_config(self, config):
         "sets the config dictionary"
-        for key in config.keys():
+        for key in config:
             self.config[key] = config[key]
         self.config.save()
         self.do_schedule(False)

--- a/deluge/plugins/Scheduler/deluge/plugins/scheduler/gtkui.py
+++ b/deluge/plugins/Scheduler/deluge/plugins/scheduler/gtkui.py
@@ -11,6 +11,8 @@
 # See LICENSE for more details.
 #
 
+from __future__ import division
+
 import logging
 
 import gtk
@@ -38,9 +40,9 @@ class SchedulerSelectWidget(gtk.DrawingArea):
         self.connect("motion_notify_event", self.mouse_hover)
         self.connect("leave_notify_event", self.mouse_leave)
 
-        self.colors = [[115.0 / 255, 210.0 / 255, 22.0 / 255],
-                       [237.0 / 255, 212.0 / 255, 0.0 / 255],
-                       [204.0 / 255, 0.0 / 255, 0.0 / 255]]
+        self.colors = [[115 / 255, 210 / 255, 22 / 255],
+                       [237 / 255, 212 / 255, 0 / 255],
+                       [204 / 255, 0 / 255, 0 / 255]]
         self.button_state = [[0] * 7 for dummy in xrange(24)]
 
         self.start_point = [0, 0]
@@ -70,8 +72,8 @@ class SchedulerSelectWidget(gtk.DrawingArea):
                 context.set_source_rgba(self.colors[self.button_state[x][y]][0],
                                         self.colors[self.button_state[x][y]][1],
                                         self.colors[self.button_state[x][y]][2], 0.7)
-                context.rectangle(width * (6 * x / 145.0 + 1 / 145.0), height * (6 * y / 43.0 + 1 / 43.0),
-                                  5 * width / 145.0, 5 * height / 43.0)
+                context.rectangle(width * (6 * x / 145 + 1 / 145), height * (6 * y / 43 + 1 / 43),
+                                  5 * width / 145, 5 * height / 43)
                 context.fill_preserve()
                 context.set_source_rgba(0.5, 0.5, 0.5, 0.5)
                 context.stroke()
@@ -79,8 +81,8 @@ class SchedulerSelectWidget(gtk.DrawingArea):
     # coordinates --> which box
     def get_point(self, event):
         size = self.window.get_size()
-        x = int((event.x - size[0] * 0.5 / 145.0) / (6 * size[0] / 145.0))
-        y = int((event.y - size[1] * 0.5 / 43.0) / (6 * size[1] / 43.0))
+        x = int((event.x - size[0] * 0.5 / 145) / (6 * size[0] / 145))
+        y = int((event.y - size[1] * 0.5 / 43) / (6 * size[1] / 43))
 
         if x > 23:
             x = 23

--- a/deluge/plugins/Stats/deluge/plugins/stats/core.py
+++ b/deluge/plugins/Stats/deluge/plugins/stats/core.py
@@ -136,7 +136,7 @@ class Core(CorePluginBase):
 
             # extract the ones we are interested in
             # adding them to the 1s array
-            for stat, stat_list in self.stats[1].iteritems():
+            for stat, stat_list in self.stats[1].items():
                 if stat in stats:
                     stat_list.insert(0, int(stats[stat]))
                 else:
@@ -150,7 +150,7 @@ class Core(CorePluginBase):
                     self.last_update[interval] = update_time
                     self.count[interval] = 0
                     current_stats = self.stats[interval]
-                    for stat, stat_list in self.stats[base].iteritems():
+                    for stat, stat_list in self.stats[base].items():
                         try:
                             avg = mean(stat_list[0:multiplier])
                         except ValueError:

--- a/deluge/plugins/Stats/deluge/plugins/stats/core.py
+++ b/deluge/plugins/Stats/deluge/plugins/stats/core.py
@@ -11,6 +11,8 @@
 # See LICENSE for more details.
 #
 
+from __future__ import division
+
 import logging
 import time
 
@@ -46,7 +48,7 @@ def get_key(config, key):
 
 def mean(items):
     try:
-        return sum(items) / len(items)
+        return sum(items) // len(items)
     except Exception:
         return 0
 

--- a/deluge/plugins/Stats/deluge/plugins/stats/core.py
+++ b/deluge/plugins/Stats/deluge/plugins/stats/core.py
@@ -213,7 +213,7 @@ class Core(CorePluginBase):
     @export
     def set_config(self, config):
         "sets the config dictionary"
-        for key in config.keys():
+        for key in config:
             self.config[key] = config[key]
         self.config.save()
 

--- a/deluge/plugins/Stats/deluge/plugins/stats/graph.py
+++ b/deluge/plugins/Stats/deluge/plugins/stats/graph.py
@@ -14,6 +14,9 @@
 """
 port of old plugin by markybob.
 """
+
+from __future__ import division
+
 import logging
 import math
 import time
@@ -40,7 +43,7 @@ def size_formatter_scale(value):
     scale = 1.0
     for i in range(0, 3):
         scale = scale * 1024.0
-        if value / scale < 1024:
+        if value // scale < 1024:
             return scale
 
 
@@ -118,22 +121,22 @@ class Graph(object):
         (left, top, right, bottom) = bounds
         duration = self.length * self.interval
         start = self.last_update - duration
-        ratio = (right - left) / float(duration)
+        ratio = (right - left) / duration
 
         if duration < 1800 * 10:
             # try rounding to nearest 1min, 5mins, 10mins, 30mins
             for step in [60, 300, 600, 1800]:
-                if duration / step < 10:
+                if duration // step < 10:
                     x_step = step
                     break
         else:
             # If there wasnt anything useful find a nice fitting hourly divisor
-            x_step = ((duration / 5) / 3600) * 3600
+            x_step = ((duration // 5) // 3600) * 3600
 
         # this doesnt allow for dst and timezones...
-        seconds_to_step = math.ceil(start / float(x_step)) * x_step - start
+        seconds_to_step = math.ceil(start / x_step) * x_step - start
 
-        for i in xrange(0, duration / x_step + 1):
+        for i in xrange(0, duration // x_step + 1):
             text = time.strftime('%H:%M', time.localtime(start + seconds_to_step + i * x_step))
             # + 0.5 to allign x to nearest pixel
             x = int(ratio * (seconds_to_step + i * x_step) + left) + 0.5
@@ -144,10 +147,10 @@ class Graph(object):
 
     def draw_graph(self):
         font_extents = self.ctx.font_extents()
-        x_axis_space = font_extents[2] + 2 + self.line_size / 2.0
+        x_axis_space = font_extents[2] + 2 + self.line_size / 2
         plot_height = self.height - x_axis_space
         # lets say we need 2n-1*font height pixels to plot the y ticks
-        tick_limit = (plot_height / font_extents[3])  # / 2.0
+        tick_limit = plot_height / font_extents[3]
 
         max_value = 0
         for stat in self.stat_info:
@@ -171,7 +174,7 @@ class Graph(object):
             return math.ceil(te[4] - te[0])
         y_tick_width = max((space_required(text) for text in y_tick_text))
 
-        top = font_extents[2] / 2.0
+        top = font_extents[2] / 2
         # bounds(left, top, right, bottom)
         bounds = (y_tick_width + 4, top + 2, self.width, self.height - x_axis_space)
 
@@ -192,7 +195,7 @@ class Graph(object):
         scale = 1
         if 'formatter_scale' in self.left_axis:
             scale = self.left_axis['formatter_scale'](x)
-            x = x / float(scale)
+            x = x / scale
 
         # Find the largest power of 10 less than x
         comm_log = math.log10(x)
@@ -212,7 +215,7 @@ class Graph(object):
             steps = steps * 2
 
         if limit is not None and steps > limit:
-            multi = steps / float(limit)
+            multi = steps / limit
             if multi > 2:
                 interval = interval * 5
             else:
@@ -261,7 +264,7 @@ class Graph(object):
         self.ctx.line_to(right, int(bottom - values[0] * ratio))
 
         x = right
-        step = (right - left) / float(self.length - 1)
+        step = (right - left) / (self.length - 1)
         for i, value in enumerate(values):
             if i == self.length - 1:
                 x = left
@@ -290,7 +293,7 @@ class Graph(object):
         height = fe[2]
         x_bearing = te[0]
         width = te[2]
-        self.ctx.move_to(int(x - width / 2.0 + x_bearing), int(y + height))
+        self.ctx.move_to(int(x - width / 2 + x_bearing), int(y + height))
         self.ctx.set_source_rgba(*self.black)
         self.ctx.show_text(text)
 
@@ -302,7 +305,7 @@ class Graph(object):
         ascent = fe[0]
         x_bearing = te[0]
         width = te[4]
-        self.ctx.move_to(int(x - width - x_bearing - 2), int(y + (ascent - descent) / 2.0))
+        self.ctx.move_to(int(x - width - x_bearing - 2), int(y + (ascent - descent) / 2))
         self.ctx.set_source_rgba(*self.black)
         self.ctx.show_text(text)
 

--- a/deluge/plugins/Stats/deluge/plugins/stats/graph.py
+++ b/deluge/plugins/Stats/deluge/plugins/stats/graph.py
@@ -242,7 +242,7 @@ class Graph(object):
             self.draw_y_text(y_tick_text[i], left, y)
         self.draw_line(gray, left, top, left, bottom)
 
-        for stat, info in stats.iteritems():
+        for stat, info in stats.items():
             if len(info['values']) > 0:
                 self.draw_value_poly(info['values'], info['color'], max_value, bounds)
                 self.draw_value_poly(info['values'], info['fill_color'], max_value, bounds, info['fill'])

--- a/deluge/plugins/Stats/deluge/plugins/stats/gtkui.py
+++ b/deluge/plugins/Stats/deluge/plugins/stats/gtkui.py
@@ -128,7 +128,7 @@ class GraphsTab(Tab):
         return False
 
     def update(self):
-        d1 = client.stats.get_stats(self.graph.stat_info.keys(), self.selected_interval)
+        d1 = client.stats.get_stats(list(self.graph.stat_info), self.selected_interval)
         d1.addCallback(self.graph.set_stats)
 
         def _update_complete(result):

--- a/deluge/plugins/Stats/deluge/plugins/stats/gtkui.py
+++ b/deluge/plugins/Stats/deluge/plugins/stats/gtkui.py
@@ -12,6 +12,8 @@
 # See LICENSE for more details.
 #
 
+from __future__ import division
+
 import logging
 
 import gtk
@@ -52,7 +54,7 @@ def neat_time(column, cell, model, data):
     """Render seconds as seconds or minutes with label"""
     seconds = model.get_value(data, 0)
     if seconds > 60:
-        text = "%d %s" % (seconds / 60, _("minutes"))
+        text = "%d %s" % (seconds // 60, _("minutes"))
     elif seconds == 60:
         text = _("1 minute")
     elif seconds == 1:
@@ -69,11 +71,10 @@ def int_str(number):
 
 def gtk_to_graph_color(color):
     """Turns a gtk.gdk.Color into a tuple with range 0-1 as used by the graph"""
-    max_val = float(65535)
     gtk_color = gtk.gdk.Color(color)
-    red = gtk_color.red / max_val
-    green = gtk_color.green / max_val
-    blue = gtk_color.blue / max_val
+    red = gtk_color.red / 65535
+    green = gtk_color.green / 65535
+    blue = gtk_color.blue / 65535
     return (red, green, blue)
 
 

--- a/deluge/plugins/Stats/deluge/plugins/stats/tests/test_stats.py
+++ b/deluge/plugins/Stats/deluge/plugins/stats/tests/test_stats.py
@@ -18,7 +18,7 @@ from deluge.ui.client import client
 
 
 def print_totals(totals):
-    for name, value in totals.iteritems():
+    for name, value in totals.items():
         print(name, fsize(value))
 
     print("overhead:")

--- a/deluge/plugins/WebUi/deluge/plugins/webui/core.py
+++ b/deluge/plugins/WebUi/deluge/plugins/webui/core.py
@@ -50,8 +50,7 @@ class Core(CorePluginBase):
     @export
     def got_deluge_web(self):
         try:
-            from deluge.ui.web import server
-            assert server  # silence pyflakes
+            from deluge.ui.web import server  # noqa pylint: disable=unused-import
             return True
         except ImportError:
             return False

--- a/deluge/plugins/WebUi/deluge/plugins/webui/core.py
+++ b/deluge/plugins/WebUi/deluge/plugins/webui/core.py
@@ -98,7 +98,7 @@ class Core(CorePluginBase):
             if not action:
                 action = 'restart'
 
-        for key in config.keys():
+        for key in config:
             self.config[key] = config[key]
         self.config.save()
 

--- a/deluge/scripts/create_plugin.py
+++ b/deluge/scripts/create_plugin.py
@@ -132,7 +132,7 @@ class Core(CorePluginBase):
     @export
     def set_config(self, config):
         \"\"\"Sets the config dictionary\"\"\"
-        for key in config.keys():
+        for key in config:
             self.config[key] = config[key]
         self.config.save()
 

--- a/deluge/tests/common.py
+++ b/deluge/tests/common.py
@@ -7,6 +7,8 @@
 # See LICENSE for more details.
 #
 
+from __future__ import print_function
+
 import os
 import sys
 import tempfile
@@ -64,7 +66,7 @@ def add_watchdog(deferred, timeout=0.05, message=None):
             watchdog.cancel()
         if not deferred.called:
             if message:
-                print message
+                print(message)
             deferred.cancel()
         return value
 
@@ -190,7 +192,7 @@ class ProcessOutputHandler(protocol.ProcessProtocol):
         if self.check_callbacks(data):
             pass
         elif '[ERROR' in data:
-            print data,
+            print(data, end=' ')
 
     def errReceived(self, data):  # NOQA
         """Process output from stderr"""
@@ -201,7 +203,7 @@ class ProcessOutputHandler(protocol.ProcessProtocol):
             return
         data = "\n%s" % data.strip()
         prefixed = data.replace("\n", "\nSTDERR: ")
-        print "\n%s" % prefixed
+        print("\n%s" % prefixed)
 
 
 def start_core(listen_port=58846, logfile=None, timeout=10, timeout_msg=None,

--- a/deluge/tests/common.py
+++ b/deluge/tests/common.py
@@ -50,7 +50,7 @@ def todo_test(caller):
     # Without the delugereporter the todo would print a stack trace, so in
     # that case we rely only on skipTest
     if os.environ.get("DELUGE_REPORTER", None):
-        getattr(caller, caller._testMethodName).im_func.todo = "To be fixed"
+        getattr(caller, caller._testMethodName).__func__.todo = "To be fixed"
 
     filename = os.path.basename(traceback.extract_stack(None, 2)[0][0])
     funcname = traceback.extract_stack(None, 2)[0][2]

--- a/deluge/tests/daemon_base.py
+++ b/deluge/tests/daemon_base.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import os.path
 
 import pytest
@@ -20,7 +22,7 @@ class DaemonBase(object):
     def terminate_core(self, *args):
         if args[0] is not None:
             if hasattr(args[0], "getTraceback"):
-                print "terminate_core: Errback Exception: %s" % args[0].getTraceback()
+                print("terminate_core: Errback Exception: %s" % args[0].getTraceback())
 
         if not self.core.killed:
             d = self.core.kill()

--- a/deluge/tests/test_component.py
+++ b/deluge/tests/test_component.py
@@ -1,4 +1,5 @@
 from twisted.internet import defer, threads
+from twisted.trial.unittest import SkipTest
 
 import deluge.component as component
 
@@ -200,7 +201,10 @@ class ComponentTestClass(BaseTestCase):
         yield component.start(["test_pause_c1"])
         yield component.pause(["test_pause_c1"])
         test_comp = component.get("test_pause_c1")
-        result = self.failureResultOf(test_comp._component_start())
+        try:
+            result = self.failureResultOf(test_comp._component_start())
+        except AttributeError:
+            raise SkipTest("This test requires trial failureResultOf() in Twisted version >= 13")
         self.assertEqual(result.check(component.ComponentException), component.ComponentException)
 
     @defer.inlineCallbacks

--- a/deluge/tests/test_core.py
+++ b/deluge/tests/test_core.py
@@ -1,4 +1,5 @@
 import base64
+import sys
 from hashlib import sha1 as sha
 
 import pytest
@@ -259,7 +260,11 @@ class CoreTestCase(BaseTestCase):
 
     def test_get_free_space(self):
         space = self.core.get_free_space(".")
-        self.assertTrue(isinstance(space, (int, long)))
+        # get_free_space returns long on Python 2 (32-bit).
+        if sys.version_info >= (3, 0):
+            self.assertTrue(isinstance(space, int))
+        else:
+            self.assertTrue(isinstance(space, (int, long)))
         self.assertTrue(space >= 0)
         self.assertEquals(self.core.get_free_space("/someinvalidpath"), -1)
 

--- a/deluge/tests/test_files_tab.py
+++ b/deluge/tests/test_files_tab.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import pytest
 from twisted.trial import unittest
 
@@ -46,7 +48,7 @@ class FilesTabTestCase(BaseTestCase):
         level = 1
 
         def p_level(s, l):
-            print "%s%s" % (" " * l, s)
+            print("%s%s" % (" " * l, s))
 
         def _print_treestore_children(i, lvl):
             while i:
@@ -55,9 +57,9 @@ class FilesTabTestCase(BaseTestCase):
                     _print_treestore_children(treestore.iter_children(i), lvl + 2)
                 i = treestore.iter_next(i)
 
-        print "\n%s" % title
+        print("\n%s" % title)
         _print_treestore_children(root, level)
-        print ""
+        print("")
 
     def verify_treestore(self, treestore, tree):
 

--- a/deluge/tests/test_httpdownloader.py
+++ b/deluge/tests/test_httpdownloader.py
@@ -7,19 +7,13 @@ from twisted.python.failure import Failure
 from twisted.trial import unittest
 from twisted.web.error import PageRedirect
 from twisted.web.http import NOT_MODIFIED
+from twisted.web.resource import Resource
 from twisted.web.server import Site
 from twisted.web.util import redirectTo
 
 from deluge.httpdownloader import download_file
 from deluge.log import setup_logger
 from deluge.ui.web.common import compress
-
-try:
-    from twisted.web.resource import Resource
-except ImportError:
-    # twisted 8
-    from twisted.web.error import Resource
-
 
 temp_dir = tempfile.mkdtemp()
 

--- a/deluge/tests/test_json_api.py
+++ b/deluge/tests/test_json_api.py
@@ -175,7 +175,7 @@ class RPCRaiseDelugeErrorJSONTestCase(JSONBase):
         self.assertTrue("testclass.test" in methods)
 
         request = MagicMock()
-        request.getCookie = MagicMock(return_value=auth.config["sessions"].keys()[0])
+        request.getCookie = MagicMock(return_value=list(auth.config["sessions"])[0])
         json_data = {"method": "testclass.test", "id": 0, "params": []}
         request.json = json_lib.dumps(json_data)
         request_id, result, error = json._handle_request(request)

--- a/deluge/tests/test_sessionproxy.py
+++ b/deluge/tests/test_sessionproxy.py
@@ -33,7 +33,7 @@ class Core(object):
 
     def get_torrent_status(self, torrent_id, keys, diff=False):
         if not keys:
-            keys = self.torrents[torrent_id].keys()
+            keys = list(self.torrents[torrent_id])
 
         if not diff:
             ret = {}
@@ -55,9 +55,9 @@ class Core(object):
 
     def get_torrents_status(self, filter_dict, keys, diff=False):
         if not filter_dict:
-            filter_dict["id"] = self.torrents.keys()
+            filter_dict["id"] = list(self.torrents)
         if not keys:
-            keys = self.torrents["a"].keys()
+            keys = list(self.torrents["a"])
         if not diff:
             if "id" in filter_dict:
                 torrents = filter_dict["id"]

--- a/deluge/tests/test_torrentview.py
+++ b/deluge/tests/test_torrentview.py
@@ -8,20 +8,21 @@ from deluge.ui.util import lang
 from . import common
 from .basetest import BaseTestCase
 
-libs_available = True
 # Allow running other tests without GTKUI dependencies available
 try:
     from gobject import TYPE_UINT64
-    from deluge.ui.gtkui.mainwindow import MainWindow
-    from deluge.ui.gtkui.menubar import MenuBar
-    from deluge.ui.gtkui.torrentdetails import TorrentDetails
-    from deluge.ui.gtkui.torrentview import TorrentView
-    from deluge.ui.gtkui.gtkui import DEFAULT_PREFS
 except ImportError as err:
     libs_available = False
     TYPE_UINT64 = "Whatever"
     import traceback
     traceback.print_exc()
+else:
+    libs_available = True
+    from deluge.ui.gtkui.mainwindow import MainWindow  # pylint: disable=ungrouped-imports
+    from deluge.ui.gtkui.menubar import MenuBar
+    from deluge.ui.gtkui.torrentdetails import TorrentDetails
+    from deluge.ui.gtkui.torrentview import TorrentView
+    from deluge.ui.gtkui.gtkui import DEFAULT_PREFS
 
 lang.setup_translations()
 

--- a/deluge/tests/test_tracker_icons.py
+++ b/deluge/tests/test_tracker_icons.py
@@ -1,7 +1,6 @@
 import os
 
 import pytest
-from twisted.trial.unittest import SkipTest
 
 import deluge.component as component
 import deluge.ui.tracker_icons
@@ -54,15 +53,6 @@ class TrackerIconsTestCase(BaseTestCase):
         # ubuntu.com has inline css which causes HTMLParser issues
         icon = TrackerIcon(os.path.join(dirname, "ubuntu.png"))
         d = self.icons.fetch("www.ubuntu.com")
-        d.addCallback(self.assertNotIdentical, None)
-        d.addCallback(self.assertEquals, icon)
-        return d
-
-    def test_get_openbt_png(self):
-        raise SkipTest("openbittorrent.com site is down, possibly permanently")
-        # openbittorrent.com has an incorrect type (image/gif) pylint: disable=unreachable
-        icon = TrackerIcon(os.path.join(dirname, "openbt.png"))
-        d = self.icons.fetch("openbittorrent.com")
         d.addCallback(self.assertNotIdentical, None)
         d.addCallback(self.assertEquals, icon)
         return d

--- a/deluge/tests/test_ui_entry.py
+++ b/deluge/tests/test_ui_entry.py
@@ -17,7 +17,6 @@ import sys
 import mock
 import pytest
 from twisted.internet import defer
-from twisted.logger import Logger
 
 import deluge
 import deluge.component as component
@@ -31,8 +30,6 @@ from deluge.ui.web.server import DelugeWeb
 from . import common
 from .basetest import BaseTestCase
 from .daemon_base import DaemonBase
-
-log = Logger()
 
 DEBUG_COMMAND = False
 
@@ -165,8 +162,9 @@ class GtkUIBaseTestCase(UIBaseTestCase):
 class GtkUIDelugeScriptEntryTestCase(BaseTestCase, GtkUIBaseTestCase):
 
     def __init__(self, testname):
-        BaseTestCase.__init__(self, testname)
+        super(GtkUIDelugeScriptEntryTestCase, self).__init__(testname)
         GtkUIBaseTestCase.__init__(self)
+
         self.var["cmd_name"] = "deluge gtk"
         self.var["start_cmd"] = ui_entry.start_ui
         self.var["sys_arg_cmd"] = ["./deluge", "gtk"]
@@ -182,7 +180,7 @@ class GtkUIDelugeScriptEntryTestCase(BaseTestCase, GtkUIBaseTestCase):
 class GtkUIScriptEntryTestCase(BaseTestCase, GtkUIBaseTestCase):
 
     def __init__(self, testname):
-        BaseTestCase.__init__(self, testname)
+        super(GtkUIScriptEntryTestCase, self).__init__(testname)
         GtkUIBaseTestCase.__init__(self)
         from deluge.ui import gtkui
         self.var["cmd_name"] = "deluge-gtk"
@@ -231,7 +229,7 @@ class WebUIBaseTestCase(UIBaseTestCase):
 class WebUIScriptEntryTestCase(BaseTestCase, WebUIBaseTestCase):
 
     def __init__(self, testname):
-        BaseTestCase.__init__(self, testname)
+        super(WebUIScriptEntryTestCase, self).__init__(testname)
         WebUIBaseTestCase.__init__(self)
         self.var["cmd_name"] = "deluge-web"
         self.var["start_cmd"] = deluge.ui.web.start
@@ -247,7 +245,7 @@ class WebUIScriptEntryTestCase(BaseTestCase, WebUIBaseTestCase):
 class WebUIDelugeScriptEntryTestCase(BaseTestCase, WebUIBaseTestCase):
 
     def __init__(self, testname):
-        BaseTestCase.__init__(self, testname)
+        super(WebUIDelugeScriptEntryTestCase, self).__init__(testname)
         WebUIBaseTestCase.__init__(self)
         self.var["cmd_name"] = "deluge web"
         self.var["start_cmd"] = ui_entry.start_ui
@@ -368,7 +366,7 @@ Total torrents: 0
 class ConsoleScriptEntryWithDaemonTestCase(BaseTestCase, ConsoleUIWithDaemonBaseTestCase):
 
     def __init__(self, testname):
-        BaseTestCase.__init__(self, testname)
+        super(ConsoleScriptEntryWithDaemonTestCase, self).__init__(testname)
         ConsoleUIWithDaemonBaseTestCase.__init__(self)
         self.var["cmd_name"] = "deluge-console"
         self.var["sys_arg_cmd"] = ["./deluge-console"]
@@ -391,7 +389,7 @@ class ConsoleScriptEntryWithDaemonTestCase(BaseTestCase, ConsoleUIWithDaemonBase
 class ConsoleScriptEntryTestCase(BaseTestCase, ConsoleUIBaseTestCase):
 
     def __init__(self, testname):
-        BaseTestCase.__init__(self, testname)
+        super(ConsoleScriptEntryTestCase, self).__init__(testname)
         ConsoleUIBaseTestCase.__init__(self)
         self.var["cmd_name"] = "deluge-console"
         self.var["start_cmd"] = deluge.ui.console.start
@@ -407,7 +405,7 @@ class ConsoleScriptEntryTestCase(BaseTestCase, ConsoleUIBaseTestCase):
 class ConsoleDelugeScriptEntryTestCase(BaseTestCase, ConsoleUIBaseTestCase):
 
     def __init__(self, testname):
-        BaseTestCase.__init__(self, testname)
+        super(ConsoleDelugeScriptEntryTestCase, self).__init__(testname)
         ConsoleUIBaseTestCase.__init__(self)
         self.var["cmd_name"] = "deluge console"
         self.var["start_cmd"] = ui_entry.start_ui

--- a/deluge/tests/test_webserver.py
+++ b/deluge/tests/test_webserver.py
@@ -12,6 +12,7 @@ from StringIO import StringIO
 
 import twisted.web.client
 from twisted.internet import defer, reactor
+from twisted.trial.unittest import SkipTest
 from twisted.web.client import Agent, FileBodyProducer
 from twisted.web.http_headers import Headers
 
@@ -26,6 +27,7 @@ class WebServerTestCase(WebServerTestBase, WebServerMockBase):
 
     @defer.inlineCallbacks
     def test_get_torrent_info(self):
+
         agent = Agent(reactor)
 
         self.mock_authentication_ignore(self.deluge_web.auth)
@@ -42,7 +44,10 @@ class WebServerTestCase(WebServerTestBase, WebServerMockBase):
             Headers({'User-Agent': ['Twisted Web Client Example'],
                      'Content-Type': ['application/json']}),
             FileBodyProducer(StringIO('{"params": ["%s"], "method": "web.get_torrent_info", "id": 22}' % filename)))
+        try:
+            body = yield twisted.web.client.readBody(d)
+        except AttributeError:
+            raise SkipTest("This test requires 't.w.c.readBody()' in Twisted version >= 13.2")
 
-        body = yield twisted.web.client.readBody(d)
         json = json_lib.loads(body)
         self.assertEqual(None, json["error"])

--- a/deluge/tests/test_webserver.py
+++ b/deluge/tests/test_webserver.py
@@ -26,9 +26,6 @@ class WebServerTestCase(WebServerTestBase, WebServerMockBase):
 
     @defer.inlineCallbacks
     def test_get_torrent_info(self):
-        """
-
-        """
         agent = Agent(reactor)
 
         self.mock_authentication_ignore(self.deluge_web.auth)

--- a/deluge/ui/Win32IconImagePlugin.py
+++ b/deluge/ui/Win32IconImagePlugin.py
@@ -139,7 +139,7 @@ class Win32IcoFile(object):
             # figure out where AND mask image starts
             mode = a[0]
             bpp = 8
-            for k in PIL.BmpImagePlugin.BIT2MODE.keys():
+            for k in PIL.BmpImagePlugin.BIT2MODE:
                 if mode == PIL.BmpImagePlugin.BIT2MODE[k][1]:
                     bpp = k
                     break

--- a/deluge/ui/Win32IconImagePlugin.py
+++ b/deluge/ui/Win32IconImagePlugin.py
@@ -44,6 +44,8 @@ Example icon to test with `down.ico`_
 .. _down.ico: http://www.axialis.com/tutorials/iw/down.ico
 """
 
+from __future__ import division
+
 import logging
 import struct
 
@@ -132,7 +134,7 @@ class Win32IcoFile(object):
             log.debug("Loaded image: %s %s %s %s", im.format, im.mode, im.size, im.info)
 
             # change tile dimension to only encompass XOR image
-            im.size = im.size[0], im.size[1] / 2
+            im.size = im.size[0], im.size[1] // 2
             d, e, o, a = im.tile[0]
             im.tile[0] = d, (0, 0) + im.size, o, a
 
@@ -145,7 +147,7 @@ class Win32IcoFile(object):
                     break
             # end for
             log.debug("o:%s, w:%s, h:%s, bpp:%s", o, im.size[0], im.size[1], bpp)
-            and_mask_offset = o + (im.size[0] * im.size[1] * (bpp / 8.0))
+            and_mask_offset = o + (im.size[0] * im.size[1] * (bpp / 8))
 
             if bpp == 32:
                 # 32-bit color depth icon image allows semitransparent areas
@@ -178,7 +180,7 @@ class Win32IcoFile(object):
                     # bitmap row data is aligned to word boundaries
                     w += 32 - (im.size[0] % 32)
                 # the total mask data is padded row size * height / bits per char
-                total_bytes = int((w * im.size[1]) / 8)
+                total_bytes = (w * im.size[1]) // 8
                 log.debug("tot=%d, off=%d, w=%d, size=%d", len(data), and_mask_offset, w, total_bytes)
 
                 self.buf.seek(and_mask_offset)
@@ -190,7 +192,7 @@ class Win32IcoFile(object):
                     im.size,        # (w, h)
                     mask_data,       # source chars
                     'raw',          # raw decoder
-                    ('1;I', int(w / 8), -1)  # 1bpp inverted, padded, reversed
+                    ('1;I', w // 8, -1)  # 1bpp inverted, padded, reversed
                 )
 
                 # now we have two images, im is XOR image and mask is AND image

--- a/deluge/ui/Win32IconImagePlugin.py
+++ b/deluge/ui/Win32IconImagePlugin.py
@@ -178,7 +178,7 @@ class Win32IcoFile(object):
                     # bitmap row data is aligned to word boundaries
                     w += 32 - (im.size[0] % 32)
                 # the total mask data is padded row size * height / bits per char
-                total_bytes = long((w * im.size[1]) / 8)
+                total_bytes = int((w * im.size[1]) / 8)
                 log.debug("tot=%d, off=%d, w=%d, size=%d", len(data), and_mask_offset, w, total_bytes)
 
                 self.buf.seek(and_mask_offset)

--- a/deluge/ui/baseargparser.py
+++ b/deluge/ui/baseargparser.py
@@ -37,7 +37,7 @@ def find_subcommand(self, args=None, sys_argv=True):
     for x in self._subparsers._actions:
         if not isinstance(x, argparse._SubParsersAction):
             continue
-        for sp_name in x._name_parser_map.keys():
+        for sp_name in x._name_parser_map:
             if sp_name in args:
                 subcommand_found = args.index(sp_name)
 

--- a/deluge/ui/client.py
+++ b/deluge/ui/client.py
@@ -394,7 +394,7 @@ class DaemonSSLProxy(DaemonProxy):
         # We need to tell the daemon what events we're interested in receiving
         if self.__factory.event_handlers:
             self.call("daemon.set_event_interest",
-                      self.__factory.event_handlers.keys())
+                      list(self.__factory.event_handlers))
 
             self.call("core.get_auth_levels_mappings").addCallback(
                 self.__on_auth_levels_mappings

--- a/deluge/ui/common.py
+++ b/deluge/ui/common.py
@@ -134,7 +134,7 @@ class TorrentInfo(object):
                         item.update(paths[path])
                     item["download"] = True
 
-                file_tree = FileTree2(paths.keys())
+                file_tree = FileTree2(list(paths))
                 file_tree.walk(walk)
             else:
                 def walk(path, item):
@@ -313,7 +313,7 @@ class FileTree2(object):
         :type callback: function
         """
         def walk(directory, parent_path):
-            for path in directory["contents"].keys():
+            for path in directory["contents"]:
                 full_path = os.path.join(parent_path, path).replace("\\", "/")
                 if directory["contents"][path]["type"] == "dir":
                     directory["contents"][path] = callback(
@@ -393,7 +393,7 @@ class FileTree(object):
         :type callback: function
         """
         def walk(directory, parent_path):
-            for path in directory.keys():
+            for path in directory:
                 full_path = os.path.join(parent_path, path)
                 if isinstance(directory[path], dict):
                     directory[path] = callback(full_path, directory[path]) or directory[path]

--- a/deluge/ui/console/commands/config.py
+++ b/deluge/ui/console/commands/config.py
@@ -20,16 +20,16 @@ from deluge.ui.console.main import BaseCommand
 log = logging.getLogger(__name__)
 
 
-def atom(_next, token):
+def atom(src, token):
     """taken with slight modifications from http://effbot.org/zone/simple-iterator-parser.htm"""
     if token[1] == "(":
         out = []
-        token = _next()
+        token = next(src)
         while token[1] != ")":
-            out.append(atom(_next, token))
-            token = _next()
+            out.append(atom(src, token))
+            token = next(src)
             if token[1] == ",":
-                token = _next()
+                token = next(src)
         return tuple(out)
     elif token[0] is tokenize.NUMBER or token[1] == "-":
         try:
@@ -58,7 +58,7 @@ def simple_eval(source):
     src = cStringIO.StringIO(source).readline
     src = tokenize.generate_tokens(src)
     src = (token for token in src if token[0] is not tokenize.NL)
-    res = atom(src.next, src.next())
+    res = atom(src, next(src))
     return res
 
 

--- a/deluge/ui/console/commands/config.py
+++ b/deluge/ui/console/commands/config.py
@@ -83,9 +83,8 @@ class Command(BaseCommand):
 
     def _get_config(self, options):
         def _on_get_config(config):
-            keys = sorted(config.keys())
             s = ""
-            for key in keys:
+            for key in sorted(config):
                 if key not in options.values:
                     continue
                 color = "{!white,black,bold!}"
@@ -120,7 +119,7 @@ class Command(BaseCommand):
             self.console.write("{!error!}%s" % ex)
             return
 
-        if key not in config.keys():
+        if key not in config:
             self.console.write("{!error!}The key '%s' is invalid!" % key)
             return
 
@@ -138,4 +137,4 @@ class Command(BaseCommand):
         return client.core.set_config({key: val}).addCallback(on_set_config)
 
     def complete(self, text):
-        return [k for k in component.get("CoreConfig").keys() if k.startswith(text)]
+        return [k for k in component.get("CoreConfig") if k.startswith(text)]

--- a/deluge/ui/console/commands/info.py
+++ b/deluge/ui/console/commands/info.py
@@ -8,6 +8,8 @@
 # See LICENSE for more details.
 #
 
+from __future__ import division
+
 from os.path import sep as dirsep
 
 import deluge.common as common
@@ -363,7 +365,7 @@ class Command(BaseCommand):
                 s += " {!cyan!}%s" % torrent_id
             else:
                 # Shorten the ID
-                a = int(space_left * 2 / 3.0)
+                a = space_left * 2 // 3
                 b = space_left - a
                 if a < 8:
                     b = b - (8 - a)

--- a/deluge/ui/console/commands/manage.py
+++ b/deluge/ui/console/commands/manage.py
@@ -75,7 +75,7 @@ class Command(BaseCommand):
                 return
             request_options.append(opt)
         if not request_options:
-            request_options = [opt for opt in torrent_options.keys()]
+            request_options = list(torrent_options)
         request_options.append('name')
 
         d = client.core.get_torrents_status({"id": torrent_ids}, request_options)

--- a/deluge/ui/console/modes/alltorrents.py
+++ b/deluge/ui/console/modes/alltorrents.py
@@ -555,7 +555,7 @@ class AllTorrents(BaseMode, component.Component):
 
             # Get first element so we can check if it has given field
             # and if it's a string
-            first_element = state[state.keys()[0]]
+            first_element = state[list(state)[0]]
             if field in first_element:
                 is_string = isinstance(first_element[field], basestring)
 

--- a/deluge/ui/console/modes/alltorrents.py
+++ b/deluge/ui/console/modes/alltorrents.py
@@ -7,6 +7,8 @@
 # See LICENSE for more details.
 #
 
+from __future__ import division
+
 import logging
 from collections import deque
 
@@ -390,14 +392,14 @@ class AllTorrents(BaseMode, component.Component):
         self.column_widths = [self.config["%s_width" % c] for c in self.__cols_to_show]
         requested_width = sum([width for width in self.column_widths if width >= 0])
         if requested_width > self.cols:  # can't satisfy requests, just spread out evenly
-            cw = int(self.cols / len(self.__columns))
+            cw = self.cols // len(self.__columns)
             for i in range(0, len(self.column_widths)):
                 self.column_widths[i] = cw
         else:
             rem = self.cols - requested_width
             var_cols = len([width for width in self.column_widths if width < 0])
             if var_cols > 0:
-                vw = int(rem / var_cols)
+                vw = rem // var_cols
                 for i in range(0, len(self.column_widths)):
                     if self.column_widths[i] < 0:
                         self.column_widths[i] = vw
@@ -1173,14 +1175,14 @@ class AllTorrents(BaseMode, component.Component):
             if not self._scroll_up(1):
                 effected_lines = [self.cursel - 1, self.cursel]
         elif c == curses.KEY_PPAGE:
-            self._scroll_up(int(self.rows / 2))
+            self._scroll_up(self.rows // 2)
         elif c == curses.KEY_DOWN:
             if self.cursel >= self.numtorrents:
                 return
             if not self._scroll_down(1):
                 effected_lines = [self.cursel - 2, self.cursel - 1]
         elif c == curses.KEY_NPAGE:
-            self._scroll_down(int(self.rows / 2))
+            self._scroll_down(self.rows // 2)
         elif c == curses.KEY_HOME:
             self._scroll_up(self.cursel)
         elif c == curses.KEY_END:

--- a/deluge/ui/console/modes/input_popup.py
+++ b/deluge/ui/console/modes/input_popup.py
@@ -9,10 +9,7 @@
 # See LICENSE for more details.
 #
 
-try:
-    import curses
-except ImportError:
-    pass
+from __future__ import division
 
 import logging
 import os
@@ -20,6 +17,12 @@ import os.path
 
 from deluge.ui.console import colors
 from deluge.ui.console.modes.popup import ALIGN, Popup
+
+try:
+    import curses
+except ImportError:
+    pass
+
 
 log = logging.getLogger(__name__)
 
@@ -877,7 +880,7 @@ class InputPopup(Popup):
 
         if self.content_height > (self.height - 2):
             lts = self.content_height - (self.height - 3)
-            perc_sc = float(self.lineoff) / lts
+            perc_sc = self.lineoff / lts
             sb_pos = int((self.height - 2) * perc_sc) + 1
             if (sb_pos == 1) and (self.lineoff != 0):
                 sb_pos += 1

--- a/deluge/ui/console/modes/popup.py
+++ b/deluge/ui/console/modes/popup.py
@@ -7,14 +7,17 @@
 # See LICENSE for more details.
 #
 
+from __future__ import division
+
+import logging
+
+from deluge.ui.console.modes import format_utils
+
 try:
     import curses
 except ImportError:
     pass
 
-import logging
-
-from deluge.ui.console.modes import format_utils
 
 log = logging.getLogger(__name__)
 
@@ -97,7 +100,7 @@ class Popup(object):
 
         # Height
         if hr == 0:
-            hr = int(self.parent.rows / 2)
+            hr = self.parent.rows // 2
         elif hr == -1:
             hr = self.parent.rows - 2
         elif hr > self.parent.rows - 2:
@@ -105,7 +108,7 @@ class Popup(object):
 
         # Width
         if wr == 0:
-            wr = int(self.parent.cols / 2)
+            wr = self.parent.cols // 2
         elif wr == -1:
             wr = self.parent.cols
         elif wr >= self.parent.cols:
@@ -114,14 +117,14 @@ class Popup(object):
         if self.align in [ALIGN.TOP_CENTER, ALIGN.TOP_LEFT, ALIGN.TOP_RIGHT]:
             by = 1
         elif self.align in [ALIGN.MIDDLE_CENTER, ALIGN.MIDDLE_LEFT, ALIGN.MIDDLE_RIGHT]:
-            by = (self.parent.rows / 2) - (hr / 2)
+            by = (self.parent.rows // 2) - (hr // 2)
         elif self.align in [ALIGN.BOTTOM_CENTER, ALIGN.BOTTOM_LEFT, ALIGN.BOTTOM_RIGHT]:
             by = self.parent.rows - hr - 1
 
         if self.align in [ALIGN.TOP_LEFT, ALIGN.MIDDLE_LEFT, ALIGN.BOTTOM_LEFT]:
             bx = 0
         elif self.align in [ALIGN.TOP_CENTER, ALIGN.MIDDLE_CENTER, ALIGN.BOTTOM_CENTER]:
-            bx = (self.parent.cols / 2) - (wr / 2)
+            bx = (self.parent.cols // 2) - (wr // 2)
         elif self.align in [ALIGN.TOP_RIGHT, ALIGN.MIDDLE_RIGHT, ALIGN.BOTTOM_RIGHT]:
             bx = self.parent.cols - wr - 1
 
@@ -139,7 +142,7 @@ class Popup(object):
         self._refresh_lines()
         if len(self._lines) > (self.height - 2):
             lts = len(self._lines) - (self.height - 3)
-            perc_sc = float(self.lineoff) / lts
+            perc_sc = self.lineoff / lts
             sb_pos = int((self.height - 2) * perc_sc) + 1
             if (sb_pos == 1) and (self.lineoff != 0):
                 sb_pos += 1

--- a/deluge/ui/console/modes/preferences.py
+++ b/deluge/ui/console/modes/preferences.py
@@ -194,7 +194,7 @@ class Preferences(BaseMode):
         if client.connected():
             # Only do this if we're connected to a daemon
             config_to_set = {}
-            for key in new_core_config.keys():
+            for key in new_core_config:
                 # The values do not match so this needs to be updated
                 if self.core_config[key] != new_core_config[key]:
                     config_to_set[key] = new_core_config[key]
@@ -214,7 +214,7 @@ class Preferences(BaseMode):
             # are ever reordered, so do it the slightly slower but safer way
             if isinstance(pane, InterfacePane) or isinstance(pane, ColumnsPane):
                 pane.add_config_values(new_console_config)
-        for key in new_console_config.keys():
+        for key in new_console_config:
             # The values do not match so this needs to be updated
             if self.console_config[key] != new_console_config[key]:
                 self.console_config[key] = new_console_config[key]

--- a/deluge/ui/console/modes/torrentdetail.py
+++ b/deluge/ui/console/modes/torrentdetail.py
@@ -7,6 +7,8 @@
 # See LICENSE for more details.
 #
 
+from __future__ import division
+
 import logging
 from collections import deque
 
@@ -205,7 +207,7 @@ class TorrentDetail(BaseMode, component.Component):
         for f in fs:
             if f[3]:  # dir, has some children
                 bd = self.__fill_progress(f[3], progs)
-                f[5] = format_utils.format_progress((bd / f[2]) * 100)
+                f[5] = format_utils.format_progress(bd / f[2] * 100)
             else:  # file, update own prog and add to total
                 bd = f[2] * progs[f[1]]
                 f[5] = format_utils.format_progress(progs[f[1]] * 100)
@@ -226,13 +228,13 @@ class TorrentDetail(BaseMode, component.Component):
         self.column_widths = [-1, 15, 15, 20]
         req = sum([col_width for col_width in self.column_widths if col_width >= 0])
         if req > self.cols:  # can't satisfy requests, just spread out evenly
-            cw = int(self.cols / len(self.column_names))
+            cw = self.cols // len(self.column_names)
             for i in range(0, len(self.column_widths)):
                 self.column_widths[i] = cw
         else:
             rem = self.cols - req
             var_cols = len([col_width for col_width in self.column_widths if col_width < 0])
-            vw = int(rem / var_cols)
+            vw = rem // var_cols
             for i in range(0, len(self.column_widths)):
                 if self.column_widths[i] < 0:
                     self.column_widths[i] = vw
@@ -404,7 +406,7 @@ class TorrentDetail(BaseMode, component.Component):
         if self.popup:
             self.popup.handle_resize()
 
-        self._listing_start = self.rows / 2
+        self._listing_start = self.rows // 2
         self.refresh()
 
     def render_header(self, off):

--- a/deluge/ui/gtkui/addtorrentdialog.py
+++ b/deluge/ui/gtkui/addtorrentdialog.py
@@ -7,6 +7,8 @@
 # See LICENSE for more details.
 #
 
+from __future__ import division
+
 import base64
 import logging
 import os
@@ -620,7 +622,7 @@ class AddTorrentDialog(component.Component):
 
         def on_part(data, current_length, total_length):
             if total_length:
-                percent = float(current_length) / float(total_length)
+                percent = current_length / total_length
                 pb.set_fraction(percent)
                 pb.set_text("%.2f%% (%s / %s)" % (
                     percent * 100,

--- a/deluge/ui/gtkui/addtorrentdialog.py
+++ b/deluge/ui/gtkui/addtorrentdialog.py
@@ -300,7 +300,7 @@ class AddTorrentDialog(component.Component):
 
     def add_files(self, parent_iter, split_files):
         ret = 0
-        for key, value in split_files.iteritems():
+        for key, value in split_files.items():
             if key.endswith(os.path.sep):
                 chunk_iter = self.files_treestore.append(
                     parent_iter, [True, key, 0, -1, False, gtk.STOCK_DIRECTORY])

--- a/deluge/ui/gtkui/createtorrentdialog.py
+++ b/deluge/ui/gtkui/createtorrentdialog.py
@@ -7,6 +7,8 @@
 # See LICENSE for more details.
 #
 
+from __future__ import division
+
 import base64
 import logging
 import os.path
@@ -124,7 +126,7 @@ class CreateTorrentDialog(object):
         model = self.builder.get_object("combo_piece_size").get_model()
         for index, value in enumerate(model):
             psize = self.parse_piece_size_text(value[0])
-            pieces = size / psize
+            pieces = size // psize
             if pieces < 2048 or (index + 1) == len(model):
                 self.builder.get_object("combo_piece_size").set_active(index)
                 break
@@ -376,7 +378,7 @@ class CreateTorrentDialog(object):
                                          {"download_location": os.path.split(path)[0]})
 
     def _on_create_torrent_progress(self, value, num_pieces):
-        percent = float(value) / float(num_pieces)
+        percent = value / num_pieces
 
         def update_pbar_with_gobject(percent):
             pbar = self.builder.get_object("progressbar")

--- a/deluge/ui/gtkui/dialogs.py
+++ b/deluge/ui/gtkui/dialogs.py
@@ -271,7 +271,7 @@ class AccountDialog(BaseDialog):
 
         self.authlevel_combo = gtk.combo_box_new_text()
         active_idx = None
-        for idx, level in enumerate(levels_mapping.keys()):
+        for idx, level in enumerate(levels_mapping):
             self.authlevel_combo.append_text(level)
             if authlevel and authlevel == level:
                 active_idx = idx

--- a/deluge/ui/gtkui/files_tab.py
+++ b/deluge/ui/gtkui/files_tab.py
@@ -362,7 +362,7 @@ class FilesTab(Tab):
 
     def add_files(self, parent_iter, split_files):
         chunk_size_total = 0
-        for key, value in split_files.iteritems():
+        for key, value in split_files.items():
             if key.endswith("/"):
                 chunk_iter = self.treestore.append(parent_iter,
                                                    [key, 0, "", 0, 0, -1, gtk.STOCK_DIRECTORY])

--- a/deluge/ui/gtkui/files_tab.py
+++ b/deluge/ui/gtkui/files_tab.py
@@ -7,6 +7,8 @@
 # See LICENSE for more details.
 #
 
+from __future__ import division
+
 import cPickle
 import logging
 import os.path
@@ -423,12 +425,12 @@ class FilesTab(Tab):
                 if self.treestore.iter_children(row):
                     completed_bytes += get_completed_bytes(self.treestore.iter_children(row))
                 else:
-                    completed_bytes += self.treestore[row][1] * (float(self.treestore[row][3]) / 100.0)
+                    completed_bytes += self.treestore[row][1] * self.treestore[row][3] / 100
 
                 row = self.treestore.iter_next(row)
 
             try:
-                value = (float(completed_bytes) / float(self.treestore[parent][1])) * 100
+                value = completed_bytes / self.treestore[parent][1] * 100
             except ZeroDivisionError:
                 # Catch the unusal error found when moving folders around
                 value = 0

--- a/deluge/ui/gtkui/filtertreeview.py
+++ b/deluge/ui/gtkui/filtertreeview.py
@@ -159,7 +159,7 @@ class FilterTreeView(component.Component):
 
         # update rows
         visible_filters = []
-        for cat, filters in filter_items.iteritems():
+        for cat, filters in filter_items.items():
             for value, count in filters:
                 self.update_row(cat, value, count)
                 visible_filters.append((cat, value))

--- a/deluge/ui/gtkui/listview.py
+++ b/deluge/ui/gtkui/listview.py
@@ -118,7 +118,7 @@ class ListView(object):
 
         def set_col_attributes(self, renderer, add=True, **kw):
             if add is True:
-                for attr, value in kw.iteritems():
+                for attr, value in kw.items():
                     self.add_attribute(renderer, attr, value)
             else:
                 self.set_attributes(renderer, **kw)

--- a/deluge/ui/gtkui/listview.py
+++ b/deluge/ui/gtkui/listview.py
@@ -303,7 +303,7 @@ class ListView(object):
 
     def get_state_field_column(self, field):
         """Returns the column number for the state field"""
-        for column in self.columns.keys():
+        for column in self.columns:
             if self.columns[column].status_field is None:
                 continue
 

--- a/deluge/ui/gtkui/mainwindow.py
+++ b/deluge/ui/gtkui/mainwindow.py
@@ -41,7 +41,7 @@ class _GtkBuilderSignalsHolder(object):
     def connect_signals(self, mapping_or_class):
 
         if isinstance(mapping_or_class, dict):
-            for name, handler in mapping_or_class.iteritems():
+            for name, handler in mapping_or_class.items():
                 if hasattr(self, name):
                     raise RuntimeError(
                         "A handler for signal %r has already been registered: %s" %

--- a/deluge/ui/gtkui/menubar.py
+++ b/deluge/ui/gtkui/menubar.py
@@ -496,7 +496,7 @@ class MenuBar(component.Component):
         known_accounts_to_log = []
         for account in known_accounts:
             account_to_log = {}
-            for key, value in account.copy().iteritems():
+            for key, value in account.copy().items():
                 if key == 'password':
                     value = '*' * len(value)
                 account_to_log[key] = value
@@ -539,7 +539,7 @@ class MenuBar(component.Component):
             return
 
         torrent_owner = component.get("TorrentView").get_torrent_status(selected[0])["owner"]
-        for username, item in self.change_owner_submenu_items.iteritems():
+        for username, item in self.change_owner_submenu_items.items():
             item.set_active(username == torrent_owner)
 
     def _on_change_owner_toggled(self, widget, username):

--- a/deluge/ui/gtkui/menubar.py
+++ b/deluge/ui/gtkui/menubar.py
@@ -413,7 +413,7 @@ class MenuBar(component.Component):
             "menuitem_max_connections": client.core.set_torrent_max_connections,
             "menuitem_upload_slots": client.core.set_torrent_max_upload_slots
         }
-        if widget.name in funcs.keys():
+        if widget.name in funcs:
             for torrent in component.get("TorrentView").get_selected_torrents():
                 funcs[widget.name](torrent, -1)
 

--- a/deluge/ui/gtkui/options_tab.py
+++ b/deluge/ui/gtkui/options_tab.py
@@ -112,7 +112,7 @@ class OptionsTab(Tab):
         # We only want to update values that have been applied in the core.  This
         # is so we don't overwrite the user changes that haven't been applied yet.
         if self.prev_status is None:
-            self.prev_status = {}.fromkeys(status.keys(), None)
+            self.prev_status = {}.fromkeys(list(status), None)
 
         if status != self.prev_status:
             if status["max_download_speed"] != self.prev_status["max_download_speed"]:

--- a/deluge/ui/gtkui/path_chooser.py
+++ b/deluge/ui/gtkui/path_chooser.py
@@ -58,7 +58,7 @@ class PathChoosersHandler(component.Component):
             self.config_properties.update(config)
             for chooser in self.path_choosers:
                 chooser.set_config(config)
-        keys = self.config_keys_to_funcs_mapping.keys()
+        keys = list(self.config_keys_to_funcs_mapping)
         keys += self.paths_list_keys
         client.core.get_config_values(keys).addCallback(_on_config_values)
 
@@ -107,7 +107,7 @@ class PathChoosersHandler(component.Component):
                 chooser.set_values(values)
 
     def get_config_keys(self):
-        keys = self.config_keys_to_funcs_mapping.keys()
+        keys = list(self.config_keys_to_funcs_mapping)
         keys += self.paths_list_keys
         return keys
 

--- a/deluge/ui/gtkui/path_combo_chooser.py
+++ b/deluge/ui/gtkui/path_combo_chooser.py
@@ -8,7 +8,7 @@
 # See LICENSE for more details.
 #
 
-from __future__ import print_function
+from __future__ import division, print_function
 
 import os
 
@@ -596,7 +596,7 @@ class PathChooserPopup(object):
         # Adjust height according to number of list items
         if len(self.tree_store) > 0 and self.max_visible_rows > 0:
             # The height for one row in the list
-            self.row_height = self.treeview.size_request()[1] / len(self.tree_store)
+            self.row_height = self.treeview.size_request()[1] // len(self.tree_store)
             # Set height to number of rows
             height = len(self.tree_store) * self.row_height + height_extra
             # Adjust the height according to the max number of rows

--- a/deluge/ui/gtkui/peers_tab.py
+++ b/deluge/ui/gtkui/peers_tab.py
@@ -274,7 +274,7 @@ class PeersTab(Tab):
                     import binascii
                     # Split out the :port
                     ip = ":".join(peer["ip"].split(":")[:-1])
-                    ip_int = long(binascii.hexlify(socket.inet_pton(socket.AF_INET6, ip)), 16)
+                    ip_int = int(binascii.hexlify(socket.inet_pton(socket.AF_INET6, ip)), 16)
                     peer_ip = "[%s]:%s" % (ip, peer["ip"].split(":")[-1])
 
                 if peer["seed"]:

--- a/deluge/ui/gtkui/peers_tab.py
+++ b/deluge/ui/gtkui/peers_tab.py
@@ -9,7 +9,7 @@
 
 import logging
 import os.path
-from itertools import izip
+from future_builtins import zip  # pylint: disable=redefined-builtin
 
 import gtk
 
@@ -266,7 +266,7 @@ class PeersTab(Tab):
                 if peer["ip"].count(":") == 1:
                     # This is an IPv4 address
                     ip_int = sum([int(byte) << shift
-                                  for byte, shift in izip(peer["ip"].split(":")[0].split("."), (24, 16, 8, 0))])
+                                  for byte, shift in zip(peer["ip"].split(":")[0].split("."), (24, 16, 8, 0))])
                     peer_ip = peer["ip"]
                 else:
                     # This is an IPv6 address

--- a/deluge/ui/gtkui/peers_tab.py
+++ b/deluge/ui/gtkui/peers_tab.py
@@ -296,7 +296,7 @@ class PeersTab(Tab):
                 self.peers[peer["ip"]] = row
 
         # Now we need to remove any ips that were not in status["peers"] list
-        for ip in set(self.peers.keys()).difference(new_ips):
+        for ip in set(self.peers).difference(new_ips):
             self.liststore.remove(self.peers[ip])
             del self.peers[ip]
 

--- a/deluge/ui/gtkui/piecesbar.py
+++ b/deluge/ui/gtkui/piecesbar.py
@@ -7,6 +7,8 @@
 # See LICENSE for more details.
 #
 
+from __future__ import division
+
 import logging
 from math import pi
 
@@ -104,9 +106,9 @@ class PiecesBar(gtk.DrawingArea):
 
     def __create_roundcorners_subpath(self, ctx, x, y, width, height):
         aspect = 1.0
-        corner_radius = height / 10.0
+        corner_radius = height / 10
         radius = corner_radius / aspect
-        degrees = pi / 180.0
+        degrees = pi / 180
         ctx.new_sub_path()
         ctx.arc(x + width - radius, y + radius, radius, -90 * degrees, 0 * degrees)
         ctx.arc(x + width - radius, y + height - radius, radius, 0 * degrees, 90 * degrees)
@@ -125,14 +127,14 @@ class PiecesBar(gtk.DrawingArea):
             ctx = cairo.Context(self.__pieces_overlay)
             start_pos = 0
             num_pieces = self.__num_pieces and self.__num_pieces or len(self.__pieces)
-            piece_width = self.__width * 1.0 / num_pieces
+            piece_width = self.__width * 1 / num_pieces
 
             for state in self.__pieces:
                 color = self.gtkui_config["pieces_color_%s" % COLOR_STATES[state]]
                 ctx.set_source_rgb(
-                    color[0] / 65535.0,
-                    color[1] / 65535.0,
-                    color[2] / 65535.0,
+                    color[0] / 65535,
+                    color[1] / 65535,
+                    color[2] / 65535,
                 )
                 ctx.rectangle(start_pos, 0, piece_width, self.__height)
                 ctx.fill()
@@ -149,15 +151,15 @@ class PiecesBar(gtk.DrawingArea):
                 cairo.FORMAT_ARGB32, self.__width, self.__height
             )
             ctx = cairo.Context(self.__pieces_overlay)
-            piece_width = self.__width * 1.0 / self.__num_pieces
+            piece_width = self.__width * 1 / self.__num_pieces
             start = 0
             for _ in range(self.__num_pieces):
                 # Like this to keep same aspect ratio
                 color = self.gtkui_config["pieces_color_%s" % COLOR_STATES[3]]
                 ctx.set_source_rgb(
-                    color[0] / 65535.0,
-                    color[1] / 65535.0,
-                    color[2] / 65535.0,
+                    color[0] / 65535,
+                    color[1] / 65535,
+                    color[2] / 65535,
                 )
                 ctx.rectangle(start, 0, piece_width, self.__height)
                 ctx.fill()
@@ -214,11 +216,11 @@ class PiecesBar(gtk.DrawingArea):
             log.trace("PiecesBar text %r", text)
             pl.set_text(text)
             plsize = pl.get_size()
-            text_width = plsize[0] / pango.SCALE
-            text_height = plsize[1] / pango.SCALE
+            text_width = plsize[0] // pango.SCALE
+            text_height = plsize[1] // pango.SCALE
             area_width_without_text = self.__width - text_width
             area_height_without_text = self.__height - text_height
-            ctx.move_to(area_width_without_text / 2, area_height_without_text / 2)
+            ctx.move_to(area_width_without_text // 2, area_height_without_text // 2)
             ctx.set_source_rgb(1.0, 1.0, 1.0)
             pg.update_layout(pl)
             pg.show_layout(pl)

--- a/deluge/ui/gtkui/preferences.py
+++ b/deluge/ui/gtkui/preferences.py
@@ -150,8 +150,7 @@ class Preferences(component.Component):
 
         if not deluge.common.osx_check() and not deluge.common.windows_check():
             try:
-                import appindicator
-                assert appindicator  # silence pyflakes
+                import appindicator  # noqa pylint: disable=unused-import
             except ImportError:
                 pass
             else:

--- a/deluge/ui/gtkui/preferences.py
+++ b/deluge/ui/gtkui/preferences.py
@@ -1006,7 +1006,7 @@ class Preferences(component.Component):
         known_accounts_to_log = []
         for account in known_accounts:
             account_to_log = {}
-            for key, value in account.copy().iteritems():
+            for key, value in account.copy().items():
                 if key == 'password':
                     value = '*' * len(value)
                 account_to_log[key] = value

--- a/deluge/ui/gtkui/preferences.py
+++ b/deluge/ui/gtkui/preferences.py
@@ -400,7 +400,7 @@ class Preferences(component.Component):
         core_widgets[self.copy_torrent_files_path_chooser] = ("path_chooser", "torrentfiles_location")
 
         # Update the widgets accordingly
-        for key in core_widgets.keys():
+        for key in core_widgets:
             modifier = core_widgets[key][0]
             if isinstance(key, str):
                 widget = self.builder.get_object(key)
@@ -433,7 +433,7 @@ class Preferences(component.Component):
                 widget.set_text(value, cursor_end=False, default_text=True)
 
         if self.is_connected:
-            for key in core_widgets.keys():
+            for key in core_widgets:
                 if isinstance(key, str):
                     widget = self.builder.get_object(key)
                 else:
@@ -674,7 +674,7 @@ class Preferences(component.Component):
             dialog.run()
 
         # GtkUI
-        for key in new_gtkui_config.keys():
+        for key in new_gtkui_config:
             # The values do not match so this needs to be updated
             if self.gtkui_config[key] != new_gtkui_config[key]:
                 self.gtkui_config[key] = new_gtkui_config[key]
@@ -683,7 +683,7 @@ class Preferences(component.Component):
         if client.connected():
             # Only do this if we're connected to a daemon
             config_to_set = {}
-            for key in new_core_config.keys():
+            for key in new_core_config:
                 # The values do not match so this needs to be updated
                 if self.core_config[key] != new_core_config[key]:
                     config_to_set[key] = new_core_config[key]
@@ -799,7 +799,7 @@ class Preferences(component.Component):
 
         def update_dependent_widgets(name, value):
             dependency = dependents[name]
-            for dep in dependency.keys():
+            for dep in dependency:
                 if dep in path_choosers:
                     depwidget = path_choosers[dep]
                 else:
@@ -809,7 +809,7 @@ class Preferences(component.Component):
                 if dep in dependents:
                     update_dependent_widgets(dep, depwidget.get_active() and sensitive)
 
-        for key in dependents.keys():
+        for key in dependents:
             if widget != self.builder.get_object(key):
                 continue
             update_dependent_widgets(key, value)

--- a/deluge/ui/gtkui/status_tab.py
+++ b/deluge/ui/gtkui/status_tab.py
@@ -7,6 +7,8 @@
 # See LICENSE for more details.
 #
 
+from __future__ import division
+
 import logging
 
 import deluge.component as component

--- a/deluge/ui/gtkui/statusbar.py
+++ b/deluge/ui/gtkui/statusbar.py
@@ -286,7 +286,7 @@ class StatusBar(component.Component):
         This is called when we receive a ConfigValueChangedEvent from
         the core.
         """
-        if key in self.config_value_changed_dict.keys():
+        if key in self.config_value_changed_dict:
             self.config_value_changed_dict[key](value)
 
     def _on_max_connections_global(self, max_connections):

--- a/deluge/ui/gtkui/statusbar.py
+++ b/deluge/ui/gtkui/statusbar.py
@@ -7,6 +7,8 @@
 # See LICENSE for more details.
 #
 
+from __future__ import division
+
 import logging
 
 import gobject
@@ -305,8 +307,8 @@ class StatusBar(component.Component):
     def _on_get_session_status(self, status):
         self.download_rate = fspeed(status["payload_download_rate"], precision=0, shortform=True)
         self.upload_rate = fspeed(status["payload_upload_rate"], precision=0, shortform=True)
-        self.download_protocol_rate = (status["download_rate"] - status["payload_download_rate"]) / 1024
-        self.upload_protocol_rate = (status["upload_rate"] - status["payload_upload_rate"]) / 1024
+        self.download_protocol_rate = (status["download_rate"] - status["payload_download_rate"]) // 1024
+        self.upload_protocol_rate = (status["upload_rate"] - status["payload_upload_rate"]) // 1024
         self.num_connections = status["num_peers"]
         self.update_download_label()
         self.update_upload_label()

--- a/deluge/ui/gtkui/systemtray.py
+++ b/deluge/ui/gtkui/systemtray.py
@@ -179,7 +179,7 @@ class SystemTray(component.Component):
     def config_value_changed(self, key, value):
         """This is called when we received a config_value_changed signal from
         the core."""
-        if key in self.config_value_changed_dict.keys():
+        if key in self.config_value_changed_dict:
             self.config_value_changed_dict[key](value)
 
     def _on_max_download_speed(self, max_download_speed):

--- a/deluge/ui/gtkui/torrentdetails.py
+++ b/deluge/ui/gtkui/torrentdetails.py
@@ -129,7 +129,7 @@ class TorrentDetails(component.Component):
         # We need to rename the tab in the state for backwards compat
         self.state = [(tab_name.replace("Statistics", "Status"), visible) for tab_name, visible in state]
 
-        for tab in default_tabs.itervalues():
+        for tab in default_tabs.values():
             self.add_tab(tab(), generate_menu=False)
 
         # Generate the checklist menu
@@ -140,7 +140,7 @@ class TorrentDetails(component.Component):
         # Determine insert position based on weight
         # weights is a list of visible tab names in weight order
 
-        weights = sorted([(tab.weight, name) for name, tab in self.tabs.iteritems() if tab.is_visible])
+        weights = sorted([(tab.weight, name) for name, tab in self.tabs.items() if tab.is_visible])
 
         log.debug("weights: %s", weights)
         log.debug("weight of tab: %s", weight)
@@ -243,7 +243,7 @@ class TorrentDetails(component.Component):
         self.generate_menu()
 
         show = False
-        for name, tab in self.tabs.iteritems():
+        for name, tab in self.tabs.items():
             show = show or tab.is_visible
 
         self.visible(show)

--- a/deluge/ui/gtkui/torrentview.py
+++ b/deluge/ui/gtkui/torrentview.py
@@ -408,7 +408,7 @@ class TorrentView(ListView, component.Component):
 
         if columns is None:
             # We need to iterate through all columns
-            columns = self.columns.keys()
+            columns = list(self.columns)
 
         # Iterate through supplied list of columns to update
         for column in columns:
@@ -481,7 +481,7 @@ class TorrentView(ListView, component.Component):
 
         # Get the columns to update from one of the torrents
         if status:
-            torrent_id = status.keys()[0]
+            torrent_id = list(status)[0]
             fields_to_update = []
             for column in self.columns_to_update:
                 column_index = self.get_column_index(column)
@@ -621,7 +621,7 @@ class TorrentView(ListView, component.Component):
             return {}
 
     def get_visible_torrents(self):
-        return self.status.keys()
+        return list(self.status)
 
     # Callbacks #
     def on_button_press_event(self, widget, event):

--- a/deluge/ui/sessionproxy.py
+++ b/deluge/ui/sessionproxy.py
@@ -90,7 +90,7 @@ class SessionProxy(component.Component):
                         keys_to_remove = keys_diff_cached
                     else:
                         # Not the same keys so create a new diff
-                        keys_to_remove = set(sd[torrent_id].iterkeys()) - keys
+                        keys_to_remove = set(sd[torrent_id]) - keys
                         # Update the cached diff
                         keys_diff_cached = keys_to_remove
                         keys_len = len(sd[torrent_id])
@@ -123,7 +123,7 @@ class SessionProxy(component.Component):
             # Keep track of keys we need to request from the core
             keys_to_get = []
             if not keys:
-                keys = self.torrents[torrent_id][1].keys()
+                keys = list(self.torrents[torrent_id][1])
 
             for key in keys:
                 if time() - self.cache_times[torrent_id].get(key, 0.0) > self.cache_time:
@@ -190,7 +190,7 @@ class SessionProxy(component.Component):
 
             # Create the status dict
             if not torrent_ids:
-                torrent_ids = result.keys()
+                torrent_ids = list(result)
 
             return self.create_status_dict(torrent_ids, keys)
 
@@ -214,13 +214,13 @@ class SessionProxy(component.Component):
         if not filter_dict:
             # This means we want all the torrents status
             # We get a list of any torrent_ids with expired status dicts
-            to_fetch = find_torrents_to_fetch(self.torrents.keys())
+            to_fetch = find_torrents_to_fetch(list(self.torrents))
             if to_fetch:
                 d = client.core.get_torrents_status({"id": to_fetch}, keys, True)
-                return d.addCallback(on_status, self.torrents.keys(), keys)
+                return d.addCallback(on_status, list(self.torrents), keys)
 
             # Don't need to fetch anything
-            return maybeDeferred(self.create_status_dict, self.torrents.keys(), keys)
+            return maybeDeferred(self.create_status_dict, list(self.torrents), keys)
 
         if len(filter_dict) == 1 and "id" in filter_dict:
             # At this point we should have a filter with just "id" in it

--- a/deluge/ui/sessionproxy.py
+++ b/deluge/ui/sessionproxy.py
@@ -178,7 +178,7 @@ class SessionProxy(component.Component):
         def on_status(result, torrent_ids, keys):
             # Update the internal torrent status dict with the update values
             t = time()
-            for key, value in result.iteritems():
+            for key, value in result.items():
                 try:
                     self.torrents[key][0] = t
                     self.torrents[key][1].update(value)

--- a/deluge/ui/tracker_icons.py
+++ b/deluge/ui/tracker_icons.py
@@ -15,6 +15,7 @@ from urlparse import urljoin, urlparse
 
 from twisted.internet import defer, threads
 from twisted.web.error import PageRedirect
+from twisted.web.resource import ForbiddenResource, NoResource
 
 from deluge.component import Component
 from deluge.configmanager import get_config_dir
@@ -22,18 +23,11 @@ from deluge.decorators import proxy
 from deluge.httpdownloader import download_file
 
 try:
-    from twisted.web.resource import NoResource, ForbiddenResource
-except ImportError:
-    # twisted 8
-    from twisted.web.error import NoResource, ForbiddenResource
-
-try:
     import PIL.Image as Image
-    import deluge.ui.Win32IconImagePlugin
-    assert deluge.ui.Win32IconImagePlugin  # silence pyflakes
 except ImportError:
     PIL_INSTALLED = False
 else:
+    import deluge.ui.Win32IconImagePlugin  # noqa pylint: disable=unused-import, ungrouped-imports
     PIL_INSTALLED = True
 
 log = logging.getLogger(__name__)

--- a/deluge/ui/ui_entry.py
+++ b/deluge/ui/ui_entry.py
@@ -39,7 +39,7 @@ def start_ui():
     # Get the registered UI entry points
     ui_entrypoints = dict([(entrypoint.name, entrypoint.load())
                            for entrypoint in pkg_resources.iter_entry_points("deluge.ui")])
-    ui_titles = sorted(ui_entrypoints.keys())
+    ui_titles = sorted(ui_entrypoints)
 
     def add_ui_options_group(_parser):
         """Function to enable reuse of UI Options group"""

--- a/deluge/ui/web/auth.py
+++ b/deluge/ui/web/auth.py
@@ -90,7 +90,7 @@ class Auth(JSONComponent):
         self.worker.stop()
 
     def _clean_sessions(self):
-        session_ids = self.config["sessions"].keys()
+        session_ids = list(self.config["sessions"])
 
         now = time.gmtime()
         for session_id in session_ids:

--- a/deluge/ui/web/json_api.py
+++ b/deluge/ui/web/json_api.py
@@ -891,7 +891,7 @@ class WebApi(JSONComponent):
         :type config: dictionary
         """
         web_config = component.get("DelugeWeb").config
-        for key in config.keys():
+        for key in config:
             if key in ["sessions", "pwd_salt", "pwd_sha1"]:
                 log.warn("Ignored attempt to overwrite web config key '%s'", key)
                 continue
@@ -912,7 +912,7 @@ class WebApi(JSONComponent):
         """
 
         return {
-            "enabled_plugins": component.get("Web.PluginManager").plugins.keys(),
+            "enabled_plugins": list(component.get("Web.PluginManager").plugins),
             "available_plugins": component.get("Web.PluginManager").available_plugins
         }
 

--- a/deluge/ui/web/json_api.py
+++ b/deluge/ui/web/json_api.py
@@ -7,6 +7,8 @@
 # See LICENSE for more details.
 #
 
+from __future__ import division
+
 import base64
 import hashlib
 import json
@@ -590,8 +592,8 @@ class WebApi(JSONComponent):
                         dirinfo["priority"] = 9
 
                 progresses = dirinfo.setdefault("progresses", [])
-                progresses.append(torrent_file["size"] * (torrent_file["progress"] / 100.0))
-                dirinfo["progress"] = float(sum(progresses)) / dirinfo["size"] * 100
+                progresses.append(torrent_file["size"] * torrent_file["progress"] / 100)
+                dirinfo["progress"] = sum(progresses) / dirinfo["size"] * 100
                 dirinfo["path"] = dirname
                 dirname = os.path.dirname(dirname)
 

--- a/gen_web_gettext.py
+++ b/gen_web_gettext.py
@@ -89,7 +89,7 @@ def create_gettext_js(js_dir):
     gettext_file = os.path.join(os.path.dirname(js_dir), 'gettext.js')
     with open(gettext_file, 'w') as fp:
         fp.write(gettext_tpl)
-        for key in sorted(strings.keys()):
+        for key in sorted(strings):
             if DEBUG:
                 fp.write('\n// %s\n' % ', '.join(['%s:%s' % x for x in strings[key]]))
             fp.write('''GetText.add('%(key)s','${escape(_("%(key)s"))}')\n''' % locals())

--- a/msgfmt.py
+++ b/msgfmt.py
@@ -25,6 +25,7 @@ Options:
     --version
         Display version information and exit.
 """
+from __future__ import print_function
 
 import array
 import ast
@@ -42,9 +43,9 @@ def usage(ecode, msg=''):
     """
     Print usage and msg and exit with given code.
     """
-    print >> sys.stderr, __doc__
+    print(__doc__, file=sys.stderr)
     if msg:
-        print >> sys.stderr, msg
+        print(msg, file=sys.stderr)
     sys.exit(ecode)
 
 
@@ -115,8 +116,8 @@ def make(filename, outfile):
     try:
         with open(infile) as _file:
             lines = _file.readlines()
-    except IOError, msg:
-        print >> sys.stderr, msg
+    except IOError as msg:
+        print(msg, file=sys.stderr)
         sys.exit(1)
 
     section = None
@@ -170,8 +171,8 @@ def make(filename, outfile):
         elif section == section_str:
             msgstr += l
         else:
-            print >> sys.stderr, 'Syntax error on %s:%d' % (infile, lno), 'before:'
-            print >> sys.stderr, l
+            print('Syntax error on %s:%d' % (infile, lno), 'before:', file=sys.stderr)
+            print(l, file=sys.stderr)
             sys.exit(1)
     # Add last entry
     if section == section_str:
@@ -183,15 +184,15 @@ def make(filename, outfile):
     try:
         with open(outfile, "wb") as _file:
             _file.write(output)
-    except IOError, msg:
-        print >> sys.stderr, msg
+    except IOError as msg:
+        print(msg, file=sys.stderr)
 
 
 def main():
     try:
         opts, args = getopt.getopt(sys.argv[1:], 'hVo:',
                                    ['help', 'version', 'output-file='])
-    except getopt.error, msg:
+    except getopt.error as msg:
         usage(1, msg)
 
     outfile = None
@@ -200,14 +201,14 @@ def main():
         if opt in ('-h', '--help'):
             usage(0)
         elif opt in ('-V', '--version'):
-            print >> sys.stderr, "msgfmt.py", __version__
+            print("msgfmt.py", __version__, file=sys.stderr)
             sys.exit(0)
         elif opt in ('-o', '--output-file'):
             outfile = arg
     # do it
     if not args:
-        print >> sys.stderr, 'No input file given'
-        print >> sys.stderr, "Try `msgfmt --help' for more information."
+        print('No input file given', file=sys.stderr)
+        print("Try `msgfmt --help' for more information.", file=sys.stderr)
         return
 
     for filename in args:

--- a/msgfmt.py
+++ b/msgfmt.py
@@ -60,9 +60,8 @@ def generate():
     """
     Return the generated output.
     """
-    keys = MESSAGES.keys()
     # the keys are sorted in the .mo file
-    keys.sort()
+    keys = sorted(MESSAGES)
     offsets = []
     ids = strs = ''
     for _id in keys:

--- a/msgfmt.py
+++ b/msgfmt.py
@@ -86,7 +86,7 @@ def generate():
         voffsets += [l2, o2 + valuestart]
     offsets = koffsets + voffsets
     output = struct.pack("Iiiiiii",
-                         0x950412deL,       # Magic
+                         0x950412de,       # Magic
                          0,                 # Version
                          len(keys),         # # of entries
                          7 * 4,             # start of key index

--- a/setup.py
+++ b/setup.py
@@ -232,8 +232,8 @@ class Build(_build):
         try:
             from deluge._libtorrent import lt
             print('Found libtorrent version: %s' % lt.__version__)
-        except ImportError, e:
-            print('Warning libtorrent not found: %s' % e)
+        except ImportError as ex:
+            print('Warning libtorrent not found: %s' % ex)
 
 
 class InstallData(_install_data):


### PR DESCRIPTION
A rebase and continuation of the work in PR #117

Issue needing reviewed:
 - [x] In [` deluge/ui/console/commands/config.py`](https://github.com/deluge-torrent/deluge/pull/124/files#diff-50c098ec747e111ab711aee1a88205aeL61) is the change of `src.next` to `src` correct?
 - [x] Can use `from future_builtins import zip` to retain use of izip in Py2.

------ 

To verify code at this stage `python-modernize` can be used without `six` dependency. (Ignore long to int conversions in rencode and test_core):
`python-modernize --no-six -wn -j 2 --no-diffs -x libmodernize.fixes.fix_import deluge`
or
`futurize -1 -w -n --no-diffs -x absolute_import deluge`

So far from futurize Stage2 confirmed only these pass:

libfuturize.fixes.fix_division_safe 
libfuturize.fixes.fix_execfile
lib2to3.fixes.fix_long

- [ ] Use newstyle classes to fix: `libpasteurize.fixes.fix_newstyle`

This may help decide which direction we want to go with the codebase for Py3: 

http://python-future.org/faq.html#what-is-the-relationship-between-future-and-six

- [ ] Note must add these details to ticket or wiki
 - http://dev.deluge-torrent.org/ticket/1328
 - http://dev.deluge-torrent.org/wiki/Plan/Python3
