### PR TITLE
[UI|Daemon][#3081] Move baseargparser out of deluge/ui

### DIFF
--- a/deluge/argparser_base.py
+++ b/deluge/argparser_base.py
@@ -16,9 +16,29 @@ import platform
 import sys
 import textwrap
 
+from six.moves import builtins
+
 import deluge.log
 from deluge import common
 from deluge.configmanager import get_config_dir, set_config_dir
+
+log = logging.getLogger(__name__)
+log.addHandler(
+    logging.NullHandler()
+)  # Silence: No handlers could be found for logger "deluge.util.lang"
+
+
+def set_dummy_trans(warn_msg=None):
+    def _func(*txt):
+        if warn_msg:
+            log.warning(
+                '"%s" has been marked for translation, but translation is unavailable.',
+                txt[0],
+            )
+        return txt[0]
+
+    builtins.__dict__['_'] = _func
+    builtins.__dict__['ngettext'] = builtins.__dict__['_n'] = _func
 
 
 def find_subcommand(self, args=None, sys_argv=True):

--- a/deluge/core/daemon_entry.py
+++ b/deluge/core/daemon_entry.py
@@ -15,9 +15,9 @@ from logging import DEBUG, FileHandler, getLogger
 
 from twisted.internet.error import CannotListenError
 
+from deluge.argparser_base import BaseArgParser
 from deluge.common import run_profiled
 from deluge.configmanager import get_config_dir
-from deluge.ui.baseargparser import BaseArgParser
 from deluge.ui.translations_util import set_dummy_trans
 
 

--- a/deluge/ui/console/console.py
+++ b/deluge/ui/console/console.py
@@ -15,7 +15,7 @@ import os
 import sys
 
 import deluge.common
-from deluge.ui.baseargparser import BaseArgParser, DelugeTextHelpFormatter
+from deluge.argparser_base import BaseArgParser, DelugeTextHelpFormatter
 from deluge.ui.ui import UI
 
 log = logging.getLogger(__name__)

--- a/deluge/ui/translations_util.py
+++ b/deluge/ui/translations_util.py
@@ -11,31 +11,13 @@ from __future__ import unicode_literals
 
 import gettext
 import locale
-import logging
 import os
 import sys
 
 from six.moves import builtins
 
 import deluge.common
-
-log = logging.getLogger(__name__)
-log.addHandler(
-    logging.NullHandler()
-)  # Silence: No handlers could be found for logger "deluge.util.lang"
-
-
-def set_dummy_trans(warn_msg=None):
-    def _func(*txt):
-        if warn_msg:
-            log.warning(
-                '"%s" has been marked for translation, but translation is unavailable.',
-                txt[0],
-            )
-        return txt[0]
-
-    builtins.__dict__['_'] = _func
-    builtins.__dict__['ngettext'] = builtins.__dict__['_n'] = _func
+from deluge.argparser_base import log, set_dummy_trans
 
 
 def get_translations_path():

--- a/deluge/ui/ui.py
+++ b/deluge/ui/ui.py
@@ -14,7 +14,7 @@ import logging
 import deluge.common
 import deluge.configmanager
 import deluge.log
-from deluge.ui.baseargparser import BaseArgParser
+from deluge.argparser_base import BaseArgParser
 from deluge.ui.translations_util import setup_translations
 
 log = logging.getLogger(__name__)

--- a/deluge/ui/ui_entry.py
+++ b/deluge/ui/ui_entry.py
@@ -23,7 +23,7 @@ import pkg_resources
 
 import deluge.common
 import deluge.configmanager
-from deluge.ui.baseargparser import BaseArgParser
+from deluge.argparser_base import BaseArgParser
 from deluge.ui.translations_util import setup_translations
 
 DEFAULT_PREFS = {'default_ui': 'gtk'}


### PR DESCRIPTION
This file is being used by both UI and Daemon. 
Therefor, it should not be located in the UI, but in the top-level `deluge` and renamed to `argparser_base`.
The same is with the function `set_dummy_trans`, which was located in `translation_util` and is now part of `argparser_base`.