### PR TITLE
syntax fix

### DIFF
--- a/deluge/ui/web/js/deluge-all/details/FilesTab.js
+++ b/deluge/ui/web/js/deluge-all/details/FilesTab.js
@@ -183,7 +183,7 @@ Deluge.details.FilesTab = Ext.extend(Ext.ux.tree.TreeGrid, {
                     priorities[index] = indexes[index];
                 }
 
-                deluge.client.core.set_torrent_options([this.torrentId], {'file_priorities': priorities})
+                deluge.client.core.set_torrent_options([this.torrentId], {'file_priorities': priorities}, {
                     success: function() {
                         Ext.each(nodes, function(node) {
                             node.setColumnValue(3, baseItem.filePriority);


### PR DESCRIPTION
[#495 ](https://github.com/deluge-torrent/deluge/commit/179de3b0ffebec8bf82402bcbe1f852870346057#diff-8b2a53a064d5072152197a2b0bb9fd7eL186) broke minify causing

```
$ python minify_web_js.py
deluge/ui/web/js/deluge-all-debug.js:1332: ERROR - Parse error. 'identifier' expected
                    success: function() {
                                     ^

1 error(s), 0 warning(s)
Error minifying deluge/ui/web/js/deluge-all
Minified deluge/ui/web/js/extjs/ext-extensions
```

tests ok with closure