### PR TITLE
Rename classic to standalone in all code

### DIFF
--- a/deluge/core/daemon.py
+++ b/deluge/core/daemon.py
@@ -64,19 +64,19 @@ def is_daemon_running(pid_file):
 class Daemon(object):
     """The Deluge Daemon class"""
 
-    def __init__(self, listen_interface=None, interface=None, port=None, classic=False,
+    def __init__(self, listen_interface=None, interface=None, port=None, standalone=False,
                  read_only_config_keys=None):
         """
         Args:
             listen_interface (str, optional): The IP address to listen to bittorrent connections on.
             interface (str, optional): The IP address the daemon will listen for UI connections on.
             port (int, optional): The port the daemon will listen for UI connections on.
-            classic (bool, optional): If True the client is in Classic (Standalone) mode otherwise, if
+            standalone (bool, optional): If True the client is in Standalone mode otherwise, if
                 False, start the daemon as separate process.
             read_only_config_keys (list of str, optional): A list of config keys that will not be
                 altered by core.set_config() RPC method.
         """
-        self.classic = classic
+        self.standalone = standalone
         self.pid_file = get_config_dir("deluged.pid")
         log.info("Deluge daemon %s", get_version())
         if is_daemon_running(self.pid_file):
@@ -110,7 +110,7 @@ class Daemon(object):
         self.rpcserver = RPCServer(
             port=port,
             allow_remote=self.core.config["allow_remote"],
-            listen=not classic,
+            listen=not standalone,
             interface=interface
         )
 
@@ -124,7 +124,7 @@ class Daemon(object):
         # Make sure we start the PreferencesManager first
         component.start("PreferencesManager")
 
-        if not self.classic:
+        if not self.standalone:
             log.info("Deluge daemon starting...")
             # Create pid file to track if deluged is running, also includes the port number.
             pid = os.getpid()
@@ -148,7 +148,7 @@ class Daemon(object):
 
     def _shutdown(self, *args, **kwargs):
         log.info("Deluge daemon shutting down, waiting for components to shutdown...")
-        if not self.classic:
+        if not self.standalone:
             return component.shutdown()
 
     @export()

--- a/deluge/plugins/Stats/deluge/plugins/stats/tests/test_stats.py
+++ b/deluge/plugins/Stats/deluge/plugins/stats/tests/test_stats.py
@@ -31,12 +31,12 @@ class StatsTestCase(BaseTestCase):
     def set_up(self):
         defer.setDebugging(True)
         tests_common.set_tmp_config_dir()
-        client.start_classic_mode()
+        client.start_standalone()
         client.core.enable_plugin("Stats")
         return component.start()
 
     def tear_down(self):
-        client.stop_classic_mode()
+        client.stop_standalone()
         return component.shutdown()
 
     @defer.inlineCallbacks

--- a/deluge/ui/gtkui/aboutdialog.py
+++ b/deluge/ui/gtkui/aboutdialog.py
@@ -254,7 +254,7 @@ class AboutDialog(object):
         self.about.set_logo(gtk.gdk.pixbuf_new_from_file(get_pixmap("deluge-about.png")))
 
         if client.connected():
-            if not client.is_classicmode():
+            if not client.is_standalone():
                 self.about.set_comments(
                     self.about.get_comments() + _("Server:") + " %coreversion%\n")
 
@@ -272,7 +272,7 @@ class AboutDialog(object):
                 self.about.set_comments(c)
                 client.core.get_libtorrent_version().addCallback(on_lt_version)
 
-            if not client.is_classicmode():
+            if not client.is_standalone():
                 client.daemon.info().addCallback(on_info)
             else:
                 client.core.get_libtorrent_version().addCallback(on_lt_version)

--- a/deluge/ui/gtkui/glade/preferences_dialog.ui
+++ b/deluge/ui/gtkui/glade/preferences_dialog.ui
@@ -374,7 +374,7 @@
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
                                         <child>
-                                          <object class="GtkRadioButton" id="radio_classic">
+                                          <object class="GtkRadioButton" id="radio_standalone">
                                             <property name="label" translatable="yes">Standalone</property>
                                             <property name="use_action_appearance">False</property>
                                             <property name="visible">True</property>
@@ -399,7 +399,7 @@
                                             <property name="receives_default">False</property>
                                             <property name="tooltip_text" translatable="yes">Connect to a Deluge daemon (deluged)</property>
                                             <property name="draw_indicator">True</property>
-                                            <property name="group">radio_classic</property>
+                                            <property name="group">radio_standalone</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>

--- a/deluge/ui/gtkui/mainwindow.py
+++ b/deluge/ui/gtkui/mainwindow.py
@@ -216,7 +216,7 @@ class MainWindow(component.Component):
 
             if shutdown:
                 client.daemon.shutdown().addCallback(stop_gtk_reactor)
-            elif not client.is_classicmode() and client.connected():
+            elif not client.is_standalone() and client.connected():
                 client.disconnect().addCallback(stop_gtk_reactor)
             else:
                 stop_gtk_reactor()

--- a/deluge/ui/gtkui/menubar.py
+++ b/deluge/ui/gtkui/menubar.py
@@ -176,9 +176,9 @@ class MenuBar(component.Component):
                 self.builder.get_object(widget).hide()
                 self.builder.get_object(widget).set_no_show_all(True)
 
-        self.main_builder.get_object("separatormenuitem").set_visible(not self.config["classic_mode"])
-        self.main_builder.get_object("menuitem_quitdaemon").set_visible(not self.config["classic_mode"])
-        self.main_builder.get_object("menuitem_connectionmanager").set_visible(not self.config["classic_mode"])
+        self.main_builder.get_object("separatormenuitem").set_visible(not self.config["standalone"])
+        self.main_builder.get_object("menuitem_quitdaemon").set_visible(not self.config["standalone"])
+        self.main_builder.get_object("menuitem_connectionmanager").set_visible(not self.config["standalone"])
 
         # Show the Torrent menu because we're connected to a host
         self.menu_torrent.show()

--- a/deluge/ui/gtkui/menubar_osx.py
+++ b/deluge/ui/gtkui/menubar_osx.py
@@ -68,7 +68,7 @@ def menubar_osx(gtkui, osxapp):
     osxapp.insert_app_menu_item(about_item, 0)
     osxapp.insert_app_menu_item(gtk.SeparatorMenuItem(), 1)
     osxapp.insert_app_menu_item(pref_item, 2)
-    if not config["classic_mode"]:
+    if not config["standalone"]:
         osxapp.insert_app_menu_item(conn_item, 3)
     if quit_all_item.get_visible():
         osxapp.insert_app_menu_item(gtk.SeparatorMenuItem(), 4)

--- a/deluge/ui/gtkui/new_release_dialog.py
+++ b/deluge/ui/gtkui/new_release_dialog.py
@@ -43,7 +43,7 @@ class NewReleaseDialog(object):
                 builder.get_object("label_server_version").show()
                 builder.get_object("label_server_version_text").show()
 
-            if not client.is_classicmode():
+            if not client.is_standalone():
                 builder.get_object("label_client_version_text").set_label(_("<i>Client Version</i>"))
                 client.daemon.info().addCallback(on_info)
 

--- a/deluge/ui/gtkui/preferences.py
+++ b/deluge/ui/gtkui/preferences.py
@@ -449,8 +449,8 @@ class Preferences(component.Component):
         self.builder.get_object("chk_start_in_tray").set_active(self.gtkui_config["start_in_tray"])
         self.builder.get_object("radio_appind").set_active(self.gtkui_config["enable_appindicator"])
         self.builder.get_object("chk_lock_tray").set_active(self.gtkui_config["lock_tray"])
-        self.builder.get_object("radio_classic").set_active(self.gtkui_config["classic_mode"])
-        self.builder.get_object("radio_thinclient").set_active(not self.gtkui_config["classic_mode"])
+        self.builder.get_object("radio_standalone").set_active(self.gtkui_config["standalone"])
+        self.builder.get_object("radio_thinclient").set_active(not self.gtkui_config["standalone"])
         self.builder.get_object("chk_show_rate_in_title").set_active(self.gtkui_config["show_rate_in_title"])
         self.builder.get_object("chk_focus_main_window_on_add").set_active(
             self.gtkui_config["focus_main_window_on_add"])
@@ -492,7 +492,6 @@ class Preferences(component.Component):
 
         :param hide: bool, if True, will not re-show the dialog and will hide it instead
         """
-        classic_mode_was_set = self.gtkui_config["classic_mode"]
 
         # Get the values from the dialog
         new_core_config = {}
@@ -583,8 +582,9 @@ class Preferences(component.Component):
         if passhex != "c07eb5a8c0dc7bb81c217b67f11c3b7a5e95ffd7":
             new_gtkui_config["tray_password"] = passhex
 
-        new_gtkui_in_classic_mode = self.builder.get_object("radio_classic").get_active()
-        new_gtkui_config["classic_mode"] = new_gtkui_in_classic_mode
+        was_standalone = self.gtkui_config["standalone"]
+        new_gtkui_standalone = self.builder.get_object("radio_standalone").get_active()
+        new_gtkui_config["standalone"] = new_gtkui_standalone
 
         new_gtkui_config["show_rate_in_title"] = self.builder.get_object(
             "chk_show_rate_in_title").get_active()
@@ -698,19 +698,19 @@ class Preferences(component.Component):
             # Re-show the dialog to make sure everything has been updated
             self.show()
 
-        if classic_mode_was_set != new_gtkui_in_classic_mode:
+        if was_standalone != new_gtkui_standalone:
             def on_response(response):
                 if response == gtk.RESPONSE_YES:
-                    shutdown_daemon = (not client.is_classicmode() and
+                    shutdown_daemon = (not client.is_standalone() and
                                        client.connected() and
                                        client.is_localhost())
                     component.get("MainWindow").quit(shutdown=shutdown_daemon)
                 else:
-                    self.gtkui_config["classic_mode"] = not new_gtkui_in_classic_mode
-                    self.builder.get_object("radio_classic").set_active(
-                        self.gtkui_config["classic_mode"])
+                    self.gtkui_config["standalone"] = not new_gtkui_standalone
+                    self.builder.get_object("radio_standalone").set_active(
+                        self.gtkui_config["standalone"])
                     self.builder.get_object("radio_thinclient").set_active(
-                        not self.gtkui_config["classic_mode"])
+                        not self.gtkui_config["standalone"])
             dialog = YesNoDialog(
                 _("Switching client mode..."),
                 _("Your current session will be stopped. Do you wish to continue?")

--- a/deluge/ui/gtkui/queuedtorrents.py
+++ b/deluge/ui/gtkui/queuedtorrents.py
@@ -66,7 +66,7 @@ class QueuedTorrents(component.Component):
         # We only want the add button sensitive if we're connected to a host
         self.builder.get_object("button_add").set_sensitive(True)
 
-        if self.config["autoadd_queued"] or self.config["classic_mode"]:
+        if self.config["autoadd_queued"] or self.config["standalone"]:
             self.on_button_add_clicked(None)
         else:
             self.run()

--- a/deluge/ui/gtkui/systemtray.py
+++ b/deluge/ui/gtkui/systemtray.py
@@ -128,7 +128,7 @@ class SystemTray(component.Component):
     def __start(self):
         if self.config["enable_system_tray"]:
 
-            if self.config["classic_mode"]:
+            if self.config["standalone"]:
                 try:
                     self.hide_widget_list.remove("menuitem_quitdaemon")
                     self.hide_widget_list.remove("separatormenuitem4")

--- a/deluge/ui/gtkui/toolbar.py
+++ b/deluge/ui/gtkui/toolbar.py
@@ -55,7 +55,7 @@ class ToolBar(component.Component):
 
     def start(self):
         self.window.get_builder().get_object("toolbutton_connectionmanager").set_visible(
-            not self.config["classic_mode"])
+            not self.config["standalone"])
 
         for widget in self.change_sensitivity:
             self.window.get_builder().get_object(widget).set_sensitive(True)

--- a/deluge/ui/web/json_api.py
+++ b/deluge/ui/web/json_api.py
@@ -90,7 +90,7 @@ class JSON(resource.Resource, component.Component):
         component.Component.__init__(self, "JSON")
         self._remote_methods = []
         self._local_methods = {}
-        if client.is_classicmode():
+        if client.is_standalone():
             self.get_remote_methods()
 
     def get_remote_methods(self, result=None):
@@ -378,7 +378,7 @@ class WebApi(JSONComponent):
         client.deregister_event_handler("PluginEnabledEvent", self._json.get_remote_methods)
         client.deregister_event_handler("PluginDisabledEvent", self._json.get_remote_methods)
 
-        if client.is_classicmode():
+        if client.is_standalone():
             component.get("Web.PluginManager").stop()
         else:
             client.disconnect()
@@ -388,7 +388,7 @@ class WebApi(JSONComponent):
         client.register_event_handler("PluginEnabledEvent", self._json.get_remote_methods)
         client.register_event_handler("PluginDisabledEvent", self._json.get_remote_methods)
 
-        if client.is_classicmode():
+        if client.is_standalone():
             component.get("Web.PluginManager").start()
         else:
             client.set_disconnect_callback(self._on_client_disconnect)


### PR DESCRIPTION
The term `classic` is rather confusing so replace with `standalone`.
- [ ] Should we keep the deprecated ui.client classic stubs?
- [ ] Need to verify can use ui.client.is_standalone in gtkui code
