### PR TITLE
[#2946] Workaround 1.1 libtorrent default piece priority

### DIFF
--- a/deluge/core/torrent.py
+++ b/deluge/core/torrent.py
@@ -583,7 +583,7 @@ class Torrent(object):
     def get_file_progress(self):
         """Returns the file progress as a list of floats.. 0.0 -> 1.0"""
         if not self.handle.has_metadata():
-            return 0.0
+            return []
 
         file_progress = self.handle.file_progress()
         ret = []


### PR DESCRIPTION
 * The default piece priority was changed in lt 1.1 from 1 to 4
   so in 1.3 we will simple convert them back to 1 as 4 is not used.
 * The set_file_priorities method was refactored to make the changes simpler.
 * Also include correction for get_files() so it returns an empty
   list not 0.0 if no torrent_info is available.