### PR TITLE
[UI|Console] added console option to specify move completed folder

### DIFF
--- a/deluge/tests/test_ui_console_add.py
+++ b/deluge/tests/test_ui_console_add.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Deluge and is licensed under GNU General Public License 3.0, or later, with
+# the additional special exception to link portions of this program with the OpenSSL library.
+# See LICENSE for more details.
+#
+
+from __future__ import unicode_literals
+
+import argparse
+
+from deluge.tests.test_ui_entry import ConsoleUIBaseTestCase
+from deluge.ui.console.cmdline.commands.add import Command
+
+
+class UICommonTestCase(ConsoleUIBaseTestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_add_args_short_option_name(self):
+        completed_path = 'completed_path'
+        parser = argparse.ArgumentParser()
+        cmd = Command()
+        cmd.add_arguments(parser)
+        args = parser.parse_args(['torrent', '-c', completed_path])
+        self.assertEqual(args.completed, completed_path)
+
+    def test_add_args_long_option_name(self):
+        completed_path = 'completed_path'
+        parser = argparse.ArgumentParser()
+        cmd = Command()
+        cmd.add_arguments(parser)
+        args = parser.parse_args(['torrent', '--completed', completed_path])
+        self.assertEqual(args.completed, completed_path)

--- a/deluge/tests/test_ui_console_add.py
+++ b/deluge/tests/test_ui_console_add.py
@@ -9,11 +9,12 @@ from __future__ import unicode_literals
 
 import argparse
 
-from deluge.tests.test_ui_entry import ConsoleUIBaseTestCase
 from deluge.ui.console.cmdline.commands.add import Command
 
+from .basetest import BaseTestCase
 
-class UICommonTestCase(ConsoleUIBaseTestCase):
+
+class UIConsoleAddTestCase(BaseTestCase):
     def setUp(self):
         pass
 

--- a/deluge/ui/console/cmdline/commands/add.py
+++ b/deluge/ui/console/cmdline/commands/add.py
@@ -38,7 +38,10 @@ class Command(BaseCommand):
             '-p', '--path', dest='path', help=_('download folder for torrent')
         )
         parser.add_argument(
-            '-c', '--completed', dest='completed', help=_('move completed torrents folder')
+            '-c',
+            '--completed',
+            dest='completed',
+            help=_('move completed torrents folder'),
         )
         parser.add_argument(
             'torrents',
@@ -52,11 +55,15 @@ class Command(BaseCommand):
 
         t_options = {}
         if options.path:
-            t_options['download_location'] = os.path.abspath(os.path.expanduser(options.path))
+            t_options['download_location'] = os.path.abspath(
+                os.path.expanduser(options.path)
+            )
 
         if options.completed:
             t_options['move_completed'] = True
-            t_options['move_completed_path'] = os.path.abspath(os.path.expanduser(options.completed))
+            t_options['move_completed_path'] = os.path.abspath(
+                os.path.expanduser(options.completed)
+            )
 
         def on_success(result):
             if not result:

--- a/deluge/ui/console/cmdline/commands/add.py
+++ b/deluge/ui/console/cmdline/commands/add.py
@@ -38,6 +38,9 @@ class Command(BaseCommand):
             '-p', '--path', dest='path', help=_('download folder for torrent')
         )
         parser.add_argument(
+            '-c', '--completed', dest='completed', help=_('move completed torrents folder')
+        )
+        parser.add_argument(
             'torrents',
             metavar='<torrent>',
             nargs='+',
@@ -49,9 +52,11 @@ class Command(BaseCommand):
 
         t_options = {}
         if options.path:
-            t_options['download_location'] = os.path.abspath(
-                os.path.expanduser(options.path)
-            )
+            t_options['download_location'] = os.path.abspath(os.path.expanduser(options.path))
+
+        if options.completed:
+            t_options['move_completed'] = True
+            t_options['move_completed_path'] = os.path.abspath(os.path.expanduser(options.completed))
 
         def on_success(result):
             if not result:


### PR DESCRIPTION
This option helps to split items to different folders. Useful for Plex media server for example.
Would be nice to see in ubuntu ppa.