### PR TITLE
Fixed a minor typo in the documentation.

### DIFF
--- a/docs/man/deluge-console.1
+++ b/docs/man/deluge-console.1
@@ -39,7 +39,7 @@ reannounce@Alias for \fBupdate_tracker\fR
 recheck@Forces a recheck of the torrent data
 resume@Resume torrents
 rm@Remove a torrent
-status@Shows a various status information from the daemon
+status@Shows various status information from the daemon
 update_tracker@Update tracker for torrent(s)
 .TE
 


### PR DESCRIPTION
I was looking through the documentation and noticed a small grammatical error: the 'a' before various in the deluge command description.