### PR TITLE
Refactor/gtk tabs

### DIFF
--- a/deluge/core/torrent.py
+++ b/deluge/core/torrent.py
@@ -977,6 +977,7 @@ class Torrent(object):
             'download_payload_rate': lambda: self.status.download_payload_rate,
             'file_priorities': self.get_file_priorities,
             'hash': lambda: self.torrent_id,
+            'auto_managed': lambda: self.options['auto_managed'],
             'is_auto_managed': lambda: self.options['auto_managed'],
             'is_finished': lambda: self.is_finished,
             'max_connections': lambda: self.options['max_connections'],

--- a/deluge/ui/gtkui/addtorrentdialog.py
+++ b/deluge/ui/gtkui/addtorrentdialog.py
@@ -53,18 +53,7 @@ class AddTorrentDialog(component.Component):
 
         self.dialog.connect('delete-event', self._on_delete_event)
 
-        self.builder.connect_signals({
-            'on_button_file_clicked': self._on_button_file_clicked,
-            'on_button_url_clicked': self._on_button_url_clicked,
-            'on_button_hash_clicked': self._on_button_hash_clicked,
-            'on_button_remove_clicked': self._on_button_remove_clicked,
-            'on_button_trackers_clicked': self._on_button_trackers_clicked,
-            'on_button_cancel_clicked': self._on_button_cancel_clicked,
-            'on_button_add_clicked': self._on_button_add_clicked,
-            'on_button_apply_clicked': self._on_button_apply_clicked,
-            'on_button_revert_clicked': self._on_button_revert_clicked,
-            'on_chk_move_completed_toggled': self._on_chk_move_completed_toggled
-        })
+        self.builder.connect_signals(self)
 
         # download?, path, filesize, sequence number, inconsistent?
         self.files_treestore = gtk.TreeStore(
@@ -517,8 +506,8 @@ class AddTorrentDialog(component.Component):
             _iter = self.files_treestore.iter_next(_iter)
         return this_level_toggle
 
-    def _on_button_file_clicked(self, widget):
-        log.debug('_on_button_file_clicked')
+    def on_button_file_clicked(self, widget):
+        log.debug('on_button_file_clicked')
         # Setup the filechooserdialog
         chooser = gtk.FileChooserDialog(
             _('Choose a .torrent file'),
@@ -561,8 +550,8 @@ class AddTorrentDialog(component.Component):
         chooser.destroy()
         self.add_from_files(result)
 
-    def _on_button_url_clicked(self, widget):
-        log.debug('_on_button_url_clicked')
+    def on_button_url_clicked(self, widget):
+        log.debug('on_button_url_clicked')
         dialog = self.builder.get_object('url_dialog')
         entry = self.builder.get_object('entry_url')
 
@@ -647,8 +636,8 @@ class AddTorrentDialog(component.Component):
         os.close(tmp_fd)
         d.addCallbacks(on_download_success, on_download_fail)
 
-    def _on_button_hash_clicked(self, widget):
-        log.debug('_on_button_hash_clicked')
+    def on_button_hash_clicked(self, widget):
+        log.debug('on_button_hash_clicked')
         dialog = self.builder.get_object('dialog_infohash')
         entry = self.builder.get_object('entry_hash')
         textview = self.builder.get_object('text_trackers')
@@ -683,8 +672,8 @@ class AddTorrentDialog(component.Component):
         textview.get_buffer().set_text('')
         dialog.hide()
 
-    def _on_button_remove_clicked(self, widget):
-        log.debug('_on_button_remove_clicked')
+    def on_button_remove_clicked(self, widget):
+        log.debug('on_button_remove_clicked')
         (model, row) = self.listview_torrents.get_selection().get_selected()
         if row is None:
             return
@@ -695,15 +684,15 @@ class AddTorrentDialog(component.Component):
         del self.files[torrent_id]
         del self.infos[torrent_id]
 
-    def _on_button_trackers_clicked(self, widget):
-        log.debug('_on_button_trackers_clicked')
+    def on_button_trackers_clicked(self, widget):
+        log.debug('on_button_trackers_clicked')
 
-    def _on_button_cancel_clicked(self, widget):
-        log.debug('_on_button_cancel_clicked')
+    def on_button_cancel_clicked(self, widget):
+        log.debug('on_button_cancel_clicked')
         self.hide()
 
-    def _on_button_add_clicked(self, widget):
-        log.debug('_on_button_add_clicked')
+    def on_button_add_clicked(self, widget):
+        log.debug('on_button_add_clicked')
         self.add_torrents()
         self.hide()
 
@@ -745,8 +734,8 @@ class AddTorrentDialog(component.Component):
                 log.info('Successfully added %d torrents.', len(torrents_to_add))
         client.core.add_torrent_files(torrents_to_add).addCallback(on_torrents_added)
 
-    def _on_button_apply_clicked(self, widget):
-        log.debug('_on_button_apply_clicked')
+    def on_button_apply_clicked(self, widget):
+        log.debug('on_button_apply_clicked')
         (model, row) = self.listview_torrents.get_selection().get_selected()
         if row is None:
             return
@@ -764,8 +753,8 @@ class AddTorrentDialog(component.Component):
             self.options[torrent_id].update(options)
             row = model.iter_next(row)
 
-    def _on_button_revert_clicked(self, widget):
-        log.debug('_on_button_revert_clicked')
+    def on_button_revert_clicked(self, widget):
+        log.debug('on_button_revert_clicked')
         (model, row) = self.listview_torrents.get_selection().get_selected()
         if row is None:
             return
@@ -773,7 +762,7 @@ class AddTorrentDialog(component.Component):
         del self.options[model.get_value(row, 0)]
         self.set_default_options()
 
-    def _on_chk_move_completed_toggled(self, widget):
+    def on_chk_move_completed_toggled(self, widget):
         value = widget.get_active()
         self.move_completed_path_chooser.set_sensitive(value)
 

--- a/deluge/ui/gtkui/createtorrentdialog.py
+++ b/deluge/ui/gtkui/createtorrentdialog.py
@@ -57,17 +57,7 @@ class CreateTorrentDialog(object):
         self.dialog = self.builder.get_object('create_torrent_dialog')
         self.dialog.set_transient_for(component.get('MainWindow').window)
 
-        self.builder.connect_signals({
-            'on_button_file_clicked': self._on_button_file_clicked,
-            'on_button_folder_clicked': self._on_button_folder_clicked,
-            'on_button_remote_path_clicked': self._on_button_remote_path_clicked,
-            'on_button_cancel_clicked': self._on_button_cancel_clicked,
-            'on_button_save_clicked': self._on_button_save_clicked,
-            'on_button_up_clicked': self._on_button_up_clicked,
-            'on_button_add_clicked': self._on_button_add_clicked,
-            'on_button_remove_clicked': self._on_button_remove_clicked,
-            'on_button_down_clicked': self._on_button_down_clicked
-        })
+        self.builder.connect_signals(self)
 
         # path, icon, size
         self.files_treestore = gtk.TreeStore(str, str, TYPE_UINT64)
@@ -132,8 +122,8 @@ class CreateTorrentDialog(object):
                 self.builder.get_object('combo_piece_size').set_active(index)
                 break
 
-    def _on_button_file_clicked(self, widget):
-        log.debug('_on_button_file_clicked')
+    def on_button_file_clicked(self, widget):
+        log.debug('on_button_file_clicked')
         # Setup the filechooserdialog
         chooser = gtk.FileChooserDialog(_('Choose a file'),
                                         self.dialog,
@@ -161,8 +151,8 @@ class CreateTorrentDialog(object):
         self.adjust_piece_size()
         chooser.destroy()
 
-    def _on_button_folder_clicked(self, widget):
-        log.debug('_on_button_folder_clicked')
+    def on_button_folder_clicked(self, widget):
+        log.debug('on_button_folder_clicked')
         # Setup the filechooserdialog
         chooser = gtk.FileChooserDialog(_('Choose a folder'),
                                         self.dialog,
@@ -189,8 +179,8 @@ class CreateTorrentDialog(object):
         self.adjust_piece_size()
         chooser.destroy()
 
-    def _on_button_remote_path_clicked(self, widget):
-        log.debug('_on_button_remote_path_clicked')
+    def on_button_remote_path_clicked(self, widget):
+        log.debug('on_button_remote_path_clicked')
         dialog = self.builder.get_object('remote_path_dialog')
         entry = self.builder.get_object('entry_path')
         dialog.set_transient_for(self.dialog)
@@ -212,12 +202,12 @@ class CreateTorrentDialog(object):
 
         dialog.hide()
 
-    def _on_button_cancel_clicked(self, widget):
-        log.debug('_on_button_cancel_clicked')
+    def on_button_cancel_clicked(self, widget):
+        log.debug('on_button_cancel_clicked')
         self.dialog.destroy()
 
-    def _on_button_save_clicked(self, widget):
-        log.debug('_on_button_save_clicked')
+    def on_button_save_clicked(self, widget):
+        log.debug('on_button_save_clicked')
         if len(self.files_treestore) == 0:
             return
 
@@ -393,8 +383,8 @@ class CreateTorrentDialog(object):
             # crash the UI while updating it.
             idle_add(update_pbar_with_gobject, percent)
 
-    def _on_button_up_clicked(self, widget):
-        log.debug('_on_button_up_clicked')
+    def on_button_up_clicked(self, widget):
+        log.debug('on_button_up_clicked')
         row = self.builder.get_object('tracker_treeview').get_selection().get_selected()[1]
         if row is None:
             return
@@ -403,15 +393,15 @@ class CreateTorrentDialog(object):
         else:
             self.trackers_liststore[row][0] -= 1
 
-    def _on_button_down_clicked(self, widget):
-        log.debug('_on_button_down_clicked')
+    def on_button_down_clicked(self, widget):
+        log.debug('on_button_down_clicked')
         row = self.builder.get_object('tracker_treeview').get_selection().get_selected()[1]
         if row is None:
             return
         self.trackers_liststore[row][0] += 1
 
-    def _on_button_add_clicked(self, widget):
-        log.debug('_on_button_add_clicked')
+    def on_button_add_clicked(self, widget):
+        log.debug('on_button_add_clicked')
         builder = gtk.Builder()
         builder.add_from_file(resource_filename(
             'deluge.ui.gtkui', os.path.join('glade', 'edit_trackers.add.ui')
@@ -441,8 +431,8 @@ class CreateTorrentDialog(object):
 
         dialog.destroy()
 
-    def _on_button_remove_clicked(self, widget):
-        log.debug('_on_button_remove_clicked')
+    def on_button_remove_clicked(self, widget):
+        log.debug('on_button_remove_clicked')
         row = self.builder.get_object('tracker_treeview').get_selection().get_selected()[1]
         if row is None:
             return

--- a/deluge/ui/gtkui/details_tab.py
+++ b/deluge/ui/gtkui/details_tab.py
@@ -22,28 +22,17 @@ log = logging.getLogger(__name__)
 
 class DetailsTab(Tab):
     def __init__(self):
-        super(DetailsTab, self).__init__()
-        # Get the labels we need to update.
-        # widget name, modifier function, status keys
-        main_builder = component.get('MainWindow').get_builder()
+        super(DetailsTab, self).__init__('Details', 'details_tab', 'details_tab_label')
 
-        self._name = 'Details'
-        self._child_widget = main_builder.get_object('details_tab')
-        self._tab_label = main_builder.get_object('details_tab_label')
-
-        self.label_widgets = [
-            (main_builder.get_object('summary_name'), None, ('name',)),
-            (main_builder.get_object('summary_total_size'), fsize, ('total_size',)),
-            (main_builder.get_object('summary_num_files'), str, ('num_files',)),
-            (main_builder.get_object('summary_completed'), fdate_or_dash, ('completed_time',)),
-            (main_builder.get_object('summary_date_added'), fdate, ('time_added',)),
-            (main_builder.get_object('summary_torrent_path'), None, ('download_location',)),
-            (main_builder.get_object('summary_hash'), str, ('hash',)),
-            (main_builder.get_object('summary_comments'), str, ('comment',)),
-            (main_builder.get_object('summary_pieces'), fpieces_num_size, ('num_pieces', 'piece_length')),
-        ]
-
-        self.status_keys = [status for widget in self.label_widgets for status in widget[2]]
+        self.add_tab_widget('summary_name', None, ('name',))
+        self.add_tab_widget('summary_total_size', fsize, ('total_size',))
+        self.add_tab_widget('summary_num_files', str, ('num_files',))
+        self.add_tab_widget('summary_completed', fdate_or_dash, ('completed_time',))
+        self.add_tab_widget('summary_date_added', fdate, ('time_added',))
+        self.add_tab_widget('summary_torrent_path', None, ('download_location',))
+        self.add_tab_widget('summary_hash', str, ('hash',))
+        self.add_tab_widget('summary_comments', str, ('comment',))
+        self.add_tab_widget('summary_pieces', fpieces_num_size, ('num_pieces', 'piece_length'))
 
     def update(self):
         # Get the first selected torrent
@@ -66,14 +55,14 @@ class DetailsTab(Tab):
             return
 
         # Update all the label widgets
-        for widget in self.label_widgets:
-            txt = xml_escape(self.get_status_for_widget(widget, status))
-            if widget[0].get_text() != txt:
-                if widget[2][0] == 'comment' and is_url(txt):
-                    widget[0].set_markup('<a href="%s">%s</a>' % (txt, txt))
+        for widget in self.tab_widgets.values():
+            txt = xml_escape(self.widget_status_as_fstr(widget, status))
+            if widget.obj.get_text() != txt:
+                if 'comment' in widget.status_keys and is_url(txt):
+                    widget.obj.set_markup('<a href="%s">%s</a>' % (txt, txt))
                 else:
-                    widget[0].set_markup(txt)
+                    widget.obj.set_markup(txt)
 
     def clear(self):
-        for widget in self.label_widgets:
-            widget[0].set_text('')
+        for widget in self.tab_widgets.values():
+            widget.obj.set_text('')

--- a/deluge/ui/gtkui/edittrackersdialog.py
+++ b/deluge/ui/gtkui/edittrackersdialog.py
@@ -109,18 +109,7 @@ class EditTrackersDialog(object):
             self.dialog.set_transient_for(parent)
 
         # Connect the signals
-        self.builder.connect_signals({
-            'on_button_up_clicked': self.on_button_up_clicked,
-            'on_button_add_clicked': self.on_button_add_clicked,
-            'on_button_edit_clicked': self.on_button_edit_clicked,
-            'on_button_edit_cancel_clicked': self.on_button_edit_cancel_clicked,
-            'on_button_edit_ok_clicked': self.on_button_edit_ok_clicked,
-            'on_button_remove_clicked': self.on_button_remove_clicked,
-            'on_button_down_clicked': self.on_button_down_clicked,
-            'on_button_add_ok_clicked': self.on_button_add_ok_clicked,
-            'on_button_add_cancel_clicked': self.on_button_add_cancel_clicked,
-            'on_edit_trackers_dialog_configure_event': self.on_edit_trackers_dialog_configure_event
-        })
+        self.builder.connect_signals(self)
 
         # Create a liststore for tier, url
         self.liststore = gtk.ListStore(int, str)

--- a/deluge/ui/gtkui/files_tab.py
+++ b/deluge/ui/gtkui/files_tab.py
@@ -181,15 +181,7 @@ class FilesTab(Tab):
         self.listview.connect('drag_data_get', self._on_drag_data_get_data)
         self.listview.connect('drag_data_received', self._on_drag_data_received_data)
 
-        component.get('MainWindow').connect_signals({
-            'on_menuitem_open_file_activate': self._on_menuitem_open_file_activate,
-            'on_menuitem_show_file_activate': self._on_menuitem_show_file_activate,
-            'on_menuitem_ignore_activate': self._on_menuitem_ignore_activate,
-            'on_menuitem_low_activate': self._on_menuitem_low_activate,
-            'on_menuitem_normal_activate': self._on_menuitem_normal_activate,
-            'on_menuitem_high_activate': self._on_menuitem_high_activate,
-            'on_menuitem_expand_all_activate': self._on_menuitem_expand_all_activate
-        })
+        component.get('MainWindow').connect_signals(self)
 
         # Connect to various events from the daemon
         client.register_event_handler('TorrentFileRenamedEvent', self._on_torrentfilerenamed_event)
@@ -289,7 +281,7 @@ class FilesTab(Tab):
         self.torrent_id = None
 
     def _on_row_activated(self, tree, path, view_column):
-        self._on_menuitem_open_file_activate(None)
+        self.on_menuitem_open_file_activate(None)
 
     def get_file_path(self, row, path=''):
         if not row:
@@ -498,12 +490,12 @@ class FilesTab(Tab):
                 self.listview.set_cursor(path, column, True)
                 return True
 
-    def _on_menuitem_open_file_activate(self, menuitem):
+    def on_menuitem_open_file_activate(self, menuitem):
         if client.is_localhost:
             component.get('SessionProxy').get_torrent_status(
                 self.torrent_id, ['download_location']).addCallback(self._on_open_file)
 
-    def _on_menuitem_show_file_activate(self, menuitem):
+    def on_menuitem_show_file_activate(self, menuitem):
         if client.is_localhost:
             component.get('SessionProxy').get_torrent_status(
                 self.torrent_id, ['download_location']).addCallback(self._on_show_file)
@@ -525,23 +517,23 @@ class FilesTab(Tab):
         log.debug('priorities: %s', priorities)
         client.core.set_torrent_options([self.torrent_id], {'file_priorities': priorities})
 
-    def _on_menuitem_ignore_activate(self, menuitem):
+    def on_menuitem_ignore_activate(self, menuitem):
         self._set_file_priorities_on_user_change(
             self.get_selected_files(), FILE_PRIORITY['Ignore'])
 
-    def _on_menuitem_low_activate(self, menuitem):
+    def on_menuitem_low_activate(self, menuitem):
         self._set_file_priorities_on_user_change(
             self.get_selected_files(), FILE_PRIORITY['Low'])
 
-    def _on_menuitem_normal_activate(self, menuitem):
+    def on_menuitem_normal_activate(self, menuitem):
         self._set_file_priorities_on_user_change(
             self.get_selected_files(), FILE_PRIORITY['Normal'])
 
-    def _on_menuitem_high_activate(self, menuitem):
+    def on_menuitem_high_activate(self, menuitem):
         self._set_file_priorities_on_user_change(
             self.get_selected_files(), FILE_PRIORITY['High'])
 
-    def _on_menuitem_expand_all_activate(self, menuitem):
+    def on_menuitem_expand_all_activate(self, menuitem):
         self.listview.expand_all()
 
     def _on_filename_edited(self, renderer, path, new_text):

--- a/deluge/ui/gtkui/files_tab.py
+++ b/deluge/ui/gtkui/files_tab.py
@@ -70,14 +70,9 @@ def cell_progress(column, cell, model, row, data):
 
 class FilesTab(Tab):
     def __init__(self):
-        super(FilesTab, self).__init__()
-        main_builder = component.get('MainWindow').get_builder()
+        super(FilesTab, self).__init__('Files', 'files_tab', 'files_tab_label')
 
-        self._name = 'Files'
-        self._child_widget = main_builder.get_object('files_tab')
-        self._tab_label = main_builder.get_object('files_tab_label')
-
-        self.listview = main_builder.get_object('files_listview')
+        self.listview = self.main_builder.get_object('files_listview')
         # filename, size, progress string, progress value, priority, file index, icon id
         self.treestore = gtk.TreeStore(str, TYPE_UINT64, str, float, int, int, str)
         self.treestore.set_sort_column_id(0, gtk.SORT_ASCENDING)
@@ -155,19 +150,19 @@ class FilesTab(Tab):
 
         self.listview.get_selection().set_mode(gtk.SELECTION_MULTIPLE)
 
-        self.file_menu = main_builder.get_object('menu_file_tab')
+        self.file_menu = self.main_builder.get_object('menu_file_tab')
         self.file_menu_priority_items = [
-            main_builder.get_object('menuitem_ignore'),
-            main_builder.get_object('menuitem_low'),
-            main_builder.get_object('menuitem_normal'),
-            main_builder.get_object('menuitem_high'),
-            main_builder.get_object('menuitem_priority_sep')
+            self.main_builder.get_object('menuitem_ignore'),
+            self.main_builder.get_object('menuitem_low'),
+            self.main_builder.get_object('menuitem_normal'),
+            self.main_builder.get_object('menuitem_high'),
+            self.main_builder.get_object('menuitem_priority_sep')
         ]
 
         self.localhost_widgets = [
-            main_builder.get_object('menuitem_open_file'),
-            main_builder.get_object('menuitem_show_file'),
-            main_builder.get_object('menuitem3')
+            self.main_builder.get_object('menuitem_open_file'),
+            self.main_builder.get_object('menuitem_show_file'),
+            self.main_builder.get_object('menuitem3')
         ]
 
         self.listview.connect('row-activated', self._on_row_activated)

--- a/deluge/ui/gtkui/filtertreeview.py
+++ b/deluge/ui/gtkui/filtertreeview.py
@@ -109,11 +109,7 @@ class FilterTreeView(component.Component):
         builder = gtk.Builder()
         builder.add_from_file(resource_filename('deluge.ui.gtkui', os.path.join('glade', 'filtertree_menu.ui')))
         self.menu = builder.get_object('filtertree_menu')
-        builder.connect_signals({
-            'select_all': self.on_select_all,
-            'pause_all': self.on_pause_all,
-            'resume_all': self.on_resume_all
-        })
+        builder.connect_signals(self)
 
         self.default_menu_items = self.menu.get_children()
 

--- a/deluge/ui/gtkui/glade/filtertree_menu.ui
+++ b/deluge/ui/gtkui/glade/filtertree_menu.ui
@@ -31,7 +31,7 @@
         <property name="use_underline">True</property>
         <property name="image">image22</property>
         <property name="use_stock">False</property>
-        <signal name="activate" handler="select_all" swapped="no"/>
+        <signal name="activate" handler="on_select_all" swapped="no"/>
       </object>
     </child>
     <child>
@@ -43,7 +43,7 @@
         <property name="use_underline">True</property>
         <property name="image">menu-item-image22</property>
         <property name="use_stock">False</property>
-        <signal name="activate" handler="pause_all" swapped="no"/>
+        <signal name="activate" handler="on_pause_all" swapped="no"/>
       </object>
     </child>
     <child>
@@ -56,7 +56,7 @@
         <property name="use_underline">True</property>
         <property name="image">menu-item-image23</property>
         <property name="use_stock">False</property>
-        <signal name="activate" handler="resume_all" swapped="no"/>
+        <signal name="activate" handler="on_resume_all" swapped="no"/>
       </object>
     </child>
   </object>

--- a/deluge/ui/gtkui/glade/main_window.tabs.ui
+++ b/deluge/ui/gtkui/glade/main_window.tabs.ui
@@ -1597,13 +1597,13 @@
                                     <property name="xscale">0.69999998807907104</property>
                                     <child>
                                       <object class="GtkButton" id="button_apply">
-                                        <property name="label">gtk-apply</property>
+                                        <property name="label">_Apply</property>
                                         <property name="use_action_appearance">False</property>
                                         <property name="visible">True</property>
                                         <property name="sensitive">False</property>
                                         <property name="can_focus">True</property>
                                         <property name="receives_default">True</property>
-                                        <property name="use_stock">True</property>
+                                        <property name="use_underline">True</property>
                                         <signal name="clicked" handler="on_button_apply_clicked" swapped="no"/>
                                       </object>
                                     </child>

--- a/deluge/ui/gtkui/menubar.py
+++ b/deluge/ui/gtkui/menubar.py
@@ -109,48 +109,10 @@ class MenuBar(component.Component):
         self.main_builder.get_object('sidebar_show_owners').set_active(self.config['sidebar_show_owners'])
 
         # Connect main window Signals #
-        self.mainwindow.connect_signals({
-            # File Menu
-            'on_menuitem_addtorrent_activate': self.on_menuitem_addtorrent_activate,
-            'on_menuitem_createtorrent_activate': self.on_menuitem_createtorrent_activate,
-            'on_menuitem_quitdaemon_activate': self.on_menuitem_quitdaemon_activate,
-            'on_menuitem_quit_activate': self.on_menuitem_quit_activate,
-
-            # Edit Menu
-            'on_menuitem_preferences_activate': self.on_menuitem_preferences_activate,
-            'on_menuitem_connectionmanager_activate': self.on_menuitem_connectionmanager_activate,
-
-            # View Menu
-            'on_menuitem_toolbar_toggled': self.on_menuitem_toolbar_toggled,
-            'on_menuitem_sidebar_toggled': self.on_menuitem_sidebar_toggled,
-            'on_menuitem_statusbar_toggled': self.on_menuitem_statusbar_toggled,
-
-            # Help Menu
-            'on_menuitem_homepage_activate': self.on_menuitem_homepage_activate,
-            'on_menuitem_faq_activate': self.on_menuitem_faq_activate,
-            'on_menuitem_community_activate': self.on_menuitem_community_activate,
-            'on_menuitem_about_activate': self.on_menuitem_about_activate,
-            'on_menuitem_sidebar_zero_toggled': self.on_menuitem_sidebar_zero_toggled,
-            'on_menuitem_sidebar_trackers_toggled': self.on_menuitem_sidebar_trackers_toggled,
-            'on_menuitem_sidebar_owners_toggled': self.on_menuitem_sidebar_owners_toggled
-        })
+        self.mainwindow.connect_signals(self)
 
         # Connect menubar signals
-        self.builder.connect_signals({
-            # Torrent Menu
-            'on_menuitem_pause_activate': self.on_menuitem_pause_activate,
-            'on_menuitem_resume_activate': self.on_menuitem_resume_activate,
-            'on_menuitem_updatetracker_activate': self.on_menuitem_updatetracker_activate,
-            'on_menuitem_edittrackers_activate': self.on_menuitem_edittrackers_activate,
-            'on_menuitem_remove_activate': self.on_menuitem_remove_activate,
-            'on_menuitem_recheck_activate': self.on_menuitem_recheck_activate,
-            'on_menuitem_open_folder_activate': self.on_menuitem_open_folder_activate,
-            'on_menuitem_move_activate': self.on_menuitem_move_activate,
-            'on_menuitem_queue_top_activate': self.on_menuitem_queue_top_activate,
-            'on_menuitem_queue_up_activate': self.on_menuitem_queue_up_activate,
-            'on_menuitem_queue_down_activate': self.on_menuitem_queue_down_activate,
-            'on_menuitem_queue_bottom_activate': self.on_menuitem_queue_bottom_activate
-        })
+        self.builder.connect_signals(self)
 
         self.change_sensitivity = [
             'menuitem_addtorrent'

--- a/deluge/ui/gtkui/options_tab.py
+++ b/deluge/ui/gtkui/options_tab.py
@@ -22,8 +22,9 @@ class OptionsTab(Tab):
     def __init__(self):
         super(OptionsTab, self).__init__('Options', 'options_tab', 'options_tab_label')
 
-        self.prev_torrent_id = None
+        self.prev_torrent_ids = None
         self.prev_status = None
+        self.inconsistent_keys = []
 
         # Create TabWidget items with widget id, get/set func name, status key.
         self.add_tab_widget('spin_max_download', 'value', ['max_download_speed'])
@@ -66,56 +67,89 @@ class OptionsTab(Tab):
     def stop(self):
         pass
 
+    def clear(self):
+        self.prev_torrent_ids = None
+        self.prev_status = None
+        self.inconsistent_keys = []
+
     def update(self):
-        # Get the first selected torrent
         torrent_ids = component.get('TorrentView').get_selected_torrents()
 
-        # Only use the first torrent in the list or return if None selected
+        # Set True if torrent(s) selected in torrentview, else False.
+        self._child_widget.set_sensitive(bool(torrent_ids))
+
         if torrent_ids:
-            torrent_id = torrent_ids[0]
-            self._child_widget.set_sensitive(True)
+            if torrent_ids != self.prev_torrent_ids:
+                self.clear()
+
+            component.get('SessionProxy').get_torrents_status(
+                {'id': torrent_ids}, self.status_keys
+                ).addCallback(self.parse_torrents_statuses)
+
+            self.prev_torrent_ids = torrent_ids
+
+    def parse_torrents_statuses(self, statuses):
+        """Finds common status values to all torrrents in statuses.
+
+        Values which differ are replaced with config values.
+
+
+        Args:
+            statuses (dict): A status dict of {torrent_id: {key: value}}.
+
+        Returns:
+            dict: A single status dict.
+
+        """
+        status = {}
+        if len(statuses) == 1:
+            # A single torrent so pop torrent status.
+            status = statuses.popitem()[1]
+            self.button_apply.set_label('_Apply')
         else:
-            # No torrent is selected in the torrentview
-            self._child_widget.set_sensitive(False)
-            return
+            for status_key in self.status_keys:
+                prev_value = None
+                for idx, status in enumerate(statuses.values()):
+                    if idx == 0:
+                        prev_value = status[status_key]
+                        continue
+                    elif status[status_key] != prev_value:
+                        self.inconsistent_keys.append(status_key)
+                        break
+                status[status_key] = prev_value
+            self.button_apply.set_label(_('_Apply to selected'))
 
-        if torrent_id != self.prev_torrent_id:
-            self.prev_status = None
+        self.on_get_torrent_status(status)
 
-        component.get('SessionProxy').get_torrent_status(
-            torrent_id, self.status_keys
-            ).addCallback(self.on_get_torrent_status)
-
-        self.prev_torrent_id = torrent_id
-
-    def clear(self):
-        self.prev_torrent_id = None
-        self.prev_status = None
-
-    def on_get_torrent_status(self, status):
+    def on_get_torrent_status(self, new_status):
         # So we don't overwrite the user's unapplied changes we only
         # want to update values that have been applied in the core.
         if self.prev_status is None:
-            self.prev_status = dict.fromkeys(status, None)
+            self.prev_status = dict.fromkeys(new_status, None)
 
-        if status != self.prev_status:
+        if new_status != self.prev_status:
             for widget in self.tab_widgets.values():
                 status_key = widget.status_keys[0]
-                if status[status_key] != self.prev_status[status_key]:
+                status_value = new_status[status_key]
+                if status_value != self.prev_status[status_key]:
                     set_func = 'set_' + widget.func.replace('_as_int', '')
-                    getattr(widget.obj, set_func)(status[status_key])
+                    getattr(widget.obj, set_func)(status_value)
+                    if set_func == 'set_active':
+                        widget.obj.set_inconsistent(status_key in self.inconsistent_keys)
 
-            if status['move_completed_path'] != self.prev_status['move_completed_path']:
-                self.move_completed_path_chooser.set_text(
-                    status['move_completed_path'], cursor_end=False, default_text=True)
+            if new_status['move_completed_path'] != self.prev_status['move_completed_path']:
+                text = new_status['move_completed_path']
+                self.move_completed_path_chooser.set_text(text, cursor_end=False, default_text=True)
 
             # Update sensitivity of widgets.
-            self.tab_widgets['spin_stop_ratio'].obj.set_sensitive(status['stop_at_ratio'])
-            self.tab_widgets['chk_remove_at_ratio'].obj.set_sensitive(status['stop_at_ratio'])
+            self.tab_widgets['spin_stop_ratio'].obj.set_sensitive(new_status['stop_at_ratio'])
+            self.tab_widgets['chk_remove_at_ratio'].obj.set_sensitive(new_status['stop_at_ratio'])
 
             # Ensure apply button sensitivity is set False.
             self.button_apply.set_sensitive(False)
-            self.prev_status = status
+            self.prev_status = new_status
+
+# === Widget signal handlers === #
 
     def on_button_apply_clicked(self, button):
         options = {}
@@ -124,26 +158,27 @@ class OptionsTab(Tab):
             if status_key == 'owner':
                 continue  # A label so read-only
             widget_value = getattr(widget.obj, 'get_' + widget.func)()
-            if widget_value != self.prev_status[status_key]:
+            if widget_value != self.prev_status[status_key] or (
+                    status_key in self.inconsistent_keys and not widget.obj.get_inconsistent()):
                 options[status_key] = widget_value
 
         if options.get('move_completed', False):
             options['move_completed_path'] = self.move_completed_path_chooser.get_text()
 
-        client.core.set_torrent_options([self.prev_torrent_id], options)
+        client.core.set_torrent_options(self.prev_torrent_ids, options)
         self.button_apply.set_sensitive(False)
 
     def on_chk_move_completed_toggled(self, widget):
         self.move_completed_path_chooser.set_sensitive(widget.get_active())
-        self.button_apply.set_sensitive(True)
+        self.on_chk_toggled(widget)
 
     def on_chk_stop_at_ratio_toggled(self, widget):
-        is_active = widget.get_active()
-        self.tab_widgets['spin_stop_ratio'].obj.set_sensitive(is_active)
-        self.tab_widgets['chk_remove_at_ratio'].obj.set_sensitive(is_active)
-        self.button_apply.set_sensitive(True)
+        self.tab_widgets['spin_stop_ratio'].obj.set_sensitive(widget.get_active())
+        self.tab_widgets['chk_remove_at_ratio'].obj.set_sensitive(widget.get_active())
+        self.on_chk_toggled(widget)
 
     def on_chk_toggled(self, widget):
+        widget.set_inconsistent(False)
         self.button_apply.set_sensitive(True)
 
     def on_spin_value_changed(self, widget):

--- a/deluge/ui/gtkui/options_tab.py
+++ b/deluge/ui/gtkui/options_tab.py
@@ -52,14 +52,7 @@ class OptionsTab(Tab):
         self.prev_torrent_id = None
         self.prev_status = None
 
-        component.get('MainWindow').connect_signals({
-            'on_button_apply_clicked': self._on_button_apply_clicked,
-            'on_chk_move_completed_toggled': self._on_chk_move_completed_toggled,
-            'on_chk_stop_at_ratio_toggled': self._on_chk_stop_at_ratio_toggled,
-            'on_chk_toggled': self._on_chk_toggled,
-            'on_spin_value_changed': self._on_spin_value_changed,
-            'on_move_completed_file_set': self._on_move_completed_file_set
-        })
+        component.get('MainWindow').connect_signals(self)
 
         self.spin_max_download.connect('key-press-event', self._on_key_press_event)
         self.spin_max_upload.connect('key-press-event', self._on_key_press_event)
@@ -163,7 +156,7 @@ class OptionsTab(Tab):
 
             self.prev_status = status
 
-    def _on_button_apply_clicked(self, button):
+    def on_button_apply_clicked(self, button):
         options = {}
         if self.spin_max_download.get_value() != self.prev_status['max_download_speed']:
             options['max_download_speed'] = self.spin_max_download.get_value()
@@ -194,13 +187,13 @@ class OptionsTab(Tab):
         client.core.set_torrent_options([self.prev_torrent_id], options)
         self.button_apply.set_sensitive(False)
 
-    def _on_chk_move_completed_toggled(self, widget):
+    def on_chk_move_completed_toggled(self, widget):
         value = self.chk_move_completed.get_active()
         self.move_completed_path_chooser.set_sensitive(value)
         if not self.button_apply.is_sensitive():
             self.button_apply.set_sensitive(True)
 
-    def _on_chk_stop_at_ratio_toggled(self, widget):
+    def on_chk_stop_at_ratio_toggled(self, widget):
         value = widget.get_active()
 
         self.spin_stop_ratio.set_sensitive(value)
@@ -209,11 +202,11 @@ class OptionsTab(Tab):
         if not self.button_apply.is_sensitive():
             self.button_apply.set_sensitive(True)
 
-    def _on_chk_toggled(self, widget):
+    def on_chk_toggled(self, widget):
         if not self.button_apply.is_sensitive():
             self.button_apply.set_sensitive(True)
 
-    def _on_spin_value_changed(self, widget):
+    def on_spin_value_changed(self, widget):
         if not self.button_apply.is_sensitive():
             self.button_apply.set_sensitive(True)
 
@@ -223,7 +216,7 @@ class OptionsTab(Tab):
             if not self.button_apply.is_sensitive():
                 self.button_apply.set_sensitive(True)
 
-    def _on_move_completed_file_set(self, widget):
+    def on_move_completed_file_set(self, widget):
         if not self.button_apply.is_sensitive():
             self.button_apply.set_sensitive(True)
 

--- a/deluge/ui/gtkui/peers_tab.py
+++ b/deluge/ui/gtkui/peers_tab.py
@@ -37,9 +37,7 @@ class PeersTab(Tab):
         self._child_widget = main_builder.get_object('peers_tab')
         self._tab_label = main_builder.get_object('peers_tab_label')
         self.peer_menu = main_builder.get_object('menu_peer_tab')
-        component.get('MainWindow').connect_signals({
-            'on_menuitem_add_peer_activate': self._on_menuitem_add_peer_activate,
-        })
+        component.get('MainWindow').connect_signals(self)
 
         self.listview = main_builder.get_object('peers_listview')
         self.listview.props.has_tooltip = True
@@ -325,7 +323,7 @@ class PeersTab(Tab):
             else:
                 return False
 
-    def _on_menuitem_add_peer_activate(self, menuitem):
+    def on_menuitem_add_peer_activate(self, menuitem):
         """This is a callback for manually adding a peer"""
         log.debug('on_menuitem_add_peer')
         builder = Builder()

--- a/deluge/ui/gtkui/peers_tab.py
+++ b/deluge/ui/gtkui/peers_tab.py
@@ -30,20 +30,17 @@ log = logging.getLogger(__name__)
 
 class PeersTab(Tab):
     def __init__(self):
-        super(PeersTab, self).__init__()
-        main_builder = component.get('MainWindow').get_builder()
+        super(PeersTab, self).__init__('Peers', 'peers_tab', 'peers_tab_label')
 
-        self._name = 'Peers'
-        self._child_widget = main_builder.get_object('peers_tab')
-        self._tab_label = main_builder.get_object('peers_tab_label')
-        self.peer_menu = main_builder.get_object('menu_peer_tab')
+        self.peer_menu = self.main_builder.get_object('menu_peer_tab')
         component.get('MainWindow').connect_signals(self)
 
-        self.listview = main_builder.get_object('peers_listview')
+        self.listview = self.main_builder.get_object('peers_listview')
         self.listview.props.has_tooltip = True
         self.listview.connect('button-press-event', self._on_button_press_event)
         self.listview.connect('query-tooltip', self._on_query_tooltip)
-        # country pixbuf, ip, client, downspeed, upspeed, country code, int_ip, seed/peer icon, progress
+
+        # flag, ip, client, downspd, upspd, country code, int_ip, seed/peer icon, progress
         self.liststore = ListStore(Pixbuf, str, str, int, int, str, float, Pixbuf, float)
         self.cached_flag_pixbufs = {}
 

--- a/deluge/ui/gtkui/preferences.py
+++ b/deluge/ui/gtkui/preferences.py
@@ -103,7 +103,7 @@ class Preferences(component.Component):
         password_column.set_visible(False)
         self.accounts_listview.set_model(self.accounts_liststore)
 
-        self.accounts_listview.get_selection().connect('changed', self._on_accounts_selection_changed)
+        self.accounts_listview.get_selection().connect('changed', self.on_accounts_selection_changed)
         self.accounts_frame = self.builder.get_object('AccountsFrame')
 
         # Setup plugin tab listview
@@ -124,36 +124,7 @@ class Preferences(component.Component):
 
         self.plugin_listview.get_selection().connect('changed', self.on_plugin_selection_changed)
 
-        self.builder.connect_signals({
-            'on_pref_dialog_delete_event': self.on_pref_dialog_delete_event,
-            'on_button_ok_clicked': self.on_button_ok_clicked,
-            'on_button_apply_clicked': self.on_button_apply_clicked,
-            'on_button_cancel_clicked': self.on_button_cancel_clicked,
-            'on_toggle': self.on_toggle,
-            'on_test_port_clicked': self.on_test_port_clicked,
-            'on_button_plugin_install_clicked': self._on_button_plugin_install_clicked,
-            'on_button_rescan_plugins_clicked': self._on_button_rescan_plugins_clicked,
-            'on_button_find_plugins_clicked': self._on_button_find_plugins_clicked,
-            'on_button_cache_refresh_clicked': self._on_button_cache_refresh_clicked,
-            'on_combo_encryption_changed': self._on_combo_encryption_changed,
-            'on_combo_proxy_type_changed': self._on_combo_proxy_type_changed,
-            'on_entry_proxy_host_paste_clipboard': self._on_entry_proxy_host_paste_clipboard,
-            'on_button_associate_magnet_clicked': self._on_button_associate_magnet_clicked,
-            'on_accounts_add_clicked': self._on_accounts_add_clicked,
-            'on_accounts_delete_clicked': self._on_accounts_delete_clicked,
-            'on_accounts_edit_clicked': self._on_accounts_edit_clicked,
-            'on_piecesbar_toggle_toggled': self._on_piecesbar_toggle_toggled,
-            'on_completed_color_set': self._on_completed_color_set,
-            'on_revert_color_completed_clicked': self._on_revert_color_completed_clicked,
-            'on_downloading_color_set': self._on_downloading_color_set,
-            'on_revert_color_downloading_clicked': self._on_revert_color_downloading_clicked,
-            'on_waiting_color_set': self._on_waiting_color_set,
-            'on_revert_color_waiting_clicked': self._on_revert_color_waiting_clicked,
-            'on_missing_color_set': self._on_missing_color_set,
-            'on_revert_color_missing_clicked': self._on_revert_color_missing_clicked,
-            'on_pref_dialog_configure_event': self.on_pref_dialog_configure_event,
-            'on_checkbutton_language_toggled': self._on_checkbutton_language_toggled,
-        })
+        self.builder.connect_signals(self)
 
         # Radio buttons to choose between systray and appindicator
         self.builder.get_object('alignment_tray_type').set_visible(bool(appindicator))
@@ -283,28 +254,28 @@ class Preferences(component.Component):
         if client.connected():
             self._get_accounts_tab_data()
 
-            def _on_get_config(config):
+            def on_get_config(config):
                 self.core_config = config
-                client.core.get_available_plugins().addCallback(_on_get_available_plugins)
+                client.core.get_available_plugins().addCallback(on_get_available_plugins)
 
-            def _on_get_available_plugins(plugins):
+            def on_get_available_plugins(plugins):
                 self.all_plugins = plugins
-                client.core.get_enabled_plugins().addCallback(_on_get_enabled_plugins)
+                client.core.get_enabled_plugins().addCallback(on_get_enabled_plugins)
 
-            def _on_get_enabled_plugins(plugins):
+            def on_get_enabled_plugins(plugins):
                 self.enabled_plugins = plugins
-                client.core.get_listen_port().addCallback(_on_get_listen_port)
+                client.core.get_listen_port().addCallback(on_get_listen_port)
 
-            def _on_get_listen_port(port):
+            def on_get_listen_port(port):
                 self.active_port = port
-                client.core.get_session_status(DISK_CACHE_KEYS).addCallback(_on_get_session_status)
+                client.core.get_session_status(DISK_CACHE_KEYS).addCallback(on_get_session_status)
 
-            def _on_get_session_status(status):
+            def on_get_session_status(status):
                 self.cache_status = status
                 self._show()
 
             # This starts a series of client.core requests prior to showing the window
-            client.core.get_config().addCallback(_on_get_config)
+            client.core.get_config().addCallback(on_get_config)
         else:
             self._show()
 
@@ -742,7 +713,7 @@ class Preferences(component.Component):
 
             widget.set_text(value)
 
-    def _on_button_cache_refresh_clicked(self, widget):
+    def on_button_cache_refresh_clicked(self, widget):
         def on_get_session_status(status):
             self.cache_status = status
             self.__update_cache_status()
@@ -890,8 +861,8 @@ class Preferences(component.Component):
         self.builder.get_object('label_plugin_homepage').set_text(plugin_info['Home-page'])
         self.builder.get_object('label_plugin_details').set_text(plugin_info['Description'])
 
-    def _on_button_plugin_install_clicked(self, widget):
-        log.debug('_on_button_plugin_install_clicked')
+    def on_button_plugin_install_clicked(self, widget):
+        log.debug('on_button_plugin_install_clicked')
         chooser = gtk.FileChooserDialog(
             _('Select the Plugin'),
             self.pref_dialog,
@@ -937,16 +908,16 @@ class Preferences(component.Component):
         # We need to re-show the preferences dialog to show the new plugins
         self.show()
 
-    def _on_button_rescan_plugins_clicked(self, widget):
+    def on_button_rescan_plugins_clicked(self, widget):
         component.get('PluginManager').scan_for_plugins()
         if client.connected():
             client.core.rescan_plugins()
         self.show()
 
-    def _on_button_find_plugins_clicked(self, widget):
+    def on_button_find_plugins_clicked(self, widget):
         deluge.common.open_url_in_browser('http://dev.deluge-torrent.org/wiki/Plugins')
 
-    def _on_combo_encryption_changed(self, widget):
+    def on_combo_encryption_changed(self, widget):
         combo_encin = self.builder.get_object('combo_encin').get_active()
         combo_encout = self.builder.get_object('combo_encout').get_active()
         combo_enclevel = self.builder.get_object('combo_enclevel')
@@ -957,7 +928,7 @@ class Preferences(component.Component):
         elif self.is_connected:
             combo_enclevel.set_sensitive(True)
 
-    def _on_combo_proxy_type_changed(self, widget):
+    def on_combo_proxy_type_changed(self, widget):
         proxy_type = self.builder.get_object('combo_proxy_type').get_active()
         proxy_entries = [
             'label_proxy_host', 'entry_proxy_host', 'label_proxy_port', 'spin_proxy_port',
@@ -982,7 +953,7 @@ class Preferences(component.Component):
             else:
                 self.builder.get_object(entry).hide()
 
-    def _on_entry_proxy_host_paste_clipboard(self, widget):
+    def on_entry_proxy_host_paste_clipboard(self, widget):
         text = gtk.clipboard_get().wait_for_text().strip()
         log.debug('on_entry_proxy_host_paste-clipboard: got paste: %s', text)
         text = text if '//' in text else '//' + text
@@ -997,13 +968,13 @@ class Preferences(component.Component):
         if parsed.password:
             self.builder.get_object('entry_proxy_pass').set_text(parsed.password)
 
-    def _on_button_associate_magnet_clicked(self, widget):
+    def on_button_associate_magnet_clicked(self, widget):
         associate_magnet_links(True)
 
     def _get_accounts_tab_data(self):
         def on_ok(accounts):
             self.accounts_frame.show()
-            self._on_get_known_accounts(accounts)
+            self.on_get_known_accounts(accounts)
 
         def on_fail(failure):
             if failure.type == NotAuthorizedError:
@@ -1016,7 +987,7 @@ class Preferences(component.Component):
                 ).run()
         client.core.get_known_accounts().addCallback(on_ok).addErrback(on_fail)
 
-    def _on_get_known_accounts(self, known_accounts):
+    def on_get_known_accounts(self, known_accounts):
         known_accounts_to_log = []
         for account in known_accounts:
             account_to_log = {}
@@ -1025,7 +996,7 @@ class Preferences(component.Component):
                     value = '*' * len(value)
                 account_to_log[key] = value
             known_accounts_to_log.append(account_to_log)
-        log.debug('_on_known_accounts: %s', known_accounts_to_log)
+        log.debug('on_known_accounts: %s', known_accounts_to_log)
 
         self.accounts_liststore.clear()
 
@@ -1035,8 +1006,8 @@ class Preferences(component.Component):
             self.accounts_liststore.set_value(accounts_iter, ACCOUNTS_LEVEL, account['authlevel'])
             self.accounts_liststore.set_value(accounts_iter, ACCOUNTS_PASSWORD, account['password'])
 
-    def _on_accounts_selection_changed(self, treeselection):
-        log.debug('_on_accounts_selection_changed')
+    def on_accounts_selection_changed(self, treeselection):
+        log.debug('on_accounts_selection_changed')
         (model, itr) = treeselection.get_selected()
         if not itr:
             return
@@ -1048,7 +1019,7 @@ class Preferences(component.Component):
             self.builder.get_object('accounts_edit').set_sensitive(False)
             self.builder.get_object('accounts_delete').set_sensitive(False)
 
-    def _on_accounts_add_clicked(self, widget):
+    def on_accounts_add_clicked(self, widget):
         dialog = AccountDialog(levels_mapping=client.auth_levels_mapping, parent=self.pref_dialog)
 
         def dialog_finished(response_id):
@@ -1083,7 +1054,7 @@ class Preferences(component.Component):
 
         dialog.run().addCallback(dialog_finished)
 
-    def _on_accounts_edit_clicked(self, widget):
+    def on_accounts_edit_clicked(self, widget):
         (model, itr) = self.accounts_listview.get_selection().get_selected()
         if not itr:
             return
@@ -1118,7 +1089,7 @@ class Preferences(component.Component):
 
         dialog.run().addCallback(dialog_finished)
 
-    def _on_accounts_delete_clicked(self, widget):
+    def on_accounts_delete_clicked(self, widget):
         (model, itr) = self.accounts_listview.get_selection().get_selected()
         if not itr:
             return
@@ -1152,36 +1123,36 @@ class Preferences(component.Component):
                 ).addCallback(remove_ok).addErrback(remove_fail)
         dialog.run().addCallback(dialog_finished)
 
-    def _on_piecesbar_toggle_toggled(self, widget):
+    def on_piecesbar_toggle_toggled(self, widget):
         self.gtkui_config['show_piecesbar'] = widget.get_active()
         colors_widget = self.builder.get_object('piecebar_colors_expander')
         colors_widget.set_visible(widget.get_active())
 
-    def _on_checkbutton_language_toggled(self, widget):
+    def on_checkbutton_language_toggled(self, widget):
         self.language_combo.set_visible(not self.language_checkbox.get_active())
 
-    def _on_completed_color_set(self, widget):
+    def on_completed_color_set(self, widget):
         self.__set_color('completed')
 
-    def _on_revert_color_completed_clicked(self, widget):
+    def on_revert_color_completed_clicked(self, widget):
         self.__revert_color('completed')
 
-    def _on_downloading_color_set(self, widget):
+    def on_downloading_color_set(self, widget):
         self.__set_color('downloading')
 
-    def _on_revert_color_downloading_clicked(self, widget):
+    def on_revert_color_downloading_clicked(self, widget):
         self.__revert_color('downloading')
 
-    def _on_waiting_color_set(self, widget):
+    def on_waiting_color_set(self, widget):
         self.__set_color('waiting')
 
-    def _on_revert_color_waiting_clicked(self, widget):
+    def on_revert_color_waiting_clicked(self, widget):
         self.__revert_color('waiting')
 
-    def _on_missing_color_set(self, widget):
+    def on_missing_color_set(self, widget):
         self.__set_color('missing')
 
-    def _on_revert_color_missing_clicked(self, widget):
+    def on_revert_color_missing_clicked(self, widget):
         self.__revert_color('missing')
 
     def __set_color(self, state, from_config=False):

--- a/deluge/ui/gtkui/queuedtorrents.py
+++ b/deluge/ui/gtkui/queuedtorrents.py
@@ -38,13 +38,7 @@ class QueuedTorrents(component.Component):
         self.dialog = self.builder.get_object('queued_torrents_dialog')
         self.dialog.set_icon(get_logo(32))
 
-        self.builder.connect_signals({
-            'on_button_remove_clicked': self.on_button_remove_clicked,
-            'on_button_clear_clicked': self.on_button_clear_clicked,
-            'on_button_close_clicked': self.on_button_close_clicked,
-            'on_button_add_clicked': self.on_button_add_clicked,
-            'on_chk_autoadd_toggled': self.on_chk_autoadd_toggled
-        })
+        self.builder.connect_signals(self)
 
         self.treeview = self.builder.get_object('treeview')
         self.treeview.append_column(TreeViewColumn(_('Torrent'), CellRendererText(), text=0))

--- a/deluge/ui/gtkui/removetorrentdialog.py
+++ b/deluge/ui/gtkui/removetorrentdialog.py
@@ -48,9 +48,7 @@ class RemoveTorrentDialog(object):
         self.__dialog = self.builder.get_object('remove_torrent_dialog')
         self.__dialog.set_transient_for(component.get('MainWindow').window)
 
-        self.builder.connect_signals({
-            'on_delete_files_toggled': self.on_delete_files_toggled
-        })
+        self.builder.connect_signals(self)
         self.builder.get_object('delete_files').set_active(delete_files)
         label_title = self.builder.get_object('label_title')
         label_torrents = self.builder.get_object('label_torrents')

--- a/deluge/ui/gtkui/systemtray.py
+++ b/deluge/ui/gtkui/systemtray.py
@@ -69,14 +69,7 @@ class SystemTray(component.Component):
         self.builder.add_from_file(resource_filename('deluge.ui.gtkui', os.path.join(
             'glade', 'tray_menu.ui')))
 
-        self.builder.connect_signals({
-            'on_menuitem_show_deluge_activate': self.on_menuitem_show_deluge_activate,
-            'on_menuitem_add_torrent_activate': self.on_menuitem_add_torrent_activate,
-            'on_menuitem_pause_session_activate': self.on_menuitem_pause_session_activate,
-            'on_menuitem_resume_session_activate': self.on_menuitem_resume_session_activate,
-            'on_menuitem_quit_activate': self.on_menuitem_quit_activate,
-            'on_menuitem_quitdaemon_activate': self.on_menuitem_quitdaemon_activate
-        })
+        self.builder.connect_signals(self)
 
         self.tray_menu = self.builder.get_object('tray_menu')
 

--- a/deluge/ui/gtkui/toolbar.py
+++ b/deluge/ui/gtkui/toolbar.py
@@ -28,16 +28,7 @@ class ToolBar(component.Component):
         self.toolbar = self.main_builder.get_object('toolbar')
         self.config = ConfigManager('gtkui.conf')
         # Connect main window Signals #
-        mainwindow.connect_signals({
-            'on_toolbutton_add_clicked': self.on_toolbutton_add_clicked,
-            'on_toolbutton_remove_clicked': self.on_toolbutton_remove_clicked,
-            'on_toolbutton_pause_clicked': self.on_toolbutton_pause_clicked,
-            'on_toolbutton_resume_clicked': self.on_toolbutton_resume_clicked,
-            'on_toolbutton_preferences_clicked': self.on_toolbutton_preferences_clicked,
-            'on_toolbutton_connectionmanager_clicked': self.on_toolbutton_connectionmanager_clicked,
-            'on_toolbutton_queue_up_clicked': self.on_toolbutton_queue_up_clicked,
-            'on_toolbutton_queue_down_clicked': self.on_toolbutton_queue_down_clicked
-        })
+        mainwindow.connect_signals(self)
         self.change_sensitivity = [
             'toolbutton_add',
             'toolbutton_remove',

--- a/deluge/ui/gtkui/trackers_tab.py
+++ b/deluge/ui/gtkui/trackers_tab.py
@@ -21,24 +21,13 @@ log = logging.getLogger(__name__)
 
 class TrackersTab(Tab):
     def __init__(self):
-        super(TrackersTab, self).__init__()
-        # Get the labels we need to update.
-        # widget name, modifier function, status keys
-        main_builder = component.get('MainWindow').get_builder()
+        super(TrackersTab, self).__init__('Trackers', 'trackers_tab', 'trackers_tab_label')
 
-        self._name = 'Trackers'
-        self._child_widget = main_builder.get_object('trackers_tab')
-        self._tab_label = main_builder.get_object('trackers_tab_label')
-
-        self.label_widgets = [
-            (main_builder.get_object('summary_next_announce'), ftime, ('next_announce',)),
-            (main_builder.get_object('summary_tracker'), None, ('tracker_host',)),
-            (main_builder.get_object('summary_tracker_status'), ftranslate, ('tracker_status',)),
-            (main_builder.get_object('summary_tracker_total'), fcount, ('trackers',)),
-            (main_builder.get_object('summary_private'), fyes_no, ('private',)),
-        ]
-
-        self.status_keys = [status for widget in self.label_widgets for status in widget[2]]
+        self.add_tab_widget('summary_next_announce', ftime, ('next_announce',))
+        self.add_tab_widget('summary_tracker', None, ('tracker_host',))
+        self.add_tab_widget('summary_tracker_status', ftranslate, ('tracker_status',))
+        self.add_tab_widget('summary_tracker_total', fcount, ('trackers',))
+        self.add_tab_widget('summary_private', fyes_no, ('private',))
 
         component.get('MainWindow').connect_signals(self)
 
@@ -61,15 +50,15 @@ class TrackersTab(Tab):
         if not status:
             return
 
-        # Update all the label widgets
-        for widget in self.label_widgets:
-            txt = self.get_status_for_widget(widget, status)
-            if widget[0].get_text() != txt:
-                widget[0].set_text(txt)
+        # Update all the tab label widgets
+        for widget in self.tab_widgets.values():
+            txt = self.widget_status_as_fstr(widget, status)
+            if widget.obj.get_text() != txt:
+                widget.obj.set_text(txt)
 
     def clear(self):
-        for widget in self.label_widgets:
-            widget[0].set_text('')
+        for widget in self.tab_widgets.values():
+            widget.obj.set_text('')
 
     def on_button_edit_trackers_clicked(self, button):
         torrent_id = component.get('TorrentView').get_selected_torrent()

--- a/deluge/ui/gtkui/trackers_tab.py
+++ b/deluge/ui/gtkui/trackers_tab.py
@@ -40,9 +40,7 @@ class TrackersTab(Tab):
 
         self.status_keys = [status for widget in self.label_widgets for status in widget[2]]
 
-        component.get('MainWindow').connect_signals({
-            'on_button_edit_trackers_clicked': self._on_button_edit_trackers_clicked,
-        })
+        component.get('MainWindow').connect_signals(self)
 
     def update(self):
         # Get the first selected torrent
@@ -73,7 +71,7 @@ class TrackersTab(Tab):
         for widget in self.label_widgets:
             widget[0].set_text('')
 
-    def _on_button_edit_trackers_clicked(self, button):
+    def on_button_edit_trackers_clicked(self, button):
         torrent_id = component.get('TorrentView').get_selected_torrent()
         if torrent_id:
             from deluge.ui.gtkui.edittrackersdialog import EditTrackersDialog


### PR DESCRIPTION
- [x] Use the namedtuple attributes instead of index.
- [x] Can `label_widgets` and `tab_widgets` be a single generic attribute? The current reason for difference is label can take multiple status keys.
- [x] Add to git commit message about namedtuple follows same entry order so index still works for backwards compatibility.