### PR TITLE
[#2867][WebUI] Fix Daemon connection problem

### DIFF
--- a/deluge/ui/web/js/deluge-all/ConnectionManager.js
+++ b/deluge/ui/web/js/deluge-all/ConnectionManager.js
@@ -229,15 +229,24 @@ Deluge.ConnectionManager = Ext.extend(Ext.Window, {
         var selected = this.list.getSelectedRecords()[0];
         if (!selected) return;
 
-        if (selected.get('status').toLowerCase() == 'connected') {
+        var me = this;
+        var disconnect = function() {
             deluge.client.web.disconnect({
                 success: function(result) {
                     this.update(this);
                     deluge.events.fire('disconnect');
                 },
-                scope: this
+                scope: me
             });
-        } else {
+        };
+
+        if (selected.get('status').toLowerCase() == 'connected') {
+            disconnect();
+        }  else {
+            if (this.list.getStore().find('status', 'Connected', 0, false, false) > -1) {
+                disconnect();
+            }
+
             var id = selected.id;
             deluge.client.web.connect(id, {
                 success: function(methods) {


### PR DESCRIPTION
Trying to connect to daemon B while still connected to A will cause
the torrents from A to be shown after connecting to B.
Therefor, checking if connected to any daemon before connecting to B.

This will fix [#2867](https://dev.deluge-torrent.org/ticket/2867) - web-gui does not changing deluge instance properly.