### PR TITLE
Resolve symlinked config files

### DIFF
--- a/deluge/config.py
+++ b/deluge/config.py
@@ -455,6 +455,7 @@ class Config(object):
         """
         if not filename:
             filename = self.__config_file
+        filename = os.path.realpath(filename)
         # Check to see if the current config differs from the one on disk
         # We will only write a new config file if there is a difference
         try:


### PR DESCRIPTION
Currently, deluge replaces symlinks rather than their targets. This is *Bad*.