### PR TITLE
Add a background position and size to sidebar icons

### DIFF
--- a/deluge/ui/web/css/deluge.css
+++ b/deluge/ui/web/css/deluge.css
@@ -320,6 +320,8 @@ dl.singleline dd {
 
 #sidebar .x-deluge-filter {
     background-repeat: no-repeat;
+    background-size: contain;
+    background-position: left;
     padding-left: 20px;
     line-height: 16px;
 }


### PR DESCRIPTION
Without this change tracker icons that are too big render ... well, as too big.
This restrains them to fit into the sidebar list item.

What it looks like now:
![image](https://user-images.githubusercontent.com/5056880/44958436-932e6a00-aee0-11e8-94db-5e23d8bbc32e.png)

What it will look like after:
![image](https://user-images.githubusercontent.com/5056880/44958442-ae00de80-aee0-11e8-9004-4b4548a93b3e.png)

(the red border serves the purpose to visualize the size of the sidebar item)