### PR TITLE
[Core] Call wait_for_alert in a thread

### DIFF
--- a/deluge/component.py
+++ b/deluge/component.py
@@ -64,6 +64,11 @@ class Component:
                    paused by instructing the :class:`ComponentRegistry` to pause
                    this Component.
 
+       **pause()** - This method is called when the component is being paused.
+
+       **resume()** - This method is called when the component resumes from a Paused
+                    state.
+
         **shutdown()** - This method is called when the client is exiting.  If the
                      Component is in a "Started" state when this is called, a
                      call to stop() will be issued prior to shutdown().
@@ -83,7 +88,7 @@ class Component:
         **Stopping** - The Component has had it's stop method called, but it hasn't
                     fully stopped yet.
 
-        **Paused** - The Component has had it's update timer stopped, but will
+        **Paused** - The Component has had its update timer stopped, but will
                     still be considered in a Started state.
 
     """
@@ -111,9 +116,8 @@ class Component:
             _ComponentRegistry.deregister(self)
 
     def _component_start_timer(self):
-        if hasattr(self, 'update'):
-            self._component_timer = LoopingCall(self.update)
-            self._component_timer.start(self._component_interval)
+        self._component_timer = LoopingCall(self.update)
+        self._component_timer.start(self._component_interval)
 
     def _component_start(self):
         def on_start(result):
@@ -129,13 +133,10 @@ class Component:
             return fail(result)
 
         if self._component_state == 'Stopped':
-            if hasattr(self, 'start'):
-                self._component_state = 'Starting'
-                d = deferLater(reactor, 0, self.start)
-                d.addCallbacks(on_start, on_start_fail)
-                self._component_starting_deferred = d
-            else:
-                d = maybeDeferred(on_start, None)
+            self._component_state = 'Starting'
+            d = deferLater(reactor, 0, self.start)
+            d.addCallbacks(on_start, on_start_fail)
+            self._component_starting_deferred = d
         elif self._component_state == 'Starting':
             return self._component_starting_deferred
         elif self._component_state == 'Started':
@@ -165,14 +166,11 @@ class Component:
             return result
 
         if self._component_state != 'Stopped' and self._component_state != 'Stopping':
-            if hasattr(self, 'stop'):
-                self._component_state = 'Stopping'
-                d = maybeDeferred(self.stop)
-                d.addCallback(on_stop)
-                d.addErrback(on_stop_fail)
-                self._component_stopping_deferred = d
-            else:
-                d = maybeDeferred(on_stop, None)
+            self._component_state = 'Stopping'
+            d = maybeDeferred(self.stop)
+            d.addCallback(on_stop)
+            d.addErrback(on_stop_fail)
+            self._component_stopping_deferred = d
 
         if self._component_state == 'Stopping':
             return self._component_stopping_deferred
@@ -182,13 +180,12 @@ class Component:
     def _component_pause(self):
         def on_pause(result):
             self._component_state = 'Paused'
+            if self._component_timer and self._component_timer.running:
+                self._component_timer.stop()
 
         if self._component_state == 'Started':
-            if self._component_timer and self._component_timer.running:
-                d = maybeDeferred(self._component_timer.stop)
-                d.addCallback(on_pause)
-            else:
-                d = succeed(None)
+            d = maybeDeferred(self.pause)
+            d.addCallback(on_pause)
         elif self._component_state == 'Paused':
             d = succeed(None)
         else:
@@ -205,9 +202,10 @@ class Component:
     def _component_resume(self):
         def on_resume(result):
             self._component_state = 'Started'
+            self._component_start_timer()
 
         if self._component_state == 'Paused':
-            d = maybeDeferred(self._component_start_timer)
+            d = maybeDeferred(self.resume)
             d.addCallback(on_resume)
         else:
             d = fail(
@@ -222,9 +220,7 @@ class Component:
 
     def _component_shutdown(self):
         def on_stop(result):
-            if hasattr(self, 'shutdown'):
-                return maybeDeferred(self.shutdown)
-            return succeed(None)
+            return maybeDeferred(self.shutdown)
 
         d = self._component_stop()
         d.addCallback(on_stop)
@@ -243,6 +239,12 @@ class Component:
         pass
 
     def shutdown(self):
+        pass
+
+    def pause(self):
+        pass
+
+    def resume(self):
         pass
 
 

--- a/deluge/conftest.py
+++ b/deluge/conftest.py
@@ -41,11 +41,13 @@ def mock_callback():
     The returned Mock instance will have a `deferred` attribute which will complete when the callback has been called.
     """
 
-    def reset():
+    def reset(timeout=0.5, *args, **kwargs):
         if mock.called:
-            original_reset_mock()
-        deferred = Deferred()
-        deferred.addTimeout(0.5, reactor)
+            original_reset_mock(*args, **kwargs)
+        if mock.deferred:
+            mock.deferred.cancel()
+        deferred = Deferred(canceller=lambda x: deferred.callback(None))
+        deferred.addTimeout(timeout, reactor)
         mock.side_effect = lambda *args, **kw: deferred.callback((args, kw))
         mock.deferred = deferred
 

--- a/deluge/core/alertmanager.py
+++ b/deluge/core/alertmanager.py
@@ -15,9 +15,10 @@ This should typically only be used by the Core. Plugins should utilize the
 
 """
 import logging
+import threading
 from types import SimpleNamespace
 
-from twisted.internet import reactor
+from twisted.internet import reactor, threads
 
 import deluge.component as component
 from deluge._libtorrent import lt
@@ -31,7 +32,7 @@ class AlertManager(component.Component):
 
     def __init__(self):
         log.debug('AlertManager init...')
-        component.Component.__init__(self, 'AlertManager', interval=0.3)
+        component.Component.__init__(self, 'AlertManager')
         self.session = component.get('Core').session
 
         # Increase the alert queue size so that alerts don't get lost.
@@ -54,16 +55,40 @@ class AlertManager(component.Component):
         # handlers is a dictionary of lists {"alert_type": [handler1,h2,..]}
         self.handlers = {}
         self.delayed_calls = []
+        self._event = threading.Event()
 
     def update(self):
         self.delayed_calls = [dc for dc in self.delayed_calls if dc.active()]
-        self.handle_alerts()
+
+    def start(self):
+        thread = threading.Thread(
+            target=self.wait_for_alert_in_thread, name='alert-poller', daemon=True
+        )
+        thread.start()
+        self._event.set()
 
     def stop(self):
         for delayed_call in self.delayed_calls:
             if delayed_call.active():
                 delayed_call.cancel()
         self.delayed_calls = []
+
+    def pause(self):
+        self._event.clear()
+
+    def resume(self):
+        self._event.set()
+
+    def wait_for_alert_in_thread(self):
+        while self._component_state not in ('Stopping', 'Stopped'):
+            if self.session.wait_for_alert(1000) is None:
+                continue
+            if self._event.wait():
+                threads.blockingCallFromThread(reactor, self.maybe_handle_alerts)
+
+    def maybe_handle_alerts(self):
+        if self._component_state == 'Started':
+            self.handle_alerts()
 
     def register_handler(self, alert_type, handler):
         """

--- a/deluge/tests/test_alertmanager.py
+++ b/deluge/tests/test_alertmanager.py
@@ -4,9 +4,37 @@
 # See LICENSE for more details.
 #
 
+from twisted.internet.defer import Deferred
+
 import deluge.component as component
 from deluge.conftest import BaseTestCase
 from deluge.core.core import Core
+
+
+class DummyAlert1:
+    def __init__(self):
+        self.message = '1'
+
+
+class DummyAlert2:
+    def __init__(self):
+        self.message = '2'
+
+
+class SessionMock:
+    def __init__(self):
+        self.alerts = []
+
+    def set_alerts(self, value):
+        self.alerts = [DummyAlert1(), DummyAlert2()]
+
+    def wait_for_alert(self, timeout):
+        return self.alerts[0] if len(self.alerts) > 0 else None
+
+    def pop_alerts(self):
+        alerts = self.alerts
+        self.alerts = []
+        return alerts
 
 
 class TestAlertManager(BaseTestCase):
@@ -14,6 +42,7 @@ class TestAlertManager(BaseTestCase):
         self.core = Core()
         self.core.config.config['lsd'] = False
         self.am = component.get('AlertManager')
+        self.am.session = SessionMock()
         return component.start(['AlertManager'])
 
     def tear_down(self):
@@ -25,6 +54,34 @@ class TestAlertManager(BaseTestCase):
 
         self.am.register_handler('dummy_alert', handler)
         assert self.am.handlers['dummy_alert'] == [handler]
+
+    def test_pop_alert(self):
+        def dummy_alert_1_handler(alert):
+            d.addCallback(self.assertEqual, alert.message, '1')
+            d.callback(None)
+
+        self.am.register_handler('DummyAlert1', dummy_alert_1_handler)
+        self.am.session.set_alerts()
+
+        d = Deferred()
+        return d
+
+    def test_pause_not_pop_alert(self):
+        def on_pause(value):
+            self.am.register_handler('DummyAlert1', dummy_alert_1_handler)
+            d.addCallback(check_alert)
+
+        def check_alert(value):
+            event = self.am._event.isSet()
+            self.assertFalse(event)
+
+        def dummy_alert_1_handler(alert):
+            self.fail()
+
+        d = component.pause(['AlertManager'])
+        d.addCallback(self.am.session.set_alerts)
+        d.addCallback(on_pause)
+        return d
 
     def test_deregister_handler(self):
         def handler(alert):


### PR DESCRIPTION
This spawns a thread in alertmanager to call wait_for_alert in a thread.
This reduces latency to deluge responding to events.

Based on #175.