### PR TITLE
added slimit to setup_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -487,6 +487,7 @@ setup(
     url='http://deluge-torrent.org',
     license='GPLv3',
     cmdclass=cmdclass,
+    setup_requires=['slimit'],
     tests_require=['pytest'],
     data_files=_data_files,
     package_data=_package_data,


### PR DESCRIPTION
Added `slimit` to `setup_requires` in order to avoid `Import error: Requires slimit package for minifying WebUI files.`.

The [test failures](https://travis-ci.org/krichter722/deluge/jobs/209017439) seem to indicate a further problem which occurs after adding. It'd be good to get some feedback because the changes proposed here ease the local build with `python setup.py build && sudo python setup.py install` on Ubuntu 16.10.