### PR TITLE
[#495] Deprecate core.set_torrent_* for core.set_torrent_options

### DIFF
--- a/deluge/core/core.py
+++ b/deluge/core/core.py
@@ -620,7 +620,18 @@ class Core(component.Component):
 
     @export
     def set_torrent_options(self, torrent_ids, options):
-        """Sets the torrent options for torrent_ids"""
+        """Sets the torrent options for torrent_ids
+
+        Args:
+            torrent_ids (list): A list of torrent_ids to set the options for.
+            options (dict): A dict of torrent options to set. See torrent.TorrentOptions class for valid keys.
+        """
+        if 'owner' in options and not self.core.authmanager.has_account(options['owner']):
+            raise DelugeError('Username "%s" is not known.' % options['owner'])
+
+        if isinstance(torrent_ids, basestring):
+            torrent_ids = [torrent_ids]
+
         for torrent_id in torrent_ids:
             self.torrentmanager[torrent_id].set_options(options)
 
@@ -633,93 +644,74 @@ class Core(component.Component):
     def set_torrent_max_connections(self, torrent_id, value):
         # Deprecated method, use set_torrent_options instead
         """Sets a torrents max number of connections"""
-        return self.torrentmanager[torrent_id].set_max_connections(value)
+        self.set_torrent_options([torrent_id], {'max_connections': value})
 
     @export
     def set_torrent_max_upload_slots(self, torrent_id, value):
         # Deprecated method, use set_torrent_options instead
         """Sets a torrents max number of upload slots"""
-        return self.torrentmanager[torrent_id].set_max_upload_slots(value)
+        self.set_torrent_options([torrent_id], {'max_upload_slots': value})
 
     @export
     def set_torrent_max_upload_speed(self, torrent_id, value):
         # Deprecated method, use set_torrent_options instead
         """Sets a torrents max upload speed"""
-        return self.torrentmanager[torrent_id].set_max_upload_speed(value)
+        self.set_torrent_options([torrent_id], {'max_upload_speed': value})
 
     @export
     def set_torrent_max_download_speed(self, torrent_id, value):
         # Deprecated method, use set_torrent_options instead
         """Sets a torrents max download speed"""
-        return self.torrentmanager[torrent_id].set_max_download_speed(value)
+        self.set_torrent_options([torrent_id], {'max_download_speed': value})
 
     @export
     def set_torrent_file_priorities(self, torrent_id, priorities):
         # Deprecated method, use set_torrent_options instead
         # Used by at least one 3rd party plugin:
         """Sets a torrents file priorities"""
-        return self.torrentmanager[torrent_id].set_file_priorities(priorities)
+        self.set_torrent_options([torrent_id], {'file_priorities': priorities})
 
     @export
     def set_torrent_prioritize_first_last(self, torrent_id, value):
         # Deprecated method, use set_torrent_options instead
         """Sets a higher priority to the first and last pieces"""
-        return self.torrentmanager[torrent_id].set_prioritize_first_last_pieces(value)
+        self.set_torrent_options([torrent_id], {'prioritize_first_last_pieces': value})
 
     @export
     def set_torrent_auto_managed(self, torrent_id, value):
         # Deprecated method, use set_torrent_options instead
         """Sets the auto managed flag for queueing purposes"""
-        return self.torrentmanager[torrent_id].set_auto_managed(value)
+        self.set_torrent_options([torrent_id], {'auto_managed': value})
 
     @export
     def set_torrent_stop_at_ratio(self, torrent_id, value):
         # Deprecated method, use set_torrent_options instead
         """Sets the torrent to stop at 'stop_ratio'"""
-        return self.torrentmanager[torrent_id].set_stop_at_ratio(value)
+        self.set_torrent_options([torrent_id], {'stop_at_ratio': value})
 
     @export
     def set_torrent_stop_ratio(self, torrent_id, value):
         # Deprecated method, use set_torrent_options instead
         """Sets the ratio when to stop a torrent if 'stop_at_ratio' is set"""
-        return self.torrentmanager[torrent_id].set_stop_ratio(value)
+        self.set_torrent_options([torrent_id], {'stop_ratio': value})
 
     @export
     def set_torrent_remove_at_ratio(self, torrent_id, value):
         # Deprecated method, use set_torrent_options instead
         """Sets the torrent to be removed at 'stop_ratio'"""
-        return self.torrentmanager[torrent_id].set_remove_at_ratio(value)
+        self.set_torrent_options([torrent_id], {'remove_at_ratio': value})
 
     @export
     def set_torrent_move_completed(self, torrent_id, value):
         # Deprecated method, use set_torrent_options instead
         """Sets the torrent to be moved when completed"""
-        return self.torrentmanager[torrent_id].set_move_completed(value)
+        self.set_torrent_options([torrent_id], {'move_completed': value})
 
     @export
     def set_torrent_move_completed_path(self, torrent_id, value):
         # Deprecated method, use set_torrent_options instead
         """Sets the path for the torrent to be moved when completed"""
-        return self.torrentmanager[torrent_id].set_move_completed_path(value)
-
-    @export(AUTH_LEVEL_ADMIN)
-    def set_owner(self, torrent_ids, username):
-        """Set's the torrent owner.
-
-        :param torrent_id: the torrent_id of the torrent to remove
-        :type torrent_id: string
-        :param username: the new owner username
-        :type username: string
-
-        :raises DelugeError: if the username is not known
-        """
-        if not self.authmanager.has_account(username):
-            raise DelugeError('Username "%s" is not known.' % username)
-        if isinstance(torrent_ids, basestring):
-            torrent_ids = [torrent_ids]
-        for torrent_id in torrent_ids:
-            self.torrentmanager[torrent_id].set_owner(username)
-        return None
+        self.set_torrent_options([torrent_id], {'move_completed_path': value})
 
     @export
     def get_path_size(self, path):

--- a/deluge/core/core.py
+++ b/deluge/core/core.py
@@ -35,6 +35,7 @@ from deluge.core.pluginmanager import PluginManager
 from deluge.core.preferencesmanager import PreferencesManager
 from deluge.core.rpcserver import export
 from deluge.core.torrentmanager import TorrentManager
+from deluge.decorators import deprecated
 from deluge.error import AddTorrentError, DelugeError, InvalidPathError, InvalidTorrentError
 from deluge.event import NewVersionAvailableEvent, SessionPausedEvent, SessionResumedEvent, TorrentQueueChangedEvent
 from deluge.httpdownloader import download_file
@@ -572,10 +573,12 @@ class Core(component.Component):
         """Returns the active listen port"""
         return self.session.listen_port()
 
+    @deprecated
     @export
     def get_i2p_proxy(self):
         """Returns the active listen port"""
-        i2p_settings = self.session.i2p_proxy()  # Deprecated, moved to proxy types
+        # Deprecated: Moved to proxy types
+        i2p_settings = self.session.i2p_proxy()
         i2p_dict = {'hostname': i2p_settings.hostname, 'port': i2p_settings.port}
         return i2p_dict
 
@@ -640,77 +643,76 @@ class Core(component.Component):
         """Sets a torrents tracker list.  trackers will be [{"url", "tier"}]"""
         return self.torrentmanager[torrent_id].set_trackers(trackers)
 
+    @deprecated
     @export
     def set_torrent_max_connections(self, torrent_id, value):
-        # Deprecated method, use set_torrent_options instead
-        """Sets a torrents max number of connections"""
+        """Deprecated: Use set_torrent_options with 'max_connections'"""
         self.set_torrent_options([torrent_id], {'max_connections': value})
 
+    @deprecated
     @export
     def set_torrent_max_upload_slots(self, torrent_id, value):
-        # Deprecated method, use set_torrent_options instead
-        """Sets a torrents max number of upload slots"""
+        """Deprecated: Use set_torrent_options with 'max_upload_slots'"""
         self.set_torrent_options([torrent_id], {'max_upload_slots': value})
 
+    @deprecated
     @export
     def set_torrent_max_upload_speed(self, torrent_id, value):
-        # Deprecated method, use set_torrent_options instead
-        """Sets a torrents max upload speed"""
+        """Deprecated: Use set_torrent_options with 'max_upload_speed'"""
         self.set_torrent_options([torrent_id], {'max_upload_speed': value})
 
+    @deprecated
     @export
     def set_torrent_max_download_speed(self, torrent_id, value):
-        # Deprecated method, use set_torrent_options instead
-        """Sets a torrents max download speed"""
+        """Deprecated: Use set_torrent_options with 'max_download_speed'"""
         self.set_torrent_options([torrent_id], {'max_download_speed': value})
 
+    @deprecated
     @export
     def set_torrent_file_priorities(self, torrent_id, priorities):
-        # Deprecated method, use set_torrent_options instead
-        # Used by at least one 3rd party plugin:
-        """Sets a torrents file priorities"""
+        """Deprecated: Use set_torrent_options with 'file_priorities'"""
         self.set_torrent_options([torrent_id], {'file_priorities': priorities})
 
+    @deprecated
     @export
     def set_torrent_prioritize_first_last(self, torrent_id, value):
-        # Deprecated method, use set_torrent_options instead
-        """Sets a higher priority to the first and last pieces"""
+        """Deprecated: Use set_torrent_options with 'prioritize_first_last'"""
         self.set_torrent_options([torrent_id], {'prioritize_first_last_pieces': value})
 
+    @deprecated
     @export
     def set_torrent_auto_managed(self, torrent_id, value):
-        # Deprecated method, use set_torrent_options instead
-        """Sets the auto managed flag for queueing purposes"""
+        """Deprecated: Use set_torrent_options with 'auto_managed'"""
         self.set_torrent_options([torrent_id], {'auto_managed': value})
 
+    @deprecated
     @export
     def set_torrent_stop_at_ratio(self, torrent_id, value):
-        # Deprecated method, use set_torrent_options instead
-        """Sets the torrent to stop at 'stop_ratio'"""
+        """Deprecated: Use set_torrent_options with 'stop_at_ratio'"""
         self.set_torrent_options([torrent_id], {'stop_at_ratio': value})
 
+    @deprecated
     @export
     def set_torrent_stop_ratio(self, torrent_id, value):
-        # Deprecated method, use set_torrent_options instead
-        """Sets the ratio when to stop a torrent if 'stop_at_ratio' is set"""
+        """Deprecated: Use set_torrent_options with 'stop_ratio'"""
         self.set_torrent_options([torrent_id], {'stop_ratio': value})
 
+    @deprecated
     @export
     def set_torrent_remove_at_ratio(self, torrent_id, value):
-        # Deprecated method, use set_torrent_options instead
-        """Sets the torrent to be removed at 'stop_ratio'"""
+        """Deprecated: Use set_torrent_options with 'remove_at_ratio'"""
         self.set_torrent_options([torrent_id], {'remove_at_ratio': value})
 
+    @deprecated
     @export
     def set_torrent_move_completed(self, torrent_id, value):
-        # Deprecated method, use set_torrent_options instead
-        """Sets the torrent to be moved when completed"""
+        """Deprecated: Use set_torrent_options with 'move_completed'"""
         self.set_torrent_options([torrent_id], {'move_completed': value})
 
+    @deprecated
     @export
     def set_torrent_move_completed_path(self, torrent_id, value):
-        # Deprecated method, use set_torrent_options instead
-        """Sets the path for the torrent to be moved when completed"""
+        """Deprecated: Use set_torrent_options with 'move_completed_path'"""
         self.set_torrent_options([torrent_id], {'move_completed_path': value})
 
     @export

--- a/deluge/core/torrent.py
+++ b/deluge/core/torrent.py
@@ -1006,6 +1006,8 @@ class Torrent(object):
             'owner': lambda: self.options['owner'],
             'paused': lambda: self.status.paused,
             'prioritize_first_last': lambda: self.options['prioritize_first_last_pieces'],
+            # Deprecated: Use prioritize_first_last_pieces
+            'prioritize_first_last_pieces': lambda: self.options['prioritize_first_last_pieces'],
             'sequential_download': lambda: self.options['sequential_download'],
             'progress': self.get_progress,
             'shared': lambda: self.options['shared'],

--- a/deluge/core/torrent.py
+++ b/deluge/core/torrent.py
@@ -29,6 +29,7 @@ from deluge._libtorrent import lt
 from deluge.common import decode_string, utf8_encoded
 from deluge.configmanager import ConfigManager, get_config_dir
 from deluge.core.authmanager import AUTH_LEVEL_ADMIN
+from deluge.decorators import deprecated
 from deluge.event import TorrentFolderRenamedEvent, TorrentStateChangedEvent, TorrentTrackerStatusEvent
 
 log = logging.getLogger(__name__)
@@ -361,8 +362,9 @@ class Torrent(object):
             value = int(m_down_speed * 1024)
         self.handle.set_download_limit(value)
 
+    @deprecated
     def set_prioritize_first_last(self, prioritize):
-        """Deprecated due to mismatch between option and func name."""
+        """Deprecated: Use set_prioritize_first_last_pieces."""
         self.set_prioritize_first_last_pieces(prioritize)
 
     def set_prioritize_first_last_pieces(self, prioritize):
@@ -517,8 +519,9 @@ class Torrent(object):
         if self.options['prioritize_first_last_pieces']:
             self.set_prioritize_first_last_pieces(self.options['prioritize_first_last_pieces'])
 
+    @deprecated
     def set_save_path(self, download_location):
-        """Deprecated, use set_download_location."""
+        """Deprecated: Use set_download_location."""
         self.set_download_location(download_location)
 
     def set_download_location(self, download_location):
@@ -994,8 +997,8 @@ class Torrent(object):
             'max_upload_slots': lambda: self.options['max_upload_slots'],
             'max_upload_speed': lambda: self.options['max_upload_speed'],
             'message': lambda: self.statusmsg,
-            'move_on_completed_path': lambda: self.options['move_completed_path'],  # Depr, use move_completed_path
-            'move_on_completed': lambda: self.options['move_completed'],  # Deprecated, use move_completed
+            'move_on_completed_path': lambda: self.options['move_completed_path'],  # Deprecated: move_completed_path
+            'move_on_completed': lambda: self.options['move_completed'],  # Deprecated: Use move_completed
             'move_completed_path': lambda: self.options['move_completed_path'],
             'move_completed': lambda: self.options['move_completed'],
             'next_announce': lambda: self.status.next_announce.seconds,
@@ -1008,7 +1011,7 @@ class Torrent(object):
             'progress': self.get_progress,
             'shared': lambda: self.options['shared'],
             'remove_at_ratio': lambda: self.options['remove_at_ratio'],
-            'save_path': lambda: self.options['download_location'],  # Deprecated, use download_location
+            'save_path': lambda: self.options['download_location'],  # Deprecated: Use download_location
             'download_location': lambda: self.options['download_location'],
             'seeds_peers_ratio': lambda: -1.0 if self.status.num_incomplete == 0 else (  # Use -1.0 to signify infinity
                 self.status.num_complete / self.status.num_incomplete),

--- a/deluge/core/torrent.py
+++ b/deluge/core/torrent.py
@@ -108,64 +108,64 @@ class TorrentOptions(dict):
     """TorrentOptions create a dict of the torrent options.
 
     Attributes:
+        add_paused (bool): Add the torrrent in a paused state.
+        auto_managed (bool): Set torrent to auto managed mode, i.e. will be started or queued automatically.
+        download_location (str): The path for the torrent data to be stored while downloading.
+        file_priorities (list of int): The priority for files in torrent, range is [0..7] however
+            only [0, 1, 5, 7] are normally used and correspond to [Do Not Download, Normal, High, Highest]
+        mapped_files (dict): A mapping of the renamed filenames in 'index:filename' pairs.
         max_connections (int): Sets maximum number of connections this torrent will open.
             This must be at least 2. The default is unlimited (-1).
+        max_download_speed (float): Will limit the download bandwidth used by this torrent to the
+            limit you set.The default is unlimited (-1) but will not exceed global limit.
         max_upload_slots (int): Sets the maximum number of peers that are
             unchoked at the same time on this torrent. This defaults to infinite (-1).
         max_upload_speed (float): Will limit the upload bandwidth used by this torrent to the limit
             you set. The default is unlimited (-1) but will not exceed global limit.
-        max_download_speed (float): Will limit the download bandwidth used by this torrent to the
-            limit you set.The default is unlimited (-1) but will not exceed global limit.
-        prioritize_first_last_pieces (bool): Prioritize the first and last pieces in the torrent.
-        sequential_download (bool): Download the pieces of the torrent in order.
-        pre_allocate_storage (bool): When adding the torrent should all files be pre-allocated.
-        download_location (str): The path for the torrent data to be stored while downloading.
-        auto_managed (bool): Set torrent to auto managed mode, i.e. will be started or queued automatically.
-        stop_at_ratio (bool): Stop the torrent when it has reached stop_ratio.
-        stop_ratio (float): The seeding ratio to stop (or remove) the torrent at.
-        remove_at_ratio (bool): Remove the torrent when it has reached the stop_ratio.
         move_completed (bool): Move the torrent when downloading has finished.
         move_completed_path (str): The path to move torrent to when downloading has finished.
-        add_paused (bool): Add the torrrent in a paused state.
-        shared (bool): Enable the torrent to be seen by other Deluge users.
-        super_seeding (bool): Enable super seeding/initial seeding.
-        priority (int): Torrent bandwidth priority with a range [0..255], 0 is lowest and default priority.
-        file_priorities (list of int): The priority for files in torrent, range is [0..7] however
-            only [0, 1, 5, 7] are normally used and correspond to [Do Not Download, Normal, High, Highest]
-        mapped_files (dict): A mapping of the renamed filenames in 'index:filename' pairs.
-        owner (str): The user this torrent belongs to.
         name (str): The display name of the torrent.
+        owner (str): The user this torrent belongs to.
+        pre_allocate_storage (bool): When adding the torrent should all files be pre-allocated.
+        prioritize_first_last_pieces (bool): Prioritize the first and last pieces in the torrent.
+        priority (int): Torrent bandwidth priority with a range [0..255], 0 is lowest and default priority.
         seed_mode (bool): Assume that all files are present for this torrent (Only used when adding a torent).
+        sequential_download (bool): Download the pieces of the torrent in order.
+        shared (bool): Enable the torrent to be seen by other Deluge users.
+        stop_at_ratio (bool): Stop the torrent when it has reached stop_ratio.
+        stop_ratio (float): The seeding ratio to stop (or remove) the torrent at.
+        super_seeding (bool): Enable super seeding/initial seeding.
+        remove_at_ratio (bool): Remove the torrent when it has reached the stop_ratio.
     """
     def __init__(self):
         super(TorrentOptions, self).__init__()
         config = ConfigManager('core.conf').config
         options_conf_map = {
+            'add_paused': 'add_paused',
+            'auto_managed': 'auto_managed',
+            'download_location': 'download_location',
             'max_connections': 'max_connections_per_torrent',
+            'max_download_speed': 'max_download_speed_per_torrent',
             'max_upload_slots': 'max_upload_slots_per_torrent',
             'max_upload_speed': 'max_upload_speed_per_torrent',
-            'max_download_speed': 'max_download_speed_per_torrent',
-            'prioritize_first_last_pieces': 'prioritize_first_last_pieces',
-            'sequential_download': 'sequential_download',
-            'pre_allocate_storage': 'pre_allocate_storage',
-            'download_location': 'download_location',
-            'auto_managed': 'auto_managed',
-            'stop_at_ratio': 'stop_seed_at_ratio',
-            'stop_ratio': 'stop_seed_ratio',
-            'remove_at_ratio': 'remove_seed_at_ratio',
             'move_completed': 'move_completed',
             'move_completed_path': 'move_completed_path',
-            'add_paused': 'add_paused',
-            'shared': 'shared',
-            'super_seeding': 'super_seeding',
+            'pre_allocate_storage': 'pre_allocate_storage',
             'priority': 'priority',
+            'prioritize_first_last_pieces': 'prioritize_first_last_pieces',
+            'remove_at_ratio': 'remove_seed_at_ratio',
+            'sequential_download': 'sequential_download',
+            'shared': 'shared',
+            'stop_at_ratio': 'stop_seed_at_ratio',
+            'stop_ratio': 'stop_seed_ratio',
+            'super_seeding': 'super_seeding'
         }
         for opt_k, conf_k in options_conf_map.iteritems():
             self[opt_k] = config[conf_k]
         self['file_priorities'] = []
         self['mapped_files'] = {}
-        self['owner'] = ''
         self['name'] = ''
+        self['owner'] = ''
         self['seed_mode'] = False
 
 
@@ -545,8 +545,14 @@ class Torrent(object):
     def set_owner(self, account):
         """Sets the owner of this torrent.
 
-        Only a user with admin level auth can change this value.
+        Args:
+            account (str): The new owner account name.
+
+        Notes:
+            Only a user with admin level auth can change this value.
+
         """
+
         if self.rpcserver.get_session_auth_level() == AUTH_LEVEL_ADMIN:
             self.options['owner'] = account
 

--- a/deluge/core/torrent.py
+++ b/deluge/core/torrent.py
@@ -285,16 +285,15 @@ class Torrent(object):
         Args:
             options (dict): Torrent options, see TorrentOptions class for valid keys.
         """
-        # set_prioritize_first_last is called by set_file_priorities so only run if not in options
-        skip_func = []
-        if 'file_priorities' in options:
-            self.options['prioritize_first_last_pieces'] = options['prioritize_first_last_pieces']
-            skip_func.append('prioritize_first_last_pieces')
+
+        # Skip set_prioritize_first_last if set_file_priorities is in options as it also calls the method.
+        if 'file_priorities' in options and 'prioritize_first_last_pieces' in options:
+            self.options['prioritize_first_last_pieces'] = options.pop('prioritize_first_last_pieces')
 
         for key, value in options.items():
             if key in self.options:
                 options_set_func = getattr(self, 'set_' + key, None)
-                if options_set_func and key not in skip_func:
+                if options_set_func:
                     options_set_func(value)
                 else:
                     # Update config options that do not have funcs

--- a/deluge/decorators.py
+++ b/deluge/decorators.py
@@ -9,6 +9,7 @@
 
 import inspect
 import re
+import warnings
 from functools import wraps
 
 
@@ -114,3 +115,21 @@ def _overrides(stack, method, explicit_base_classes=None):
         raise Exception('Function override "%s" not found in any superclass: %s\n%s'
                         % (method.__name__, check_classes, 'File: %s:%s' % (stack[1][1], stack[1][2])))
     return method
+
+
+def deprecated(func):
+    """This is a decorator which can be used to mark function as deprecated.
+
+    It will result in a warning being emmitted when the function is used.
+
+    """
+
+    @wraps(func)
+    def depr_func(*args, **kwargs):
+        warnings.simplefilter('always', DeprecationWarning)  # Turn off filter
+        warnings.warn('Call to deprecated function {}.'.format(func.__name__),
+                      category=DeprecationWarning, stacklevel=2)
+        warnings.simplefilter('default', DeprecationWarning)  # Reset filter
+        return func(*args, **kwargs)
+
+    return depr_func

--- a/deluge/ui/client.py
+++ b/deluge/ui/client.py
@@ -17,6 +17,7 @@ from twisted.internet.protocol import ClientFactory
 
 import deluge.common
 from deluge import error
+from deluge.decorators import deprecated
 from deluge.transfer import DelugeTransferProtocol
 from deluge.ui.common import get_localhost_auth
 
@@ -608,12 +609,14 @@ class Client(object):
         self._daemon_proxy = None
         self.__started_standalone = False
 
+    @deprecated
     def start_classic_mode(self):
-        """Deprecated"""
+        """Deprecated: Use start_standalone"""
         self.start_standalone()
 
+    @deprecated
     def stop_classic_mode(self):
-        """Deprecated"""
+        """Deprecated: Use stop_standalone"""
         self.stop_standalone()
 
     def start_daemon(self, port, config):
@@ -671,8 +674,9 @@ class Client(object):
         """
         return self.__started_standalone
 
+    @deprecated
     def is_classicmode(self):
-        """Deprecated"""
+        """Deprecated: Use is_standalone"""
         self.is_standalone()
 
     def connected(self):

--- a/deluge/ui/console/modes/torrentdetail.py
+++ b/deluge/ui/console/modes/torrentdetail.py
@@ -565,7 +565,7 @@ class TorrentDetail(BaseMode, PopupsHandler):
         self.build_prio_list(self.file_list, plist, -1, data)
         plist.sort()
         priorities = [p[1] for p in plist]
-        client.core.set_torrent_file_priorities(self.torrentid, priorities)
+        client.core.set_torrent_options([self.torrent_id], {'file_priorities': priorities})
 
         if was_empty:
             self.marked = {}

--- a/deluge/ui/gtkui/files_tab.py
+++ b/deluge/ui/gtkui/files_tab.py
@@ -541,8 +541,7 @@ class FilesTab(Tab):
         file_priorities.sort()
         priorities = [p[1] for p in file_priorities]
         log.debug('priorities: %s', priorities)
-
-        client.core.set_torrent_file_priorities(self.torrent_id, priorities)
+        client.core.set_torrent_options([self.torrent_id], {'file_priorities': priorities})
 
     def _on_menuitem_donotdownload_activate(self, menuitem):
         self._set_file_priorities_on_user_change(

--- a/deluge/ui/gtkui/menubar.py
+++ b/deluge/ui/gtkui/menubar.py
@@ -404,14 +404,14 @@ class MenuBar(component.Component):
     def on_menuitem_set_unlimited(self, widget):
         log.debug('widget name: %s', widget.get_name())
         funcs = {
-            'menuitem_down_speed': client.core.set_torrent_max_download_speed,
-            'menuitem_up_speed': client.core.set_torrent_max_upload_speed,
-            'menuitem_max_connections': client.core.set_torrent_max_connections,
-            'menuitem_upload_slots': client.core.set_torrent_max_upload_slots
+            'menuitem_down_speed': 'max_download_speed',
+            'menuitem_up_speed': 'max_upload_speed',
+            'menuitem_max_connections': 'max_connections',
+            'menuitem_upload_slots': 'max_upload_slots'
         }
         if widget.get_name() in funcs.keys():
-            for torrent in component.get('TorrentView').get_selected_torrents():
-                funcs[widget.get_name()](torrent, -1)
+            torrent_ids = component.get('TorrentView').get_selected_torrents()
+            client.core.set_torrent_options(torrent_ids, {funcs[widget.get_name()]: -1})
 
     def on_menuitem_set_other(self, widget):
         log.debug('widget name: %s', widget.get_name())
@@ -465,12 +465,12 @@ class MenuBar(component.Component):
         d.addCallback(_on_torrent_status)
 
     def on_menuitem_set_automanaged_on(self, widget):
-        for torrent in component.get('TorrentView').get_selected_torrents():
-            client.core.set_torrent_auto_managed(torrent, True)
+        client.core.set_torrent_options(component.get('TorrentView').get_selected_torrents(),
+                                        {'auto_managed': True})
 
     def on_menuitem_set_automanaged_off(self, widget):
-        for torrent in component.get('TorrentView').get_selected_torrents():
-            client.core.set_torrent_auto_managed(torrent, False)
+        client.core.set_torrent_options(component.get('TorrentView').get_selected_torrents(),
+                                        {'auto_managed': False})
 
     def on_menuitem_set_stop_seed_at_ratio_disable(self, widget):
         client.core.set_torrent_options(component.get('TorrentView').get_selected_torrents(),
@@ -556,5 +556,5 @@ class MenuBar(component.Component):
                     _('There was an error while trying changing ownership.'),
                     self.mainwindow.window, details=failure.value.logable()
                 ).run()
-            client.core.set_owner(
-                update_torrents, username).addErrback(failed_change_owner)
+            client.core.set_torrent_options(
+                update_torrents, {'owner': username}).addErrback(failed_change_owner)

--- a/deluge/ui/gtkui/options_tab.py
+++ b/deluge/ui/gtkui/options_tab.py
@@ -162,38 +162,34 @@ class OptionsTab(Tab):
             self.prev_status = status
 
     def _on_button_apply_clicked(self, button):
+        options = {}
         if self.spin_max_download.get_value() != self.prev_status['max_download_speed']:
-            client.core.set_torrent_max_download_speed(self.prev_torrent_id, self.spin_max_download.get_value())
+            options['max_download_speed'] = self.spin_max_download.get_value()
         if self.spin_max_upload.get_value() != self.prev_status['max_upload_speed']:
-            client.core.set_torrent_max_upload_speed(self.prev_torrent_id, self.spin_max_upload.get_value())
+            options['max_upload_speed'] = self.spin_max_upload.get_value()
         if self.spin_max_connections.get_value_as_int() != self.prev_status['max_connections']:
-            client.core.set_torrent_max_connections(
-                self.prev_torrent_id, self.spin_max_connections.get_value_as_int())
+            options['max_connections'] = self.spin_max_connections.get_value_as_int()
         if self.spin_max_upload_slots.get_value_as_int() != self.prev_status['max_upload_slots']:
-            client.core.set_torrent_max_upload_slots(
-                self.prev_torrent_id, self.spin_max_upload_slots.get_value_as_int())
+            options['max_upload_slots'] = self.spin_max_upload_slots.get_value_as_int()
         if self.chk_prioritize_first_last.get_active() != self.prev_status['prioritize_first_last']:
-            client.core.set_torrent_prioritize_first_last(
-                self.prev_torrent_id, self.chk_prioritize_first_last.get_active())
+            options['prioritize_first_last_pieces'] = self.chk_prioritize_first_last.get_active()
         if self.chk_sequential_download.get_active() != self.prev_status['sequential_download']:
-            client.core.set_torrent_options(
-                [self.prev_torrent_id], {'sequential_download': self.chk_sequential_download.get_active()})
+            options['sequential_download'] = self.chk_sequential_download.get_active()
         if self.chk_auto_managed.get_active() != self.prev_status['is_auto_managed']:
-            client.core.set_torrent_auto_managed(self.prev_torrent_id, self.chk_auto_managed.get_active())
+            options['auto_managed'] = self.chk_auto_managed.get_active()
         if self.chk_stop_at_ratio.get_active() != self.prev_status['stop_at_ratio']:
-            client.core.set_torrent_stop_at_ratio(self.prev_torrent_id, self.chk_stop_at_ratio.get_active())
+            options['stop_at_ratio'] = self.chk_stop_at_ratio.get_active()
         if self.spin_stop_ratio.get_value() != self.prev_status['stop_ratio']:
-            client.core.set_torrent_stop_ratio(self.prev_torrent_id, self.spin_stop_ratio.get_value())
+            options['stop_ratio'] = self.spin_stop_ratio.get_value()
         if self.chk_remove_at_ratio.get_active() != self.prev_status['remove_at_ratio']:
-            client.core.set_torrent_remove_at_ratio(self.prev_torrent_id, self.chk_remove_at_ratio.get_active())
+            options['remove_at_ratio'] = self.chk_remove_at_ratio.get_active()
         if self.chk_move_completed.get_active() != self.prev_status['move_on_completed']:
-            client.core.set_torrent_move_completed(self.prev_torrent_id, self.chk_move_completed.get_active())
+            options['move_completed'] = self.chk_move_completed.get_active()
         if self.chk_move_completed.get_active():
-            path = self.move_completed_path_chooser.get_text()
-            client.core.set_torrent_move_completed_path(self.prev_torrent_id, path)
+            options['move_completed_path'] = self.move_completed_path_chooser.get_text()
         if self.chk_shared.get_active() != self.prev_status['shared']:
-            client.core.set_torrents_shared(self.prev_torrent_id, self.chk_shared.get_active())
-
+            options['shared'] = self.chk_shared.get_active()
+        client.core.set_torrent_options([self.prev_torrent_id], options)
         self.button_apply.set_sensitive(False)
 
     def _on_chk_move_completed_toggled(self, widget):

--- a/deluge/ui/web/js/deluge-all/details/FilesTab.js
+++ b/deluge/ui/web/js/deluge-all/details/FilesTab.js
@@ -183,7 +183,7 @@ Deluge.details.FilesTab = Ext.extend(Ext.ux.tree.TreeGrid, {
                     priorities[index] = indexes[index];
                 }
 
-                deluge.client.core.set_torrent_file_priorities(this.torrentId, priorities, {
+                deluge.client.core.set_torrent_options([this.torrentId], {'file_priorities': priorities})
                     success: function() {
                         Ext.each(nodes, function(node) {
                             node.setColumnValue(3, baseItem.filePriority);

--- a/deluge/ui/web/js/deluge-all/details/OptionsTab.js
+++ b/deluge/ui/web/js/deluge-all/details/OptionsTab.js
@@ -367,15 +367,6 @@ Deluge.details.OptionsTab = Ext.extend(Ext.form.FormPanel, {
 
     onApply: function() {
         var changed = this.optionsManager.getDirty();
-        if (!Ext.isEmpty(changed['prioritize_first_last'])) {
-            var value = changed['prioritize_first_last'];
-            deluge.client.core.set_torrent_prioritize_first_last(this.torrentId, value, {
-                success: function() {
-                    this.optionsManager.set('prioritize_first_last', value);
-                },
-                scope: this
-            });
-        }
         deluge.client.core.set_torrent_options([this.torrentId], changed, {
             success: function() {
                 this.optionsManager.commit();
@@ -405,6 +396,7 @@ Deluge.details.OptionsTab = Ext.extend(Ext.form.FormPanel, {
         this.fields['private'].setDisabled(true);
         delete torrent['private'];
         torrent['auto_managed'] = torrent['is_auto_managed'];
+        torrent['prioritize_first_last_pieces'] = torrent['prioritize_first_last'];
         this.optionsManager.setDefault(torrent);
         var stop_at_ratio = this.optionsManager.get('stop_at_ratio');
         this.fields.remove_at_ratio.setDisabled(!stop_at_ratio);


### PR DESCRIPTION
Manually Testing required of:

- [x]  GTKUI Options Tab

- [x]  GTKUI menubar options can be set

- [x] GTKUI FilesTab file priority change

- [x] WebUI FilesTab file priority change

- [x] WebUI Options tab can set priority_first_last_pieces

- [x] Console UI  file priority change

- [x] Setting owner works as before but via set_torrent_options

- [x] Should we convert a basestring torrent_id in set_torrent_options into a list?
