### PR TITLE
Prevent time formatting crash when seconds were floats

### DIFF
--- a/deluge/common.py
+++ b/deluge/common.py
@@ -500,17 +500,17 @@ def ftime(secs):
     if secs <= 0:
         time_str = ''
     elif secs < 60:
-        time_str = '{:d}s'.format(secs)
+        time_str = '{:.0f}s'.format(secs)
     elif secs < 3600:
-        time_str = '{:d}m {:d}s'.format(secs // 60, secs % 60)
+        time_str = '{:.0f}m {:.0f}s'.format(secs // 60, secs % 60)
     elif secs < 86400:
-        time_str = '{:d}h {:d}m'.format(secs // 3600, secs // 60 % 60)
+        time_str = '{:.0f}h {:.0f}m'.format(secs // 3600, secs // 60 % 60)
     elif secs < 604800:
-        time_str = '{:d}d {:d}h'.format(secs // 86400, secs // 3600 % 24)
+        time_str = '{:.0f}d {:.0f}h'.format(secs // 86400, secs // 3600 % 24)
     elif secs < 31449600:
-        time_str = '{:d}w {:d}d'.format(secs // 604800, secs // 86400 % 7)
+        time_str = '{:.0f}w {:.0f}d'.format(secs // 604800, secs // 86400 % 7)
     else:
-        time_str = '{:d}y {:d}w'.format(secs // 31449600, secs // 604800 % 52)
+        time_str = '{:.0f}y {:.0f}w'.format(secs // 31449600, secs // 604800 % 52)
 
     return time_str
 


### PR DESCRIPTION
Was getting this error in deluge-console:
```
Traceback (most recent call last):
  File "/home/chase/newdeluge/deluge/ui/console/modes/basemode.py", line 207, in doRead
    self.read_input()
  File "/home/chase/newdeluge/deluge/ui/console/modes/torrentlist/torrentlist.py", line 332, in read_input
    self.refresh(affected_lines)
  File "/home/chase/newdeluge/deluge/ui/console/modes/torrentlist/torrentlist.py", line 223, in refresh
    self.torrentview.update_torrents(lines)
  File "/home/chase/newdeluge/deluge/ui/console/modes/torrentlist/torrentview.py", line 312, in update_torrents
    todraw.append((i, i - self.curoff, draw_row(i)))
  File "/home/chase/newdeluge/deluge/ui/console/modes/torrentlist/torrentview.py", line 291, in draw_row
    [get_column_value(name, ts) for name in self.cols_to_show],
  File "/home/chase/newdeluge/deluge/ui/console/utils/column.py", line 75, in get_column_value
    return col['formatter'](*args)
  File "/home/chase/newdeluge/deluge/ui/console/utils/format_utils.py", line 33, in format_time
    return deluge.common.ftime(time)
  File "/home/chase/newdeluge/deluge/common.py", line 511, in ftime
    time_str = '{:d}w {:d}d'.format(secs // 604800, secs // 86400 % 7)
ValueError: Unknown format code 'd' for object of type 'float'
```
Updated the `ftime` function to allow formatting seconds of type float.