### PR TITLE
Trac#3011 Handle WM_ENDSESSION on Windows to shutdown cleanly

### DIFF
--- a/deluge/ui/gtkui/gtkui.py
+++ b/deluge/ui/gtkui/gtkui.py
@@ -303,6 +303,8 @@ class GtkUI(object):
     def shutdown(self, *args, **kwargs):
         log.debug("gtkui shutting down..")
 
+        self.mainwindow.remove_shutdown_block()
+
         component.stop()
 
         # Process any pending gtk events since the mainloop has been quit


### PR DESCRIPTION
This is not ready for merge however it is working code and will catch the wm_queryendsession messages. The next step is to handle this correctly so Deluge is given enough time to save data to disc as the default 5 secs is probably not enough. 

See trac ticket for more details.