### PR TITLE
[TESTS] Force usage of pytest 4.0.2 only

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,4 +1,4 @@
-pytest
+pytest==4.0.2
 pytest-twisted
 pytest-cov
 mock


### PR DESCRIPTION
As of `pytest` 4.1.0, there is an issue with `pytest-twisted` 1.8.
Until `pytest-twisted` releases a new version (fixed in git), we should use the previous version of `pytest`.