### PR TITLE
Issue/plugin resources path

### DIFF
--- a/deluge/common.py
+++ b/deluge/common.py
@@ -207,15 +207,27 @@ def get_pixmap(fname):
 
 
 def resource_filename(module, path):
-    # While developing, if there's a second deluge package, installed globally
-    # and another in develop mode somewhere else, while pkg_resources.require('Deluge')
-    # returns the proper deluge instance, pkg_resources.resource_filename does
-    # not, it returns the first found on the python path, which is not good
-    # enough.
-    # This is a work-around that.
-    return pkg_resources.require('Deluge>=%s' % get_version())[0].get_resource_filename(
-        pkg_resources._manager, os.path.join(*(module.split('.') + [path]))
-    )
+    """A workaround for pkg_resources.resource_filename finding wrong package when developing
+
+    When developing and there is a second deluge package (installed globally) and
+    another in develop mode elsewhere. While pkg_resources.require('Deluge')
+    returns the proper deluge instance, resource_filename does not, it returns
+    the first found on the python path, which is not what is wanted.
+
+    Also ensures the filename path is decoded from bytes.
+
+    Args:
+        module (str): The module name in dotted notation.
+        path (str): The relative path to resource.
+
+    Returns:
+        str: The absolute resource path.
+
+    """
+    filename = pkg_resources.require('Deluge>=%s' % get_version())[0].get_resource_filename(
+        pkg_resources._manager, os.path.join(*(module.split('.') + [path])))
+
+    return decode_bytes(filename)
 
 
 def open_file(path, timestamp=None):

--- a/deluge/common.py
+++ b/deluge/common.py
@@ -109,7 +109,7 @@ def get_default_config_dir(filename=None):
     if not filename:
         filename = ''
     try:
-        return os.path.join(save_config_path('deluge'), filename)
+        return decode_bytes(os.path.join(save_config_path('deluge'), filename))
     except OSError as ex:
         log.error('Unable to use default config directory, exiting... (%s)', ex)
         sys.exit(1)

--- a/deluge/configmanager.py
+++ b/deluge/configmanager.py
@@ -111,7 +111,7 @@ def ConfigManager(config, defaults=None, file_version=1):  # NOQA: N802
 
 def set_config_dir(directory):
     """Sets the config directory, else just uses default"""
-    return _configmanager.set_config_dir(directory)
+    return _configmanager.set_config_dir(deluge.common.decode_bytes(directory))
 
 
 def get_config_dir(filename=None):

--- a/deluge/plugins/AutoAdd/deluge/plugins/autoadd/common.py
+++ b/deluge/plugins/AutoAdd/deluge/plugins/autoadd/common.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2009 GazpachoKing <chase.sterling@gmail.com>
-#
 # Basic plugin template created by:
 # Copyright (C) 2008 Martijn Voncken <mvoncken@gmail.com>
-# Copyright (C) 2007-2009 Andrew Resch <andrewresch@gmail.com>
-# Copyright (C) 2009 Damien Churchill <damoxc@gmail.com>
+#               2007-2009 Andrew Resch <andrewresch@gmail.com>
+#               2009 Damien Churchill <damoxc@gmail.com>
+#               2010 Pedro Algarvio <pedro@algarvio.me>
+#               2017 Calum Lind <calumlind+deluge@gmail.com>
 #
 # This file is part of Deluge and is licensed under GNU General Public License 3.0, or later, with
 # the additional special exception to link portions of this program with the OpenSSL library.

--- a/deluge/plugins/AutoAdd/deluge/plugins/autoadd/common.py
+++ b/deluge/plugins/AutoAdd/deluge/plugins/autoadd/common.py
@@ -14,10 +14,12 @@
 
 from __future__ import unicode_literals
 
-from os.path import join
+import os.path
 
-from deluge.common import resource_filename
+from deluge.common import decode_bytes
+
+BASE_PATH = decode_bytes(os.path.abspath(os.path.dirname(__file__)))
 
 
 def get_resource(filename):
-    return resource_filename('deluge.plugins.autoadd', join('data', filename))
+    return os.path.join(BASE_PATH, 'data', filename)

--- a/deluge/plugins/AutoAdd/deluge/plugins/autoadd/common.py
+++ b/deluge/plugins/AutoAdd/deluge/plugins/autoadd/common.py
@@ -14,10 +14,10 @@
 
 from __future__ import unicode_literals
 
-import os
+from os.path import join
 
-import pkg_resources
+from deluge.common import resource_filename
 
 
 def get_resource(filename):
-    return pkg_resources.resource_filename('deluge.plugins.autoadd', os.path.join('data', filename))
+    return resource_filename('deluge.plugins.autoadd', join('data', filename))

--- a/deluge/plugins/Blocklist/deluge/plugins/blocklist/common.py
+++ b/deluge/plugins/Blocklist/deluge/plugins/blocklist/common.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2009 Andrew Resch <andrewresch@gmail.com>
+# Basic plugin template created by:
+# Copyright (C) 2008 Martijn Voncken <mvoncken@gmail.com>
+#               2007-2009 Andrew Resch <andrewresch@gmail.com>
+#               2009 Damien Churchill <damoxc@gmail.com>
+#               2010 Pedro Algarvio <pedro@algarvio.me>
+#               2017 Calum Lind <calumlind+deluge@gmail.com>
 #
 # This file is part of Deluge and is licensed under GNU General Public License 3.0, or later, with
 # the additional special exception to link portions of this program with the OpenSSL library.

--- a/deluge/plugins/Blocklist/deluge/plugins/blocklist/common.py
+++ b/deluge/plugins/Blocklist/deluge/plugins/blocklist/common.py
@@ -9,16 +9,15 @@
 
 from __future__ import unicode_literals
 
-import os.path
 from functools import wraps
+from os.path import join
 from sys import exc_info
 
-import pkg_resources
+from deluge.common import resource_filename
 
 
 def get_resource(filename):
-    return pkg_resources.resource_filename('deluge.plugins.blocklist',
-                                           os.path.join('data', filename))
+    return resource_filename('deluge.plugins.blocklist', join('data', filename))
 
 
 def raises_errors_as(error):

--- a/deluge/plugins/Blocklist/deluge/plugins/blocklist/common.py
+++ b/deluge/plugins/Blocklist/deluge/plugins/blocklist/common.py
@@ -9,15 +9,17 @@
 
 from __future__ import unicode_literals
 
+import os.path
 from functools import wraps
-from os.path import join
 from sys import exc_info
 
-from deluge.common import resource_filename
+from deluge.common import decode_bytes
+
+BASE_PATH = decode_bytes(os.path.abspath(os.path.dirname(__file__)))
 
 
 def get_resource(filename):
-    return resource_filename('deluge.plugins.blocklist', join('data', filename))
+    return os.path.join(BASE_PATH, 'data', filename)
 
 
 def raises_errors_as(error):

--- a/deluge/plugins/Execute/deluge/plugins/execute/common.py
+++ b/deluge/plugins/Execute/deluge/plugins/execute/common.py
@@ -9,10 +9,12 @@
 
 from __future__ import unicode_literals
 
-from os.path import join
+import os.path
 
-from deluge.common import resource_filename
+from deluge.common import decode_bytes
+
+BASE_PATH = decode_bytes(os.path.abspath(os.path.dirname(__file__)))
 
 
 def get_resource(filename):
-    return resource_filename('deluge.plugins.execute', join('data', filename))
+    return os.path.join(BASE_PATH, 'data', filename)

--- a/deluge/plugins/Execute/deluge/plugins/execute/common.py
+++ b/deluge/plugins/Execute/deluge/plugins/execute/common.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2009 Andrew Resch <andrewresch@gmail.com>
+# Basic plugin template created by:
+# Copyright (C) 2008 Martijn Voncken <mvoncken@gmail.com>
+#               2007-2009 Andrew Resch <andrewresch@gmail.com>
+#               2009 Damien Churchill <damoxc@gmail.com>
+#               2010 Pedro Algarvio <pedro@algarvio.me>
+#               2017 Calum Lind <calumlind+deluge@gmail.com>
 #
 # This file is part of Deluge and is licensed under GNU General Public License 3.0, or later, with
 # the additional special exception to link portions of this program with the OpenSSL library.

--- a/deluge/plugins/Execute/deluge/plugins/execute/common.py
+++ b/deluge/plugins/Execute/deluge/plugins/execute/common.py
@@ -9,11 +9,10 @@
 
 from __future__ import unicode_literals
 
-import os.path
+from os.path import join
 
-import pkg_resources
+from deluge.common import resource_filename
 
 
 def get_resource(filename):
-    return pkg_resources.resource_filename('deluge.plugins.execute',
-                                           os.path.join('data', filename))
+    return resource_filename('deluge.plugins.execute', join('data', filename))

--- a/deluge/plugins/Extractor/deluge/plugins/extractor/common.py
+++ b/deluge/plugins/Extractor/deluge/plugins/extractor/common.py
@@ -9,10 +9,12 @@
 
 from __future__ import unicode_literals
 
-from os.path import join
+import os.path
 
-from deluge.common import resource_filename
+from deluge.common import decode_bytes
+
+BASE_PATH = decode_bytes(os.path.abspath(os.path.dirname(__file__)))
 
 
 def get_resource(filename):
-    return resource_filename('deluge.plugins.extractor', join('data', filename))
+    return os.path.join(BASE_PATH, 'data', filename)

--- a/deluge/plugins/Extractor/deluge/plugins/extractor/common.py
+++ b/deluge/plugins/Extractor/deluge/plugins/extractor/common.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2009 Andrew Resch <andrewresch@gmail.com>
+# Basic plugin template created by:
+# Copyright (C) 2008 Martijn Voncken <mvoncken@gmail.com>
+#               2007-2009 Andrew Resch <andrewresch@gmail.com>
+#               2009 Damien Churchill <damoxc@gmail.com>
+#               2010 Pedro Algarvio <pedro@algarvio.me>
+#               2017 Calum Lind <calumlind+deluge@gmail.com>
 #
 # This file is part of Deluge and is licensed under GNU General Public License 3.0, or later, with
 # the additional special exception to link portions of this program with the OpenSSL library.

--- a/deluge/plugins/Extractor/deluge/plugins/extractor/common.py
+++ b/deluge/plugins/Extractor/deluge/plugins/extractor/common.py
@@ -9,11 +9,10 @@
 
 from __future__ import unicode_literals
 
-import os
+from os.path import join
 
-import pkg_resources
+from deluge.common import resource_filename
 
 
 def get_resource(filename):
-    return pkg_resources.resource_filename('deluge.plugins.extractor',
-                                           os.path.join('data', filename))
+    return resource_filename('deluge.plugins.extractor', join('data', filename))

--- a/deluge/plugins/Label/deluge/plugins/label/common.py
+++ b/deluge/plugins/Label/deluge/plugins/label/common.py
@@ -15,4 +15,4 @@ from deluge.common import resource_filename
 
 
 def get_resource(filename):
-    return resource_filename('deluge.plugins.stats', join('data', filename))
+    return resource_filename('deluge.plugins.label', join('data', filename))

--- a/deluge/plugins/Label/deluge/plugins/label/common.py
+++ b/deluge/plugins/Label/deluge/plugins/label/common.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2009 Andrew Resch <andrewresch@gmail.com>
+# Basic plugin template created by:
+# Copyright (C) 2008 Martijn Voncken <mvoncken@gmail.com>
+#               2007-2009 Andrew Resch <andrewresch@gmail.com>
+#               2009 Damien Churchill <damoxc@gmail.com>
+#               2010 Pedro Algarvio <pedro@algarvio.me>
+#               2017 Calum Lind <calumlind+deluge@gmail.com>
 #
 # This file is part of Deluge and is licensed under GNU General Public License 3.0, or later, with
 # the additional special exception to link portions of this program with the OpenSSL library.

--- a/deluge/plugins/Label/deluge/plugins/label/common.py
+++ b/deluge/plugins/Label/deluge/plugins/label/common.py
@@ -9,10 +9,12 @@
 
 from __future__ import unicode_literals
 
-from os.path import join
+import os.path
 
-from deluge.common import resource_filename
+from deluge.common import decode_bytes
+
+BASE_PATH = decode_bytes(os.path.abspath(os.path.dirname(__file__)))
 
 
 def get_resource(filename):
-    return resource_filename('deluge.plugins.label', join('data', filename))
+    return os.path.join(BASE_PATH, 'data', filename)

--- a/deluge/plugins/Label/deluge/plugins/label/gtkui/label_config.py
+++ b/deluge/plugins/Label/deluge/plugins/label/gtkui/label_config.py
@@ -10,12 +10,12 @@
 from __future__ import unicode_literals
 
 import logging
-import os
 
-import pkg_resources  # access plugin egg
 from gtk import Builder
 
 from deluge.ui.client import client
+
+from .common import get_resource
 
 log = logging.getLogger(__name__)
 
@@ -31,7 +31,7 @@ class LabelConfig(object):
     def load(self):
         log.debug('Adding Label Preferences page')
         builder = Builder()
-        builder.add_from_file(self.get_resource('label_pref.ui'))
+        builder.add_from_file(get_resource('label_pref.ui'))
 
         self.plugin.add_preferences_page(_('Label'), builder.get_object('label_prefs_box'))
         self.plugin.register_hook('on_show_prefs', self.load_settings)
@@ -43,11 +43,6 @@ class LabelConfig(object):
         self.plugin.remove_preferences_page(_('Label'))
         self.plugin.deregister_hook('on_apply_prefs', self.on_apply_prefs)
         self.plugin.deregister_hook('on_show_prefs', self.load_settings)
-
-    def get_resource(self, filename):
-        return pkg_resources.resource_filename(
-            'deluge.plugins.label', os.path.join('data', filename)
-        )
 
     def load_settings(self, widget=None, data=None):
         client.label.get_config().addCallback(self.cb_global_options)

--- a/deluge/plugins/Label/deluge/plugins/label/gtkui/sidebar_menu.py
+++ b/deluge/plugins/Label/deluge/plugins/label/gtkui/sidebar_menu.py
@@ -17,18 +17,11 @@ import gtk
 import deluge.component as component
 from deluge.ui.client import client
 
+from .common import get_resource
+
 log = logging.getLogger(__name__)
 
 NO_LABEL = 'No Label'
-
-
-# helpers:
-def get_resource(filename):
-    import pkg_resources
-    import os
-    return pkg_resources.resource_filename(
-        'deluge.plugins.label', os.path.join('data', filename)
-    )
 
 
 # menu

--- a/deluge/plugins/Label/deluge/plugins/label/webui.py
+++ b/deluge/plugins/Label/deluge/plugins/label/webui.py
@@ -14,21 +14,14 @@
 from __future__ import unicode_literals
 
 import logging
-import os
-
-import pkg_resources
 
 from deluge.plugins.pluginbase import WebPluginBase
+
+from .common import get_resource
 
 log = logging.getLogger(__name__)
 
 
-def get_resource(filename):
-    return pkg_resources.resource_filename('deluge.plugins.label',
-                                           os.path.join('data', filename))
-
-
 class WebUI(WebPluginBase):
-
     scripts = [get_resource('label.js')]
     debug_scripts = scripts

--- a/deluge/plugins/Notifications/deluge/plugins/notifications/common.py
+++ b/deluge/plugins/Notifications/deluge/plugins/notifications/common.py
@@ -15,19 +15,21 @@
 from __future__ import unicode_literals
 
 import logging
-from os.path import join
+import os.path
 
 from twisted.internet import defer
 
 from deluge import component
-from deluge.common import resource_filename
+from deluge.common import decode_bytes
 from deluge.event import known_events
 
 log = logging.getLogger(__name__)
 
+BASE_PATH = decode_bytes(os.path.abspath(os.path.dirname(__file__)))
+
 
 def get_resource(filename):
-    return resource_filename('deluge.plugins.notifications', join('data', filename))
+    return os.path.join(BASE_PATH, 'data', filename)
 
 
 class CustomNotifications(object):

--- a/deluge/plugins/Notifications/deluge/plugins/notifications/common.py
+++ b/deluge/plugins/Notifications/deluge/plugins/notifications/common.py
@@ -15,19 +15,19 @@
 from __future__ import unicode_literals
 
 import logging
+from os.path import join
 
 from twisted.internet import defer
 
 from deluge import component
+from deluge.common import resource_filename
 from deluge.event import known_events
 
 log = logging.getLogger(__name__)
 
 
 def get_resource(filename):
-    import os
-    import pkg_resources
-    return pkg_resources.resource_filename('deluge.plugins.notifications', os.path.join('data', filename))
+    return resource_filename('deluge.plugins.notifications', join('data', filename))
 
 
 class CustomNotifications(object):

--- a/deluge/plugins/Scheduler/deluge/plugins/scheduler/common.py
+++ b/deluge/plugins/Scheduler/deluge/plugins/scheduler/common.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2009 Andrew Resch <andrewresch@gmail.com>
-#
 # Basic plugin template created by:
 # Copyright (C) 2008 Martijn Voncken <mvoncken@gmail.com>
-# Copyright (C) 2007-2009 Andrew Resch <andrewresch@gmail.com>
+#               2007-2009 Andrew Resch <andrewresch@gmail.com>
+#               2009 Damien Churchill <damoxc@gmail.com>
+#               2010 Pedro Algarvio <pedro@algarvio.me>
+#               2017 Calum Lind <calumlind+deluge@gmail.com>
 #
 # This file is part of Deluge and is licensed under GNU General Public License 3.0, or later, with
 # the additional special exception to link portions of this program with the OpenSSL library.

--- a/deluge/plugins/Scheduler/deluge/plugins/scheduler/common.py
+++ b/deluge/plugins/Scheduler/deluge/plugins/scheduler/common.py
@@ -11,11 +11,12 @@
 # See LICENSE for more details.
 #
 
-
 from __future__ import unicode_literals
+
+from os.path import join
+
+from deluge.common import resource_filename
 
 
 def get_resource(filename):
-    import os
-    import pkg_resources
-    return pkg_resources.resource_filename('deluge.plugins.scheduler', os.path.join('data', filename))
+    return resource_filename('deluge.plugins.scheduler', join('data', filename))

--- a/deluge/plugins/Scheduler/deluge/plugins/scheduler/common.py
+++ b/deluge/plugins/Scheduler/deluge/plugins/scheduler/common.py
@@ -13,10 +13,12 @@
 
 from __future__ import unicode_literals
 
-from os.path import join
+import os.path
 
-from deluge.common import resource_filename
+from deluge.common import decode_bytes
+
+BASE_PATH = decode_bytes(os.path.abspath(os.path.dirname(__file__)))
 
 
 def get_resource(filename):
-    return resource_filename('deluge.plugins.scheduler', join('data', filename))
+    return os.path.join(BASE_PATH, 'data', filename)

--- a/deluge/plugins/Stats/deluge/plugins/stats/common.py
+++ b/deluge/plugins/Stats/deluge/plugins/stats/common.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2009 Andrew Resch <andrewresch@gmail.com>
+# Basic plugin template created by:
+# Copyright (C) 2008 Martijn Voncken <mvoncken@gmail.com>
+#               2007-2009 Andrew Resch <andrewresch@gmail.com>
+#               2009 Damien Churchill <damoxc@gmail.com>
+#               2010 Pedro Algarvio <pedro@algarvio.me>
+#               2017 Calum Lind <calumlind+deluge@gmail.com>
 #
 # This file is part of Deluge and is licensed under GNU General Public License 3.0, or later, with
 # the additional special exception to link portions of this program with the OpenSSL library.

--- a/deluge/plugins/Stats/deluge/plugins/stats/common.py
+++ b/deluge/plugins/Stats/deluge/plugins/stats/common.py
@@ -9,10 +9,12 @@
 
 from __future__ import unicode_literals
 
-from os.path import join
+import os.path
 
-from deluge.common import resource_filename
+from deluge.common import decode_bytes
+
+BASE_PATH = decode_bytes(os.path.abspath(os.path.dirname(__file__)))
 
 
 def get_resource(filename):
-    return resource_filename('deluge.plugins.stats', join('data', filename))
+    return os.path.join(BASE_PATH, 'data', filename)

--- a/deluge/plugins/Toggle/deluge/plugins/toggle/common.py
+++ b/deluge/plugins/Toggle/deluge/plugins/toggle/common.py
@@ -14,10 +14,12 @@
 
 from __future__ import unicode_literals
 
-from os.path import join
+import os.path
 
-from deluge.common import resource_filename
+from deluge.common import decode_bytes
+
+BASE_PATH = decode_bytes(os.path.abspath(os.path.dirname(__file__)))
 
 
 def get_resource(filename):
-    return resource_filename('deluge.plugins.toggle', join('data', filename))
+    return os.path.join(BASE_PATH, 'data', filename)

--- a/deluge/plugins/Toggle/deluge/plugins/toggle/common.py
+++ b/deluge/plugins/Toggle/deluge/plugins/toggle/common.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2010 John Garland <johnnybg+deluge@gmail.com>
-#
 # Basic plugin template created by:
 # Copyright (C) 2008 Martijn Voncken <mvoncken@gmail.com>
-# Copyright (C) 2007-2009 Andrew Resch <andrewresch@gmail.com>
-# Copyright (C) 2009 Damien Churchill <damoxc@gmail.com>
+#               2007-2009 Andrew Resch <andrewresch@gmail.com>
+#               2009 Damien Churchill <damoxc@gmail.com>
+#               2010 Pedro Algarvio <pedro@algarvio.me>
+#               2017 Calum Lind <calumlind+deluge@gmail.com>
 #
 # This file is part of Deluge and is licensed under GNU General Public License 3.0, or later, with
 # the additional special exception to link portions of this program with the OpenSSL library.

--- a/deluge/plugins/Toggle/deluge/plugins/toggle/common.py
+++ b/deluge/plugins/Toggle/deluge/plugins/toggle/common.py
@@ -12,12 +12,12 @@
 # See LICENSE for more details.
 #
 
-
 from __future__ import unicode_literals
+
+from os.path import join
+
+from deluge.common import resource_filename
 
 
 def get_resource(filename):
-    import os.path
-    import pkg_resources
-    return pkg_resources.resource_filename('deluge.plugins.toggle',
-                                           os.path.join('data', filename))
+    return resource_filename('deluge.plugins.toggle', join('data', filename))

--- a/deluge/plugins/WebUi/deluge/plugins/webui/common.py
+++ b/deluge/plugins/WebUi/deluge/plugins/webui/common.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2009 Damien Churchill <damoxc@gmail.com>
-#
 # Basic plugin template created by:
 # Copyright (C) 2008 Martijn Voncken <mvoncken@gmail.com>
-# Copyright (C) 2007-2009 Andrew Resch <andrewresch@gmail.com>
+#               2007-2009 Andrew Resch <andrewresch@gmail.com>
+#               2009 Damien Churchill <damoxc@gmail.com>
+#               2010 Pedro Algarvio <pedro@algarvio.me>
+#               2017 Calum Lind <calumlind+deluge@gmail.com>
 #
 # This file is part of Deluge and is licensed under GNU General Public License 3.0, or later, with
 # the additional special exception to link portions of this program with the OpenSSL library.

--- a/deluge/plugins/WebUi/deluge/plugins/webui/common.py
+++ b/deluge/plugins/WebUi/deluge/plugins/webui/common.py
@@ -11,12 +11,12 @@
 # See LICENSE for more details.
 #
 
-
 from __future__ import unicode_literals
+
+from os.path import join
+
+from deluge.common import resource_filename
 
 
 def get_resource(filename):
-    import os.path
-    import pkg_resources
-    return pkg_resources.resource_filename('deluge.plugins.webui',
-                                           os.path.join('data', filename))
+    return resource_filename('deluge.plugins.webui', join('data', filename))

--- a/deluge/plugins/WebUi/deluge/plugins/webui/common.py
+++ b/deluge/plugins/WebUi/deluge/plugins/webui/common.py
@@ -13,10 +13,12 @@
 
 from __future__ import unicode_literals
 
-from os.path import join
+import os.path
 
-from deluge.common import resource_filename
+from deluge.common import decode_bytes
+
+BASE_PATH = decode_bytes(os.path.abspath(os.path.dirname(__file__)))
 
 
 def get_resource(filename):
-    return resource_filename('deluge.plugins.webui', join('data', filename))
+    return os.path.join(BASE_PATH, 'data', filename)

--- a/deluge/scripts/create_plugin.py
+++ b/deluge/scripts/create_plugin.py
@@ -208,11 +208,14 @@ setup(
 
 COMMON = """
 
+from __future__ import unicode_literals
+
+from os.path import join
+
+from deluge.common import resource_filename
+
 def get_resource(filename):
-    import pkg_resources
-    import os
-    return pkg_resources.resource_filename('deluge.plugins.%(safe_name)s',
-                                           os.path.join('data', filename))
+    return resource_filename('deluge.plugins.%(safe_name)s', join('data', filename))
 """
 
 GTKUI = """
@@ -223,7 +226,7 @@ from deluge.ui.client import client
 from deluge.plugins.pluginbase import GtkPluginBase
 import deluge.component as component
 
-from common import get_resource
+from .common import get_resource
 
 log = logging.getLogger(__name__)
 
@@ -290,7 +293,7 @@ import logging
 from deluge.ui.client import client
 from deluge.plugins.pluginbase import WebPluginBase
 
-from common import get_resource
+from .common import get_resource
 
 log = logging.getLogger(__name__)
 

--- a/deluge/scripts/create_plugin.py
+++ b/deluge/scripts/create_plugin.py
@@ -6,6 +6,7 @@ example:
 python create_plugin.py --name MyPlugin2 --basepath . --author-name "Your Name" --author-email "yourname@example.com"
 
 """
+
 from __future__ import print_function, unicode_literals
 
 import os
@@ -107,16 +108,19 @@ def create_plugin():
 
 
 CORE = """
+from __future__ import unicode_literals
+
 import logging
-from deluge.plugins.pluginbase import CorePluginBase
+
 import deluge.configmanager
 from deluge.core.rpcserver import export
+from deluge.plugins.pluginbase import CorePluginBase
+
+log = logging.getLogger(__name__)
 
 DEFAULT_PREFS = {
     'test': 'NiNiNi'
 }
-
-log = logging.getLogger(__name__)
 
 
 class Core(CorePluginBase):
@@ -169,7 +173,7 @@ class WebUIPlugin(PluginInitBase):
 
 
 SETUP = """
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 __plugin_name__ = '%(name)s'
 __author__ = '%(author_name)s'
@@ -189,7 +193,7 @@ setup(
     author_email=__author_email__,
     url=__url__,
     license=__license__,
-    long_description=__long_description__ if __long_description__ else __description__,
+    long_description=__long_description__,
 
     packages=find_packages(),
     namespace_packages=['deluge', 'deluge.plugins'],
@@ -197,17 +201,16 @@ setup(
 
     entry_points=\"\"\"
     [deluge.plugin.core]
-    %%(plugin_name)s = deluge.plugins.%%(plugin_module)s:CorePlugin
+    %%s = deluge.plugins.%%s:CorePlugin
     [deluge.plugin.gtkui]
-    %%(plugin_name)s = deluge.plugins.%%(plugin_module)s:GtkUIPlugin
+    %%s = deluge.plugins.%%s:GtkUIPlugin
     [deluge.plugin.web]
-    %%(plugin_name)s = deluge.plugins.%%(plugin_module)s:WebUIPlugin
-    \"\"\" %% dict(plugin_name=__plugin_name__, plugin_module=__plugin_name__.lower())
+    %%s = deluge.plugins.%%s:WebUIPlugin
+    \"\"\" %% ((__plugin_name__, __plugin_name__.lower()) * 3)
 )
 """
 
 COMMON = """
-
 from __future__ import unicode_literals
 
 import os.path
@@ -223,12 +226,14 @@ def get_resource(filename):
 """
 
 GTKUI = """
+from __future__ import unicode_literals
+
 import gtk
 import logging
 
-from deluge.ui.client import client
-from deluge.plugins.pluginbase import GtkPluginBase
 import deluge.component as component
+from deluge.plugins.pluginbase import GtkPluginBase
+from deluge.ui.client import client
 
 from .common import get_resource
 
@@ -293,9 +298,12 @@ GLADE = """<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 """
 
 WEBUI = """
+from __future__ import unicode_literals
+
 import logging
-from deluge.ui.client import client
+
 from deluge.plugins.pluginbase import WebPluginBase
+from deluge.ui.client import client
 
 from .common import get_resource
 
@@ -334,11 +342,11 @@ Copyright:
     },
 
     onDisable: function() {
-
+        deluge.preferences.removePage(this.prefsPage);
     },
 
     onEnable: function() {
-
+        this.prefsPage = deluge.preferences.addPage(new Deluge.ux.preferences.%(name)sPage());
     }
 });
 new %(name)sPlugin();
@@ -351,14 +359,16 @@ GPL = """#
 #
 # Basic plugin template created by:
 # Copyright (C) 2008 Martijn Voncken <mvoncken@gmail.com>
-# Copyright (C) 2007-2009 Andrew Resch <andrewresch@gmail.com>
-# Copyright (C) 2009 Damien Churchill <damoxc@gmail.com>
-# Copyright (C) 2010 Pedro Algarvio <pedro@algarvio.me>
+#               2007-2009 Andrew Resch <andrewresch@gmail.com>
+#               2009 Damien Churchill <damoxc@gmail.com>
+#               2010 Pedro Algarvio <pedro@algarvio.me>
+#               2017 Calum Lind <calumlind+deluge@gmail.com>
 #
 # This file is part of %(name)s and is licensed under GNU General Public License 3.0, or later, with
 # the additional special exception to link portions of this program with the OpenSSL library.
 # See LICENSE for more details.
 #
+
 """
 
 NAMESPACE_INIT = """# this is a namespace package

--- a/deluge/scripts/create_plugin.py
+++ b/deluge/scripts/create_plugin.py
@@ -210,12 +210,16 @@ COMMON = """
 
 from __future__ import unicode_literals
 
-from os.path import join
+import os.path
 
-from deluge.common import resource_filename
+from deluge.common import decode_bytes
+
+BASE_PATH = decode_bytes(os.path.abspath(os.path.dirname(__file__)))
+
 
 def get_resource(filename):
-    return resource_filename('deluge.plugins.%(safe_name)s', join('data', filename))
+    return os.path.join(BASE_PATH, 'data', filename)
+
 """
 
 GTKUI = """


### PR DESCRIPTION
This branch is attempting to deal with the non-ascii issue in [#2341](http://dev.deluge-torrent.org/ticket/2341) and unify the access to resources by plugins.

 - I've ensured pkg_resources.resource_filename filepath is decoded.
 - However I realised it seems unnecessary to use a `pkg_resources` lookup when the plugin `data` dir is a relative path and a call to `abspath` would resolve an absolute path.

- [x] Perhaps need to decode abspath to string...

There is another option to get the entire file as a buffer string using [`pkgutil.get_data`](https://docs.python.org/2/library/pkgutil.html#pkgutil.get_data) which can be used with `gtk.glade.xml_new_from_buffer` (instead of `gtk.glade.XML(filename)`)