### PR TITLE
Fix pause_torrents & resume_torrents logic

### DIFF
--- a/deluge/core/core.py
+++ b/deluge/core/core.py
@@ -627,7 +627,8 @@ class Core(component.Component):
         log.debug('Pausing: %s', torrent_id)
         if not isinstance(torrent_id, str if not PY2 else basestring):
             self.pause_torrents(torrent_id)
-        self.torrentmanager[torrent_id].pause()
+        else:
+            self.torrentmanager[torrent_id].pause()
 
     @export
     def pause_torrents(self, torrent_ids=None):
@@ -677,7 +678,8 @@ class Core(component.Component):
         log.debug('Resuming: %s', torrent_id)
         if not isinstance(torrent_id, str if not PY2 else basestring):
             self.resume_torrents(torrent_id)
-        self.torrentmanager[torrent_id].resume()
+        else:
+            self.torrentmanager[torrent_id].resume()
 
     @export
     def resume_torrents(self, torrent_ids=None):


### PR DESCRIPTION
If the torrent_id argument received in the pause or resume methods is not a string, the methods execute with the un-parsed input and then with parsed input on a second call. 

A key error exception is thrown from the first call, and the second call succeeds (I have replaced the real torrent_id string value with "<torrent_id>" in the following log:
```
 19:12:21.374 [DEBUG   ][deluge.core.rpcserver         :300 ] RPC dispatch core.pause_torrent
 19:12:21.374 [DEBUG   ][deluge.core.core              :627 ] Pausing: (u'<torrent_id>',)
 19:12:21.375 [DEBUG   ][deluge.core.core              :627 ] Pausing: <torrent_id>
 19:12:21.380 [WARNING ][deluge.core.rpcserver         :234 ] An exception occurred while sending RPC_ERROR to client. Wrapping it and resending. Error to send(causing exception goes next):
 Traceback (most recent call last):
    File "/media/md5/superchicken/pip/lib/python2.7/site-packages/deluge/core/rpcserver.py", line 314, in dispatch
      ret = self.factory.methods[method](*args, **kwargs)
    File "/media/md5/superchicken/pip/lib/python2.7/site-packages/deluge/core/core.py", line 630, in pause_torrent
      self.torrentmanager[torrent_id].pause()
    File "/media/md5/superchicken/pip/lib/python2.7/site-packages/deluge/core/torrentmanager.py", line 266, in __getitem__
     return self.torrents[torrent_id]
  KeyError: (u'<torrent_id>',)
19:12:21.381 [ERROR   ][deluge.core.rpcserver         :1200] Exception calling RPC request(u'<torrent_id>',)
Traceback (most recent call last):
  File "/media/md5/superchicken/pip/lib/python2.7/site-packages/deluge/core/rpcserver.py", line 314, in dispatch
      ret = self.factory.methods[method](*args, **kwargs)
    File "/media/md5/superchicken/pip/lib/python2.7/site-packages/deluge/core/core.py", line 630, in pause_torrent
      self.torrentmanager[torrent_id].pause()
    File "/media/md5/superchicken/pip/lib/python2.7/site-packages/deluge/core/torrentmanager.py", line 266, in __getitem__
      return self.torrents[torrent_id]
  KeyError: (u'<torrent_id>',)
```
deluged 2.0.0b2.dev105
libtorrent: 1.1.9.0
Python: 2.7.13
OS: Linux debian 9.4

deluge-console 2.0.0b2.dev105
libtorrent: 1.1.9.0
Python: 2.7.13
OS: Linux debian 9.4