### PR TITLE
Use gzip content encoding only if supported by client

### DIFF
--- a/deluge/tests/test_httpdownloader.py
+++ b/deluge/tests/test_httpdownloader.py
@@ -236,7 +236,7 @@ class DownloadFileTestCase(unittest.TestCase):
         def cb(result):
             print(result)
 
-        d.addCallback(self.assertNotContains, b'fail', file_mode='rb')
+        d.addCallback(self.assertContains, b'fail')
         return d
 
     def test_page_redirect_unhandled(self):

--- a/deluge/ui/web/common.py
+++ b/deluge/ui/web/common.py
@@ -41,9 +41,9 @@ def compress(contents, request):
     Check the headers if the client accepts gzip encoding, and encodes the
     request if so.
     """
-    acceptHeaders = b','.join(
+    accept_headers = b','.join(
         request.requestHeaders.getRawHeaders(b'accept-encoding', []))
-    if _gzipCheckRegex.search(acceptHeaders):
+    if _gzipCheckRegex.search(accept_headers):
         encoding = request.responseHeaders.getRawHeaders(
             b'content-encoding')
         if encoding:
@@ -55,7 +55,7 @@ def compress(contents, request):
                                               [encoding])
 
         compress = zlib.compressobj(6, zlib.DEFLATED, zlib.MAX_WBITS + 16,
-            zlib.DEF_MEM_LEVEL,0)
+                                    zlib.DEF_MEM_LEVEL, 0)
         contents = compress.compress(contents)
         contents += compress.flush()
 


### PR DESCRIPTION
At the moment deluge responds to requests for certain resource with gzip content encoding regardless of the requests `accept-encoding` header. It should only use gzip encoding if supported by the client.

To reproduce, run:
curl 127.0.0.1:8112/js/ext-extensions.js -o /dev/null -v

The response will have a "Content-Encoding: gzip" header, and it's payload will be gzipped even though the request doesn't contain an "Accpet-Encoding: gzip" header.