### PR TITLE
Feature/fixup lt1.1 deprecated

### DIFF
--- a/deluge/core/alertmanager.py
+++ b/deluge/core/alertmanager.py
@@ -38,14 +38,18 @@ class AlertManager(component.Component):
         self.alert_queue_size = 10000
         self.set_alert_queue_size(self.alert_queue_size)
 
-        self.session.set_alert_mask(
-            lt.alert.category_t.error_notification |
-            lt.alert.category_t.port_mapping_notification |
-            lt.alert.category_t.storage_notification |
-            lt.alert.category_t.tracker_notification |
-            lt.alert.category_t.status_notification |
-            lt.alert.category_t.ip_block_notification |
-            lt.alert.category_t.performance_warning)
+        alert_mask = (lt.alert.category_t.error_notification |
+                      lt.alert.category_t.port_mapping_notification |
+                      lt.alert.category_t.storage_notification |
+                      lt.alert.category_t.tracker_notification |
+                      lt.alert.category_t.status_notification |
+                      lt.alert.category_t.ip_block_notification |
+                      lt.alert.category_t.performance_warning)
+
+        try:
+            self.session.apply_settings("alert_mask", alert_mask)
+        except AttributeError:
+            self.session.set_alert_mask(alert_mask)
 
         # handlers is a dictionary of lists {"alert_type": [handler1,h2,..]}
         self.handlers = {}
@@ -120,6 +124,4 @@ class AlertManager(component.Component):
         """Sets the maximum size of the libtorrent alert queue"""
         log.info("Alert Queue Size set to %s", queue_size)
         self.alert_queue_size = queue_size
-        settings = self.session.get_settings()
-        settings["alert_queue_size"] = self.alert_queue_size
-        self.session.set_settings(settings)
+        component.get("Core").apply_session_setting("alert_queue_size", self.alert_queue_size)

--- a/deluge/core/core.py
+++ b/deluge/core/core.py
@@ -77,7 +77,6 @@ class Core(component.Component):
 
         # --- libtorrent plugins ---
         # Allows peers to download the metadata from the swarm directly
-        self.session.add_extension("metadata_transfer")
         self.session.add_extension("ut_metadata")
         # Ban peers that sends bad data
         self.session.add_extension("smart_ban")

--- a/deluge/core/preferencesmanager.py
+++ b/deluge/core/preferencesmanager.py
@@ -53,7 +53,6 @@ DEFAULT_PREFS = {
     "upnp": True,
     "natpmp": True,
     "utpex": True,
-    "lt_tex": True,
     "lsd": True,
     "enc_in_policy": 1,
     "enc_out_policy": 1,
@@ -265,11 +264,6 @@ class PreferencesManager(component.Component):
         log.debug("utpex value set to %s", value)
         if value:
             self.session.add_extension("ut_pex")
-
-    def _on_set_lt_tex(self, key, value):
-        log.debug("lt_tex value set to %s", value)
-        if value:
-            self.session.add_extension("lt_trackers")
 
     def _on_set_enc_in_policy(self, key, value):
         self._on_set_encryption(key, value)

--- a/deluge/core/torrent.py
+++ b/deluge/core/torrent.py
@@ -382,9 +382,6 @@ class Torrent(object):
             return None, None
         if not self.has_metadata:
             return None, None
-        if self.get_status(["storage_mode"])["storage_mode"] == "compact":
-            log.debug("Setting first/last priority with compact allocation does not work!")
-            return None, None
         # A list of priorities for each piece in the torrent
         priorities = self.handle.piece_priorities()
         prioritized_pieces = []
@@ -417,11 +414,8 @@ class Torrent(object):
         Args:
             set_sequencial (bool): Enable sequencial downloading.
         """
-        if self.get_status(["storage_mode"])["storage_mode"] != "compact":
-            self.options["sequential_download"] = set_sequencial
-            self.handle.set_sequential_download(set_sequencial)
-        else:
-            self.options["sequential_download"] = False
+        self.options["sequential_download"] = set_sequencial
+        self.handle.set_sequential_download(set_sequencial)
 
     def set_auto_managed(self, auto_managed):
         """Set auto managed mode, i.e. will be started or queued automatically.
@@ -497,11 +491,6 @@ class Torrent(object):
             return
         if len(file_priorities) != self.torrent_info.num_files():
             log.debug("file_priorities len != num_files")
-            self.options["file_priorities"] = self.handle.file_priorities()
-            return
-
-        if self.get_status(["storage_mode"])["storage_mode"] == "compact":
-            log.warning("Setting file priority with compact allocation does not work!")
             self.options["file_priorities"] = self.handle.file_priorities()
             return
 
@@ -982,7 +971,7 @@ class Torrent(object):
             "seeding_time": lambda: self.status.seeding_time,
             "finished_time": lambda: self.status.finished_time,
             "all_time_download": lambda: self.status.all_time_download,
-            "storage_mode": lambda: self.status.storage_mode.name.split("_")[2],  # sparse, allocate or compact
+            "storage_mode": lambda: self.status.storage_mode.name.split("_")[2],  # sparse or allocate
             "distributed_copies": lambda: max(0.0, self.status.distributed_copies),
             "download_payload_rate": lambda: self.status.download_payload_rate,
             "file_priorities": lambda: self.options["file_priorities"],

--- a/deluge/core/torrentmanager.py
+++ b/deluge/core/torrentmanager.py
@@ -1292,8 +1292,7 @@ class TorrentManager(component.Component):
             if send_buffer_watermark < max_send_buffer_watermark:
                 value = send_buffer_watermark + (500 * 1024)
                 log.info("Increasing send_buffer_watermark from %s to %s Bytes", send_buffer_watermark, value)
-                settings["send_buffer_watermark"] = value
-                self.session.set_settings(settings)
+                component.get("Core").apply_session_setting("send_buffer_watermark", value)
             else:
                 log.warning("send_buffer_watermark reached maximum value: %s Bytes", max_send_buffer_watermark)
 

--- a/deluge/core/torrentmanager.py
+++ b/deluge/core/torrentmanager.py
@@ -538,10 +538,7 @@ class TorrentManager(component.Component):
                 try:
                     for attr in set(dir(t_state_tmp)) - set(dir(state.torrents[0])):
                         for t_state in state.torrents:
-                            if attr == "storage_mode" and getattr(t_state, "compact", None):
-                                setattr(t_state, attr, "compact")
-                            else:
-                                setattr(t_state, attr, getattr(t_state_tmp, attr, None))
+                            setattr(t_state, attr, getattr(t_state_tmp, attr, None))
                 except AttributeError as ex:
                     log.error("Unable to update state file to a compatible version: %s", ex)
         return state

--- a/deluge/plugins/Scheduler/deluge/plugins/scheduler/core.py
+++ b/deluge/plugins/Scheduler/deluge/plugins/scheduler/core.py
@@ -120,14 +120,14 @@ class Core(CorePluginBase):
             self.__apply_set_functions()
         elif state == "Yellow":
             # This is Yellow (Slow), so use the settings provided from the user
-            session = component.get("Core").session
-            session.set_download_rate_limit(int(self.config["low_down"] * 1024))
-            session.set_upload_rate_limit(int(self.config["low_up"] * 1024))
-            settings = session.get_settings()
-            settings["active_limit"] = self.config["low_active"]
-            settings["active_downloads"] = self.config["low_active_down"]
-            settings["active_seeds"] = self.config["low_active_up"]
-            session.set_settings(settings)
+            settings = {
+                "active_limit": self.config["low_active"],
+                "active_downloads": self.config["low_active_down"],
+                "active_seeds": self.config["low_active_up"],
+                "download_rate_limit": int(self.config["low_down"] * 1024),
+                "upload_rate_limit": int(self.config["low_up"] * 1024)
+            }
+            component.get("Core").apply_session_settings(settings)
             # Resume the session if necessary
             component.get("Core").resume_session()
         elif state == "Red":

--- a/deluge/ui/console/modes/preferences/preference_panes.py
+++ b/deluge/ui/console/modes/preferences/preference_panes.py
@@ -249,7 +249,6 @@ class NetworkPane(BasePreferencePane):
         self.add_checked_input("upnp", "UPnP", core_conf["upnp"])
         self.add_checked_input("natpmp", "NAT-PMP", core_conf["natpmp"])
         self.add_checked_input("utpex", "Peer Exchange", core_conf["utpex"])
-        self.add_checked_input("lt_tex", "Tracker Exchange", core_conf["lt_tex"])
         self.add_checked_input("lsd", "LSD", core_conf["lsd"])
         self.add_checked_input("dht", "DHT", core_conf["dht"])
 

--- a/deluge/ui/gtkui/files_tab.py
+++ b/deluge/ui/gtkui/files_tab.py
@@ -445,10 +445,6 @@ class FilesTab(Tab):
         if self.torrent_id != torrent_id:
             return
 
-        # Store this torrent's compact setting
-        if "storage_mode" in status:
-            self.__compact = status["storage_mode"] == "compact"
-
         if "is_seed" in status:
             self.__is_seed = status["is_seed"]
 
@@ -498,7 +494,7 @@ class FilesTab(Tab):
                 self.listview.get_selection().select_iter(row)
 
             for widget in self.file_menu_priority_items:
-                widget.set_sensitive(not (self.__compact or self.__is_seed))
+                widget.set_sensitive(not self.__is_seed)
 
             self.file_menu.popup(None, None, None, event.button, event.time)
             return True

--- a/deluge/ui/gtkui/glade/preferences_dialog.ui
+++ b/deluge/ui/gtkui/glade/preferences_dialog.ui
@@ -3256,7 +3256,7 @@ used sparingly.</property>
                                       <object class="GtkTable" id="table8">
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
-                                        <property name="n_rows">3</property>
+                                        <property name="n_rows">2</property>
                                         <property name="n_columns">3</property>
                                         <property name="column_spacing">6</property>
                                         <property name="row_spacing">1</property>
@@ -3312,25 +3312,6 @@ used sparingly.</property>
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkCheckButton" id="chk_lt_tex">
-                                            <property name="label" translatable="yes">Tracker Exchange</property>
-                                            <property name="use_action_appearance">False</property>
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="tooltip_text" translatable="yes">Exchanges trackers between clients. (Disabling requires restart)</property>
-                                            <property name="use_underline">True</property>
-                                            <property name="active">True</property>
-                                            <property name="draw_indicator">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="left_attach">2</property>
-                                            <property name="right_attach">3</property>
-                                            <property name="top_attach">1</property>
-                                            <property name="bottom_attach">2</property>
-                                          </packing>
-                                        </child>
-                                        <child>
                                           <object class="GtkCheckButton" id="chk_lsd">
                                             <property name="label" translatable="yes">LSD</property>
                                             <property name="use_action_appearance">False</property>
@@ -3373,8 +3354,6 @@ used sparingly.</property>
                                               <object class="GtkLabel" id="label_peer_tos">
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
-                                                <property name="tooltip_text" translatable="yes">TOS can help with network conjestion. This value is included in every IPv4 packet header sent to peers (inc. web seeds).
-Requires a Hex value.</property>
                                                 <property name="xpad">3</property>
                                                 <property name="label" translatable="yes">Peer TOS Byte:</property>
                                               </object>
@@ -3390,6 +3369,7 @@ Requires a Hex value.</property>
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">True</property>
                                                 <property name="max_length">4</property>
+                                                <property name="invisible_char">•</property>
                                                 <property name="width_chars">4</property>
                                                 <property name="text">0x00</property>
                                                 <property name="truncate_multiline">True</property>
@@ -3406,9 +3386,10 @@ Requires a Hex value.</property>
                                             </child>
                                           </object>
                                           <packing>
+                                            <property name="left_attach">2</property>
                                             <property name="right_attach">3</property>
-                                            <property name="top_attach">2</property>
-                                            <property name="bottom_attach">3</property>
+                                            <property name="top_attach">1</property>
+                                            <property name="bottom_attach">2</property>
                                           </packing>
                                         </child>
                                       </object>

--- a/deluge/ui/gtkui/options_tab.py
+++ b/deluge/ui/gtkui/options_tab.py
@@ -147,22 +147,14 @@ class OptionsTab(Tab):
             if status["owner"] != self.prev_status["owner"]:
                 self.summary_owner.set_text(status["owner"])
 
-            if status["storage_mode"] == "compact":
-                self.chk_prioritize_first_last.set_sensitive(False)
-                if self.chk_sequential_download.get_property("visible"):
-                    self.chk_prioritize_first_last.hide()
-                self.chk_sequential_download.set_sensitive(False)
-                if self.chk_sequential_download.get_property("visible"):
-                    self.chk_sequential_download.hide()
-            else:
-                if status["prioritize_first_last"] != self.prev_status["prioritize_first_last"]:
-                    self.chk_prioritize_first_last.set_active(status["prioritize_first_last"])
-                    if not self.chk_prioritize_first_last.get_property("visible"):
-                        self.chk_prioritize_first_last.show()
-                if status["sequential_download"] != self.prev_status["sequential_download"]:
-                    self.chk_sequential_download.set_active(status["sequential_download"])
-                    if not self.chk_sequential_download.get_property("visible"):
-                        self.chk_sequential_download.show()
+            if status["prioritize_first_last"] != self.prev_status["prioritize_first_last"]:
+                self.chk_prioritize_first_last.set_active(status["prioritize_first_last"])
+                if not self.chk_prioritize_first_last.get_property("visible"):
+                    self.chk_prioritize_first_last.show()
+            if status["sequential_download"] != self.prev_status["sequential_download"]:
+                self.chk_sequential_download.set_active(status["sequential_download"])
+                if not self.chk_sequential_download.get_property("visible"):
+                    self.chk_sequential_download.show()
 
             if self.button_apply.is_sensitive():
                 self.button_apply.set_sensitive(False)
@@ -180,12 +172,10 @@ class OptionsTab(Tab):
         if self.spin_max_upload_slots.get_value_as_int() != self.prev_status["max_upload_slots"]:
             client.core.set_torrent_max_upload_slots(
                 self.prev_torrent_id, self.spin_max_upload_slots.get_value_as_int())
-        if (self.chk_prioritize_first_last.get_active() !=
-                self.prev_status["prioritize_first_last"] and self.prev_status["storage_mode"] != "compact"):
+        if (self.chk_prioritize_first_last.get_active() != self.prev_status["prioritize_first_last"]):
             client.core.set_torrent_prioritize_first_last(
                 self.prev_torrent_id, self.chk_prioritize_first_last.get_active())
-        if (self.chk_sequential_download.get_active() !=
-                self.prev_status["sequential_download"] and self.prev_status["storage_mode"] != "compact"):
+        if (self.chk_sequential_download.get_active() != self.prev_status["sequential_download"]):
             client.core.set_torrent_options(
                 [self.prev_torrent_id], {"sequential_download": self.chk_sequential_download.get_active()})
         if self.chk_auto_managed.get_active() != self.prev_status["is_auto_managed"]:

--- a/deluge/ui/gtkui/preferences.py
+++ b/deluge/ui/gtkui/preferences.py
@@ -337,7 +337,6 @@ class Preferences(component.Component):
             "chk_upnp": ("active", "upnp"),
             "chk_natpmp": ("active", "natpmp"),
             "chk_utpex": ("active", "utpex"),
-            "chk_lt_tex": ("active", "lt_tex"),
             "chk_lsd": ("active", "lsd"),
             "chk_new_releases": ("active", "new_release_check"),
             "chk_send_info": ("active", "send_info"),
@@ -545,7 +544,6 @@ class Preferences(component.Component):
         new_core_config["upnp"] = self.builder.get_object("chk_upnp").get_active()
         new_core_config["natpmp"] = self.builder.get_object("chk_natpmp").get_active()
         new_core_config["utpex"] = self.builder.get_object("chk_utpex").get_active()
-        new_core_config["lt_tex"] = self.builder.get_object("chk_lt_tex").get_active()
         new_core_config["lsd"] = self.builder.get_object("chk_lsd").get_active()
         new_core_config["enc_in_policy"] = self.builder.get_object("combo_encin").get_active()
         new_core_config["enc_out_policy"] = self.builder.get_object("combo_encout").get_active()

--- a/deluge/ui/web/js/deluge-all/preferences/NetworkPage.js
+++ b/deluge/ui/web/js/deluge-all/preferences/NetworkPage.js
@@ -189,13 +189,6 @@ Deluge.preferences.Network = Ext.extend(Ext.form.FormPanel, {
             ctCls: 'x-deluge-indent-checkbox',
             name: 'dht'
         }));
-        optMan.bind('lt_tex', fieldset.add({
-            fieldLabel: '',
-            labelSeparator: '',
-            boxLabel: _('Tracker Exchange'),
-            ctCls: 'x-deluge-indent-checkbox',
-            name: 'lt_tex'
-        }));
 
         fieldset = this.add({
             xtype: 'fieldset',


### PR DESCRIPTION
This is a refactor that works with both 1.0 and 1.1 (with/without deprecated) libtorrent branches. It is designed to try non-deprecated and fallback to deprecated with the aim to make it trivial to remove the code in future.

I am keeping compatibility for now to ease testing (I still use 1.0.9 for dev...) but likely will remove support for 1.0 and 1.1 deprecated methods shortly before release.

Still to be done:
- [x] ~~Need to merge i2p proxy into proxy settings in UI~~ See [#2919](http://dev.deluge-torrent.org/ticket/2919)

- [x] ~~Session stats still need converting~~ See [#2920](dev.deluge-torrent.org/ticket/2920)

- [x] ~~Could move and combine all the `_on_set_*` methods for session settings into `do_config_set_func` testing if key in settings_pack.  `preferencesmanager.session_set_setting` would become redundant.~~ See [#2921](http://dev.deluge-torrent.org/ticket/2921)

- [x] `core.apply_session_setting` perhaps should be plural and accept `dict` instead of `key, value`

- [x] Remove unneeded `preferencesmanager.session_set_settings`

- [x] ~~lt `listen_interfaces` and `outgoing_interfaces` now supports adapter names.~~ (advised against use by arvid in 1.1, plus no Windows support atm)

- [x] ~~Add support for 'new' `outgoing_interfaces` setting?~~ Leave it for now.

- [x] `tracker_error_alert`: `msg` has been replace by `error_message`

- [x] `filerenamed_alert`: `name` is now `new_name`

- [x] Use of `torrent.handle` `save_path` in alert should use alert path attribute.

- [x] torrent `status.error` is split into `errc` (error code) and `error_file`.

- [x] ~~`states.queued_for_checking` has been removed.~~ Should be ok to be left as is.