### PR TITLE
Feature/py gi gtk3 compatible

### DIFF
--- a/deluge/ui/gtkui/common.py
+++ b/deluge/ui/gtkui/common.py
@@ -23,6 +23,10 @@ import deluge.common
 log = logging.getLogger(__name__)
 
 
+def is_pygi_gtk3():
+    return gtk.gtk_version[0] == 3
+
+
 def get_logo(size):
     """A Deluge logo.
 

--- a/deluge/ui/gtkui/files_tab.py
+++ b/deluge/ui/gtkui/files_tab.py
@@ -20,7 +20,7 @@ from gobject import TYPE_UINT64
 import deluge.component as component
 from deluge.common import FILE_PRIORITY, open_file, show_file
 from deluge.ui.client import client
-from deluge.ui.gtkui.common import (listview_replace_treestore, load_pickled_state_file, reparent_iter,
+from deluge.ui.gtkui.common import (is_pygi_gtk3, listview_replace_treestore, load_pickled_state_file, reparent_iter,
                                     save_pickled_state_file)
 from deluge.ui.gtkui.torrentdetails import Tab
 from deluge.ui.gtkui.torrentview_data_funcs import cell_data_size
@@ -496,7 +496,11 @@ class FilesTab(Tab):
             for widget in self.file_menu_priority_items:
                 widget.set_sensitive(not self.__is_seed)
 
-            self.file_menu.popup(None, None, None, event.button, event.time)
+            popup_args = [None, None, None, event.button, event.time, None]
+            if is_pygi_gtk3():
+                # Move func data from end to index 3.
+                popup_args.insert(3, popup_args.pop())
+            self.file_menu.popup(*popup_args)
             return True
 
     def _on_key_press_event(self, widget, event):
@@ -508,7 +512,11 @@ class FilesTab(Tab):
                 return func(event)
 
     def keypress_menu(self, event):
-        self.file_menu.popup(None, None, None, 3, event.time)
+        popup_args = [None, None, None, 3, event.time, None]
+        if is_pygi_gtk3():
+            # Move func data from end to index 3.
+            popup_args.insert(3, popup_args.pop())
+        self.file_menu.popup(*popup_args)
         return True
 
     def keypress_f2(self, event):

--- a/deluge/ui/gtkui/filtertreeview.py
+++ b/deluge/ui/gtkui/filtertreeview.py
@@ -342,7 +342,11 @@ class FilterTreeView(component.Component):
             # Show the pop-up menu
             self.set_menu_sensitivity()
             self.menu.hide()
-            self.menu.popup(None, None, None, event.button, event.time)
+            popup_args = [None, None, None, event.button, event.time, None]
+            if is_pygi_gtk3():
+                # Move func data from end to index 3.
+                popup_args.insert(3, popup_args.pop())
+            self.menu.popup(*popup_args)
             self.menu.show()
 
             if cat == 'cat':

--- a/deluge/ui/gtkui/glade/add_torrent_dialog.ui
+++ b/deluge/ui/gtkui/glade/add_torrent_dialog.ui
@@ -293,7 +293,6 @@
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="show_border">False</property>
-                    <property name="tab_vborder">1</property>
                     <child>
                       <object class="GtkScrolledWindow" id="scrolledwindow2">
                         <property name="visible">True</property>

--- a/deluge/ui/gtkui/glade/main_window.tabs.ui
+++ b/deluge/ui/gtkui/glade/main_window.tabs.ui
@@ -43,7 +43,6 @@
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="tab_pos">left</property>
-        <property name="tab_hborder">8</property>
         <child>
           <object class="GtkScrolledWindow" id="status_tab">
             <property name="visible">True</property>

--- a/deluge/ui/gtkui/glade/main_window.ui
+++ b/deluge/ui/gtkui/glade/main_window.ui
@@ -768,8 +768,6 @@ This will filter torrents for the current selection on the sidebar.</property>
                     <property name="tab_pos">left</property>
                     <property name="show_border">False</property>
                     <property name="scrollable">True</property>
-                    <property name="tab_hborder">8</property>
-                    <property name="tab_vborder">0</property>
                   </object>
                   <packing>
                     <property name="resize">False</property>

--- a/deluge/ui/gtkui/listview.py
+++ b/deluge/ui/gtkui/listview.py
@@ -12,7 +12,7 @@ import logging
 import gtk
 from gobject import SIGNAL_RUN_LAST, TYPE_NONE, signal_new
 
-from deluge.ui.gtkui.common import load_pickled_state_file, save_pickled_state_file
+from deluge.ui.gtkui.common import is_pygi_gtk3, load_pickled_state_file, save_pickled_state_file
 
 signal_new('button-press-event', gtk.TreeViewColumn, SIGNAL_RUN_LAST, TYPE_NONE, (gtk.gdk.Event,))
 
@@ -322,7 +322,11 @@ class ListView(object):
 
     def on_treeview_header_right_clicked(self, column, event):
         if event.button == 3:
-            self.menu.popup(None, None, None, event.button, event.get_time())
+            popup_args = [None, None, None, event.button, event.time, None]
+            if is_pygi_gtk3():
+                # Move func data from end to index 3.
+                popup_args.insert(3, popup_args.pop())
+            self.menu.popup(*popup_args)
 
     def register_checklist_menu(self, menu):
         """Register a checklist menu with the listview.  It will automatically

--- a/deluge/ui/gtkui/mainwindow.py
+++ b/deluge/ui/gtkui/mainwindow.py
@@ -112,7 +112,7 @@ class MainWindow(component.Component):
         self.window.connect('delete-event', self.on_window_delete_event)
         self.window.connect('drag-data-received', self.on_drag_data_received_event)
         self.vpaned.connect('notify::position', self.on_vpaned_position_event)
-        self.window.connect('expose-event', self.on_expose_event)
+        self.window.connect('draw', self.on_draw_event)
 
         self.config.register_set_function('show_rate_in_title', self._on_set_show_rate_in_title, apply_now=False)
 
@@ -293,7 +293,7 @@ class MainWindow(component.Component):
             process_args(selection_data.get_text().split())
         drag_context.finish(True, True, timestamp)
 
-    def on_expose_event(self, widget, event):
+    def on_draw_event(self, widget, event):
         component.get('SystemTray').blink(False)
 
     def stop(self):

--- a/deluge/ui/gtkui/mainwindow.py
+++ b/deluge/ui/gtkui/mainwindow.py
@@ -18,9 +18,9 @@ from twisted.internet.error import ReactorNotRunning
 
 import deluge.common
 import deluge.component as component
-import deluge.ui.gtkui.common
 from deluge.configmanager import ConfigManager
 from deluge.ui.client import client
+from deluge.ui.gtkui.common import get_deluge_icon, is_pygi_gtk3
 from deluge.ui.gtkui.dialogs import PasswordDialog
 from deluge.ui.gtkui.ipcinterface import process_args
 
@@ -66,7 +66,14 @@ class MainWindow(component.Component):
         # Think about splitting up the main window gtkbuilder file into the necessary parts
         # in order not to have to monkey patch GtkBuilder. Those parts would then need to
         # be added to the main window "by hand".
-        self.main_builder.prev_connect_signals = copy.deepcopy(self.main_builder.connect_signals)
+        if is_pygi_gtk3():
+            # FIXME: The deepcopy is not an option with GTK3
+            # and raises "GObject descendants' instances are non-copyable"
+            # If signals are added correctly is this still needed?
+            self.main_builder.prev_connect_signals = self.main_builder.connect_signals
+        else:
+            # Fallback to PyGTK
+            self.main_builder.prev_connect_signals = copy.deepcopy(self.main_builder.connect_signals)
 
         def patched_connect_signals(*a, **k):
             raise RuntimeError('In order to connect signals to this GtkBuilder instance please use '
@@ -91,7 +98,7 @@ class MainWindow(component.Component):
 
         self.window = self.main_builder.get_object('main_window')
 
-        self.window.set_icon(deluge.ui.gtkui.common.get_deluge_icon())
+        self.window.set_icon(get_deluge_icon())
         self.vpaned = self.main_builder.get_object('vpaned')
 
         self.initial_vpaned_position = self.config['window_pane_position']
@@ -104,7 +111,8 @@ class MainWindow(component.Component):
         self.is_minimized = False
         self.restart = False
 
-        self.window.drag_dest_set(gtk.DEST_DEFAULT_ALL, [('text/uri-list', 0, 80)], gtk.gdk.ACTION_COPY)
+        self.window.drag_dest_set(gtk.DEST_DEFAULT_ALL, [], gtk.gdk.ACTION_COPY)
+        self.window.drag_dest_add_text_targets()
 
         # Connect events
         self.window.connect('window-state-event', self.on_window_state_event)
@@ -112,7 +120,12 @@ class MainWindow(component.Component):
         self.window.connect('delete-event', self.on_window_delete_event)
         self.window.connect('drag-data-received', self.on_drag_data_received_event)
         self.vpaned.connect('notify::position', self.on_vpaned_position_event)
-        self.window.connect('draw', self.on_draw_event)
+
+        if is_pygi_gtk3():
+            self.window.connect('draw', self.on_draw_event)
+        else:
+            # Fallback to PyGTK
+            self.window.connect('expose-event', self.on_expose_event)
 
         self.config.register_set_function('show_rate_in_title', self._on_set_show_rate_in_title, apply_now=False)
 
@@ -295,6 +308,10 @@ class MainWindow(component.Component):
 
     def on_draw_event(self, widget, event):
         component.get('SystemTray').blink(False)
+
+    def on_expose_event(self, widget, event):
+        """PyGTK compatible expose-event func"""
+        self.on_draw_event(widget, event)
 
     def stop(self):
         self.window.set_title('Deluge')

--- a/deluge/ui/gtkui/path_combo_chooser.py
+++ b/deluge/ui/gtkui/path_combo_chooser.py
@@ -19,6 +19,7 @@ from gtk import gdk, keysyms
 import deluge.component as component
 from deluge.common import resource_filename
 from deluge.path_chooser_common import get_completion_paths
+from deluge.ui.gtkui.common import is_pygi_gtk3
 
 
 def is_ascii_value(keyval, ascii_key):
@@ -390,7 +391,11 @@ class StoredValuesList(ValueList):
 
             menuitem_edit.connect('activate', on_edit_clicked, path)
             menuitem_remove.connect('activate', on_remove_clicked, path)
-            self.path_list_popup.popup(None, None, None, event.button, time, data=path)
+            popup_args = [None, None, None, event.button, time, path]
+            if is_pygi_gtk3():
+                # Move func data from end to index 3.
+                popup_args.insert(3, popup_args.pop())
+            self.path_list_popup.popup(*popup_args)
             self.path_list_popup.show_all()
 
     def remove_selected_path(self):
@@ -1081,6 +1086,7 @@ class PathChooserComboBox(gtk.HBox, StoredValuesPopup, GObject):
         old_text = self.text_entry.get_text()
         # We must block the "delete-text" signal to avoid the signal handler being called
         self.text_entry.handler_block_by_func(self.auto_completer.on_entry_text_delete_text)
+        # FIXME for pygtkcompat: "Warning: g_value_get_int: assertion 'G_VALUE_HOLDS_INT (value)' failed"
         self.text_entry.set_text(text)
         self.text_entry.handler_unblock_by_func(self.auto_completer.on_entry_text_delete_text)
 

--- a/deluge/ui/gtkui/peers_tab.py
+++ b/deluge/ui/gtkui/peers_tab.py
@@ -17,7 +17,7 @@ import deluge.common
 import deluge.component as component
 from deluge.ui.client import client
 from deluge.ui.countries import COUNTRIES
-from deluge.ui.gtkui.common import load_pickled_state_file, save_pickled_state_file
+from deluge.ui.gtkui.common import is_pygi_gtk3, load_pickled_state_file, save_pickled_state_file
 from deluge.ui.gtkui.torrentdetails import Tab
 from deluge.ui.gtkui.torrentview_data_funcs import cell_data_speed_down, cell_data_speed_up
 
@@ -308,7 +308,11 @@ class PeersTab(Tab):
         log.debug('on_button_press_event')
         # We only care about right-clicks
         if self.torrent_id and event.button == 3:
-            self.peer_menu.popup(None, None, None, event.button, event.time)
+            popup_args = [None, None, None, event.button, event.time, None]
+            if is_pygi_gtk3():
+                # Move func data from end to index 3.
+                popup_args.insert(3, popup_args.pop())
+            self.peer_menu.popup(*popup_args)
             return True
 
     def _on_query_tooltip(self, widget, x, y, keyboard_tip, tooltip):

--- a/deluge/ui/gtkui/piecesbar.py
+++ b/deluge/ui/gtkui/piecesbar.py
@@ -22,8 +22,8 @@ COLOR_STATES = ['missing', 'waiting', 'downloading', 'completed']
 
 
 class PiecesBar(gtk.DrawingArea):
-    # Draw in response to an expose-event
-    __gsignals__ = {'expose-event': 'override'}
+    # Draw in response to an draw event
+    __gsignals__ = {'draw': 'override'}
 
     def __init__(self):
         gtk.DrawingArea.__init__(self)
@@ -57,8 +57,8 @@ class PiecesBar(gtk.DrawingArea):
         self.prev_height = self.height
         self.height = size.height
 
-    # Handle the expose-event by drawing
-    def do_expose_event(self, event):
+    # Handle the draw event by drawing
+    def do_draw(self, event):
         # Create cairo context
         self.cr = self.window.cairo_create()
         self.cr.set_line_width(max(self.cr.device_to_user_distance(0.5, 0.5)))

--- a/deluge/ui/gtkui/piecesbar.py
+++ b/deluge/ui/gtkui/piecesbar.py
@@ -17,13 +17,18 @@ import pangocairo
 from cairo import FORMAT_ARGB32, Context, ImageSurface
 
 from deluge.configmanager import ConfigManager
+from deluge.ui.gtkui.common import is_pygi_gtk3
 
 COLOR_STATES = ['missing', 'waiting', 'downloading', 'completed']
 
 
 class PiecesBar(gtk.DrawingArea):
     # Draw in response to an draw event
-    __gsignals__ = {'draw': 'override'}
+    if is_pygi_gtk3():
+        __gsignals__ = {'draw': 'override'}
+    else:
+        # Fallback to PyGTK
+        __gsignals__ = {'expose-event': 'override'}
 
     def __init__(self):
         gtk.DrawingArea.__init__(self)
@@ -48,7 +53,12 @@ class PiecesBar(gtk.DrawingArea):
         self.cr = None
 
         self.connect('size-allocate', self.do_size_allocate_event)
-        self.set_colormap(gtk.gdk.colormap_get_system())
+        if is_pygi_gtk3():
+            from gi.repository import Gdk
+            self.set_visual(Gdk.Screen.get_system_visual(self.get_screen()))
+        else:
+            # Fallback to PyGTK
+            self.set_colormap(gtk.gdk.colormap_get_system())
         self.show()
 
     def do_size_allocate_event(self, widget, size):
@@ -57,10 +67,10 @@ class PiecesBar(gtk.DrawingArea):
         self.prev_height = self.height
         self.height = size.height
 
-    # Handle the draw event by drawing
     def do_draw(self, event):
+        """Handle the draw event by drawing"""
         # Create cairo context
-        self.cr = self.window.cairo_create()
+        self.cr = self.get_window().cairo_create()
         self.cr.set_line_width(max(self.cr.device_to_user_distance(0.5, 0.5)))
 
         # Restrict Cairo to the exposed area; avoid extra work
@@ -75,6 +85,10 @@ class PiecesBar(gtk.DrawingArea):
         if self.resized():
             self.prev_width = self.width
             self.prev_height = self.height
+
+    def do_expose_event(self, event):
+        """PyGTK compatible expose-event func"""
+        self.do_draw(event)
 
     def roundcorners_clipping(self):
         self.create_roundcorners_subpath(self.cr, 0, 0, self.width, self.height)

--- a/deluge/ui/gtkui/statusbar.py
+++ b/deluge/ui/gtkui/statusbar.py
@@ -18,7 +18,8 @@ import deluge.component as component
 from deluge.common import fsize, fspeed, get_pixmap
 from deluge.configmanager import ConfigManager
 from deluge.ui.client import client
-from deluge.ui.gtkui import common, dialogs
+from deluge.ui.gtkui import dialogs
+from deluge.ui.gtkui.common import build_menu_radio_list, is_pygi_gtk3
 
 log = logging.getLogger(__name__)
 
@@ -414,38 +415,44 @@ class StatusBar(component.Component):
             set_value(value)
 
     def _on_download_item_clicked(self, widget, event):
-        menu = common.build_menu_radio_list(
+        menu = build_menu_radio_list(
             self.config['tray_download_speed_list'],
             self._on_set_download_speed,
             self.max_download_speed,
             _('K/s'), show_notset=True, show_other=True)
-        menu.show_all()
-        menu.popup(None, None, None, event.button, event.time)
+        self._menu_popup(menu, event)
 
     def _on_set_download_speed(self, widget):
         log.debug('_on_set_download_speed')
         self.set_limit_value(widget, 'max_download_speed')
 
     def _on_upload_item_clicked(self, widget, event):
-        menu = common.build_menu_radio_list(
+        menu = build_menu_radio_list(
             self.config['tray_upload_speed_list'],
             self._on_set_upload_speed,
             self.max_upload_speed,
             _('K/s'), show_notset=True, show_other=True)
-        menu.show_all()
-        menu.popup(None, None, None, event.button, event.time)
+        self._menu_popup(menu, event)
 
     def _on_set_upload_speed(self, widget):
         log.debug('_on_set_upload_speed')
         self.set_limit_value(widget, 'max_upload_speed')
 
     def _on_connection_item_clicked(self, widget, event):
-        menu = common.build_menu_radio_list(
+        menu = build_menu_radio_list(
             self.config['connection_limit_list'],
             self._on_set_connection_limit,
             self.max_connections_global, show_notset=True, show_other=True)
+        self._menu_popup(menu, event)
+
+    @staticmethod
+    def _menu_popup(menu, event):
         menu.show_all()
-        menu.popup(None, None, None, event.button, event.time)
+        popup_args = [None, None, None, event.button, event.time, None]
+        if is_pygi_gtk3():
+            # Move func data from end to index 3.
+            popup_args.insert(3, popup_args.pop())
+        menu.popup(*popup_args)
 
     def _on_set_connection_limit(self, widget):
         log.debug('_on_set_connection_limit')

--- a/deluge/ui/gtkui/systemtray.py
+++ b/deluge/ui/gtkui/systemtray.py
@@ -18,7 +18,7 @@ from deluge.common import fspeed
 from deluge.configmanager import ConfigManager
 from deluge.ui.client import client
 from deluge.ui.gtkui import dialogs
-from deluge.ui.gtkui.common import build_menu_radio_list, get_logo
+from deluge.ui.gtkui.common import build_menu_radio_list, get_logo, is_pygi_gtk3
 
 try:
     import appindicator
@@ -331,7 +331,12 @@ class SystemTray(component.Component):
         if deluge.common.windows_check() or deluge.common.osx_check():
             popup_function = None
             button = 0
-        self.tray_menu.popup(None, None, popup_function, button, activate_time, status_icon)
+
+        popup_args = [None, None, popup_function, button, activate_time, status_icon]
+        if is_pygi_gtk3():
+            # Move func data to index 3.
+            popup_args.insert(3, popup_args.pop())
+        self.tray_menu.popup(*popup_args)
 
     def on_menuitem_show_deluge_activate(self, menuitem):
         log.debug('on_menuitem_show_deluge_activate')

--- a/deluge/ui/gtkui/systemtray.py
+++ b/deluge/ui/gtkui/systemtray.py
@@ -104,9 +104,17 @@ class SystemTray(component.Component):
         else:
             log.debug('Enabling the system tray icon..')
             if deluge.common.windows_check() or deluge.common.osx_check():
-                self.tray = gtk.status_icon_new_from_pixbuf(get_logo(32))
+                if is_pygi_gtk3():
+                    self.tray = gtk.StatusIcon.new_from_pixbuf(get_logo(32))
+                else:
+                    # Fallback to PyGTK
+                    self.tray = gtk.status_icon_new_from_pixbuf(get_logo(32))
             else:
-                self.tray = gtk.status_icon_new_from_icon_name('deluge')
+                if is_pygi_gtk3():
+                    self.tray = gtk.StatusIcon.new_from_icon_name('deluge')
+                else:
+                    # Fallback to PyGTK
+                    self.tray = gtk.status_icon_new_from_icon_name('deluge')
 
             self.tray.connect('activate', self.on_tray_clicked)
             self.tray.connect('popup-menu', self.on_tray_popup)

--- a/deluge/ui/gtkui/torrentview.py
+++ b/deluge/ui/gtkui/torrentview.py
@@ -19,6 +19,7 @@ from twisted.internet import reactor
 import deluge.component as component
 from deluge.ui.client import client
 from deluge.ui.gtkui import torrentview_data_funcs as funcs
+from deluge.ui.gtkui.common import is_pygi_gtk3
 from deluge.ui.gtkui.listview import ListView
 from deluge.ui.gtkui.removetorrentdialog import RemoveTorrentDialog
 
@@ -641,7 +642,11 @@ class TorrentView(ListView, component.Component):
             else:
                 self.treeview.get_selection().select_iter(row)
             torrentmenu = component.get('MenuBar').torrentmenu
-            torrentmenu.popup(None, None, None, event.button, event.time)
+            popup_args = [None, None, None, event.button, event.time, None]
+            if is_pygi_gtk3():
+                # Move func data from end to index 3.
+                popup_args.insert(3, popup_args.pop())
+            torrentmenu.popup(*popup_args)
             return True
 
     def on_selection_changed(self, treeselection):
@@ -726,5 +731,9 @@ class TorrentView(ListView, component.Component):
             return
 
         torrentmenu = component.get('MenuBar').torrentmenu
-        torrentmenu.popup(None, None, None, 3, event.time)
+        popup_args = [None, None, None, 3, event.time, None]
+        if is_pygi_gtk3():
+            # Move func data from end to index 3.
+            popup_args.insert(3, popup_args.pop())
+        torrentmenu.popup(*popup_args)
         return True

--- a/deluge/ui/gtkui/torrentview_data_funcs.py
+++ b/deluge/ui/gtkui/torrentview_data_funcs.py
@@ -14,9 +14,11 @@ from functools import partial
 
 import gtk
 from gobject import GError
+from gtk.gdk import COLORSPACE_RGB, Pixbuf
 
 import deluge.common as common
 import deluge.component as component
+from deluge.ui.gtkui.common import is_pygi_gtk3
 
 # Status icons.. Create them from file only once to avoid constantly
 # re-creating them.
@@ -84,10 +86,15 @@ def cell_data_statusicon(column, cell, model, row, data):
         pass
 
 
-def create_blank_pixbuf():
-    i = gtk.gdk.Pixbuf(gtk.gdk.COLORSPACE_RGB, True, 8, 16, 16)
-    i.fill(0x00000000)
-    return i
+def create_blank_pixbuf(width=16, height=16):
+    if is_pygi_gtk3():
+        from gi.repository.GdkPixbuf import Colorspace
+        pix = Pixbuf.new(Colorspace.RGB, True, 8, width, height)
+    else:
+        # Fallback to PyGTK
+        pix = Pixbuf(COLORSPACE_RGB, True, 8, width, height)
+    pix.fill(0x0)
+    return pix
 
 
 def set_icon(icon, cell):

--- a/deluge/ui/util/lang.py
+++ b/deluge/ui/util/lang.py
@@ -110,7 +110,7 @@ def setup_translations(setup_gettext=True, setup_pygtk=False):
             gtk.glade.bindtextdomain(domain, translations_path)
             gtk.glade.textdomain(domain)
         except Exception as ex:
-            log.error('Unable to initialize glade translation: %s', ex)
+            log.warning('Unable to initialize glade translations: %s', ex)
     if setup_gettext:
         try:
             if hasattr(locale, 'bindtextdomain'):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -42,6 +42,9 @@ class Mock(object):
     def __call__(self, *args, **kwargs):
         return Mock()
 
+    def __getitem__(self, key):
+        return None
+
     @classmethod
     def __getattr__(cls, name):
         if name in ('__file__', '__path__'):


### PR DESCRIPTION
This is an update of the GTKUI code so that it is ready for GTK3 and would require only minimal renaming to actually run. 

- [ ] Not yet decided but may remove pycompat stuff and simply merge the rest of the standard changes.

It is opening in `pycompat` mode adding the code below to `gtkui.py`. There are a few major issues such as not data showing in the tabs with no errors shown in terminal.

```diff
diff --git deluge/ui/gtkui/gtkui.py deluge/ui/gtkui/gtkui.py
index effd613..b492238 100644
--- deluge/ui/gtkui/gtkui.py
+++ deluge/ui/gtkui/gtkui.py
@@ -15,6 +15,14 @@
 import sys
 import time
 
+try:
+    from gi import pygtkcompat
+except ImportError:
+    pass
+else:
+    pygtkcompat.enable()
+    pygtkcompat.enable_gtk(version='3.0')
+
 import pygtk  # isort:skip (Required before gtk import).
 pygtk.require('2.0')  # NOQA: E402
```

Oh just a quick thanks to @doadin for the pygi branch it was quite helpful to be able to use as reference, so was not futile work :+1: 