### PR TITLE
host:port paste support

### DIFF
--- a/deluge/ui/gtkui/connectionmanager.py
+++ b/deluge/ui/gtkui/connectionmanager.py
@@ -12,6 +12,7 @@ import logging
 import os
 import time
 from socket import gethostbyname
+from urlparse import urlparse
 
 import gtk
 from twisted.internet import reactor
@@ -232,6 +233,21 @@ class ConnectionManager(component.Component):
 
         # Update the status of the hosts
         self.__update_list()
+
+    def on_entry_host_paste_clipboard(self, widget):
+        text = gtk.clipboard_get().wait_for_text().strip()
+        log.debug('on_entry_proxy_host_paste-clipboard: got paste: %s', text)
+        text = text if '//' in text else '//' + text
+        parsed = urlparse(text)
+        if parsed.hostname:
+            widget.set_text(parsed.hostname)
+            widget.emit_stop_by_name('paste-clipboard')
+        if parsed.port:
+            self.builder.get_object('spinbutton_port').set_value(parsed.port)
+        if parsed.username:
+            self.builder.get_object('entry_username').set_text(parsed.username)
+        if parsed.password:
+            self.builder.get_object('entry_password').set_text(parsed.password)
 
     # Private methods
     def __save_hostlist(self):

--- a/deluge/ui/gtkui/glade/connection_manager.addhost.ui
+++ b/deluge/ui/gtkui/glade/connection_manager.addhost.ui
@@ -114,6 +114,7 @@
                     <property name="secondary_icon_activatable">False</property>
                     <property name="primary_icon_sensitive">True</property>
                     <property name="secondary_icon_sensitive">True</property>
+                    <signal name="paste-clipboard" handler="on_entry_host_paste_clipboard" />
                   </object>
                 </child>
               </object>

--- a/deluge/ui/gtkui/glade/preferences_dialog.ui
+++ b/deluge/ui/gtkui/glade/preferences_dialog.ui
@@ -3524,6 +3524,7 @@ used sparingly.</property>
                                             <property name="secondary_icon_activatable">False</property>
                                             <property name="primary_icon_sensitive">True</property>
                                             <property name="secondary_icon_sensitive">True</property>
+                                            <signal name="paste-clipboard" handler="on_entry_proxy_host_paste_clipboard" />
                                           </object>
                                           <packing>
                                             <property name="left_attach">1</property>

--- a/deluge/ui/gtkui/preferences.py
+++ b/deluge/ui/gtkui/preferences.py
@@ -11,6 +11,7 @@
 import logging
 import os
 from hashlib import sha1 as sha
+from urlparse import urlparse
 
 import gtk
 from gtk.gdk import Color
@@ -134,6 +135,7 @@ class Preferences(component.Component):
             'on_button_cache_refresh_clicked': self._on_button_cache_refresh_clicked,
             'on_combo_encryption_changed': self._on_combo_encryption_changed,
             'on_combo_proxy_type_changed': self._on_combo_proxy_type_changed,
+            'on_entry_proxy_host_paste_clipboard': self._on_entry_proxy_host_paste_clipboard,
             'on_button_associate_magnet_clicked': self._on_button_associate_magnet_clicked,
             'on_accounts_add_clicked': self._on_accounts_add_clicked,
             'on_accounts_delete_clicked': self._on_accounts_delete_clicked,
@@ -977,6 +979,21 @@ class Preferences(component.Component):
                 self.builder.get_object(entry).show()
             else:
                 self.builder.get_object(entry).hide()
+
+    def _on_entry_proxy_host_paste_clipboard(self, widget):
+        text = gtk.clipboard_get().wait_for_text().strip()
+        log.debug('on_entry_proxy_host_paste-clipboard: got paste: %s', text)
+        text = text if '//' in text else '//' + text
+        parsed = urlparse(text)
+        if parsed.hostname:
+            widget.set_text(parsed.hostname)
+            widget.emit_stop_by_name('paste-clipboard')
+        if parsed.port:
+            self.builder.get_object('spin_proxy_port').set_value(parsed.port)
+        if parsed.username:
+            self.builder.get_object('entry_proxy_user').set_text(parsed.username)
+        if parsed.password:
+            self.builder.get_object('entry_proxy_pass').set_text(parsed.password)
 
     def _on_button_associate_magnet_clicked(self, widget):
         associate_magnet_links(True)


### PR DESCRIPTION
added a feature so that when host:port form data is pasted into proxy host field, it gets split into host and port fields
