### PR TITLE
Set notification desktop entry hint

### DIFF
--- a/deluge/plugins/Notifications/deluge/plugins/notifications/gtkui.py
+++ b/deluge/plugins/Notifications/deluge/plugins/notifications/gtkui.py
@@ -179,6 +179,7 @@ class GtkUiNotifications(CustomNotifications):
             icon = gtk.gdk.pixbuf_new_from_file_at_size(deluge.common.get_pixmap('deluge.svg'), 48, 48)
             self.note = pynotify.Notification(title, message)
             self.note.set_icon_from_pixbuf(icon)
+            self.note.set_hint('desktop-entry', 'deluge')
             if not self.note.show():
                 err_msg = _('pynotify failed to show notification')
                 log.warning(err_msg)


### PR DESCRIPTION
Due to Gnome Guidelines https://wiki.gnome.org/Initiatives/GnomeGoals/NotificationSource