### PR TITLE
Save copies of torrent files from magnet links.

### DIFF
--- a/deluge/core/torrent.py
+++ b/deluge/core/torrent.py
@@ -972,6 +972,10 @@ class Torrent(object):
             torrent_file["info"] = md
             with open(path, "wb") as _file:
                 _file.write(lt.bencode(torrent_file))
+            if self.config["copy_torrent_file"]:
+                with open(os.path.join(self.config["torrentfiles_location"],
+                self.filename), "wb") as _file:
+                    _file.write(lt.bencode(torrent_file))
         except Exception, e:
             log.warning("Unable to save torrent file: %s", e)
 


### PR DESCRIPTION
This patch is meant for 1.3-stable (1.3.15 as of the commit date).

The bug is: when you add a new magnet link to download, even if you tick
the option *Copy of .torrent files to:*, deluge still fails to save a
copy of torrent. This patch adds extra code to do so.

Bug discovered and patch tested on a Ubuntu 16.04 machine with deluge downloaded from official PPA.