### PR TITLE
Issue/3122/[Notifications]Fix no text in tab list

### DIFF
--- a/deluge/plugins/Notifications/deluge/plugins/notifications/gtkui.py
+++ b/deluge/plugins/Notifications/deluge/plugins/notifications/gtkui.py
@@ -263,12 +263,7 @@ class GtkUI(GtkPluginBase, GtkUiNotifications):
             'on_sound_path_update_preview': self.on_sound_path_update_preview
         })
 
-        prefs = component.get('Preferences')
-        parent = self.prefs.get_parent()
-        if parent:
-            parent.remove(self.prefs)
-        index = prefs.notebook.append_page(self.prefs)
-        prefs.liststore.append([index, _('Notifications')])
+        component.get('Preferences').add_page(_('Notifications'), self.prefs)
 
         component.get('PluginManager').register_hook('on_apply_prefs',
                                                      self.on_apply_prefs)


### PR DESCRIPTION
A fix for issue [3122](http://dev.deluge-torrent.org/ticket/3122).

The tab in the Preferences window is created and clickable - only the text is missing.
Cause - self insertion to the tab list instead of using the function ```add_page``` as in all other plugin.