### PR TITLE
Allow using certificate chain files for secure SSL connections

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@
 
 ==== Core ====
 	* Fix saving copy of torrent file for magnet links.
+	* Allow using certificate chain files for secure SSL connections.
 
 === Deluge 1.3.15 (12 May 2017) ===
 

--- a/deluge/core/rpcserver.py
+++ b/deluge/core/rpcserver.py
@@ -135,7 +135,7 @@ class ServerContextFactory(object):
         ssl_dir = deluge.configmanager.get_config_dir("ssl")
         ctx = SSL.Context(SSL.SSLv23_METHOD)
         ctx.set_options(SSL.OP_NO_SSLv2 | SSL.OP_NO_SSLv3)
-        ctx.use_certificate_file(os.path.join(ssl_dir, "daemon.cert"))
+        ctx.use_certificate_chain_file(os.path.join(ssl_dir, "daemon.cert"))
         ctx.use_privatekey_file(os.path.join(ssl_dir, "daemon.pkey"))
         return ctx
 


### PR DESCRIPTION
Without this, clients cannot easily verify the full chain of certificates. This is only useful if the automatically generated self signed certificates are replaced with ca signed certificates. This is necessary to prevent man-in-the-middle attacks. While the current Deluge 1.3 client does not support secure connections, other client implementations can.

This is a trivial change that does not affect the current client as far as I have tested and can only help other clients. It would be nice if the official Deluge client supported enforcing trusted signatures but that is a different subject.

----
I have not been able to test Deluge 2.0 to see if the same issue affects it. Looking at the source, it looks like it is using a different SSL library which doesn't have a chain(less) API.

Edit: Looks like Deluge 2.0 supports certificate chains: https://github.com/deluge-torrent/deluge/blob/b2e19561e6cc988f280ad896b3680e81d9a23b28/deluge/crypto_utils.py#L76