### PR TITLE
[#3244] [Web] Add support for accept-encoding header

### DIFF
--- a/deluge/tests/common_web.py
+++ b/deluge/tests/common_web.py
@@ -67,10 +67,3 @@ class WebServerMockBase(object):
             pass
 
         self.patch(auth, 'check_request', check_request)
-
-    def mock_compress_body(self):
-        def compress(contents, request):
-            return contents
-
-        # Patch compress to avoid having to decompress output with zlib
-        self.patch(deluge.ui.web.json_api, 'compress', compress)

--- a/deluge/tests/test_json_api.py
+++ b/deluge/tests/test_json_api.py
@@ -79,11 +79,6 @@ class JSONTestCase(JSONBase):
         request = MagicMock()
         request.method = b'POST'
 
-        def compress(contents, request):
-            return contents
-
-        self.patch(deluge.ui.web.json_api, 'compress', compress)
-
         def write(response_str):
             request.write_was_called = True
             response = json_lib.loads(response_str.decode())
@@ -267,7 +262,6 @@ class JSONRequestFailedTestCase(JSONBase, WebServerMockBase):
         # Circumvent authentication
         auth = Auth({})
         self.mock_authentication_ignore(auth)
-        self.mock_compress_body()
 
         def write(response_str):
             request.write_was_called = True

--- a/deluge/tests/test_webserver.py
+++ b/deluge/tests/test_webserver.py
@@ -31,7 +31,6 @@ class WebServerTestCase(WebServerTestBase, WebServerMockBase):
         agent = Agent(reactor)
 
         self.mock_authentication_ignore(self.deluge_web.auth)
-        self.mock_compress_body()
 
         # This torrent file contains an uncommon field 'filehash' which must be hex
         # encoded to allow dumping the torrent info to json. Otherwise it will fail with:

--- a/deluge/ui/web/common.py
+++ b/deluge/ui/web/common.py
@@ -10,7 +10,8 @@
 from __future__ import unicode_literals
 
 import gettext
-import zlib
+
+from mako.template import Template as MakoTemplate
 
 from deluge.common import PY2, get_version
 
@@ -34,39 +35,14 @@ def escape(text):
     return text
 
 
-def compress(contents, request):
-    request.setHeader(b'content-encoding', b'gzip')
-    compress_zlib = zlib.compressobj(
-        6, zlib.DEFLATED, zlib.MAX_WBITS + 16, zlib.DEF_MEM_LEVEL, 0
-    )
-    contents = compress_zlib.compress(contents)
-    contents += compress_zlib.flush()
-    return contents
+class Template(MakoTemplate):
+    """
+    A template that adds some built-ins to the rendering
+    """
 
+    builtins = {'_': _, 'escape': escape, 'version': get_version()}
 
-try:
-    # This is beeing done like this in order to allow tests to use the above
-    # `compress` without requiring Mako to be instaled
-    from mako.template import Template as MakoTemplate
-
-    class Template(MakoTemplate):
-        """
-        A template that adds some built-ins to the rendering
-        """
-
-        builtins = {'_': _, 'escape': escape, 'version': get_version()}
-
-        def render(self, *args, **data):
-            data.update(self.builtins)
-            rendered = MakoTemplate.render_unicode(self, *args, **data)
-            return rendered.encode('utf-8')
-
-
-except ImportError:
-    import warnings
-
-    warnings.warn('The Mako library is required to run deluge.ui.web', RuntimeWarning)
-
-    class Template(object):
-        def __new__(cls, *args, **kwargs):
-            raise RuntimeError('The Mako library is required to run deluge.ui.web')
+    def render(self, *args, **data):
+        data.update(self.builtins)
+        rendered = MakoTemplate.render_unicode(self, *args, **data)
+        return rendered.encode('utf-8')

--- a/deluge/ui/web/json_api.py
+++ b/deluge/ui/web/json_api.py
@@ -32,7 +32,7 @@ from deluge.ui.coreconfig import CoreConfig
 from deluge.ui.hostlist import HostList
 from deluge.ui.sessionproxy import SessionProxy
 from deluge.ui.translations_util import get_languages
-from deluge.ui.web.common import _, compress
+from deluge.ui.web.common import _
 
 log = logging.getLogger(__name__)
 
@@ -231,7 +231,7 @@ class JSON(resource.Resource, component.Component):
             return ''
         response = json.dumps(response)
         request.setHeader(b'content-type', b'application/json')
-        request.write(compress(response.encode(), request))
+        request.write(response.encode())
         request.finish()
         return server.NOT_DONE_YET
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ known_third_party =
     cairo, gi,
 # Ignore other module dependencies for pre-commit isort.
     twisted, OpenSSL, pytest, recommonmark, chardet, pkg_resources, zope, mock,
-    sphinx, rencode, six
+    sphinx, rencode, six, mako
 known_first_party = msgfmt, deluge
 order_by_type = true
 not_skip = __init__.py


### PR DESCRIPTION
Trac ticket: https://dev.deluge-torrent.org/ticket/3244

Use EncodingResourceWrapper to replace compress function so that the proper checks for accept-encoding header are made

Also ensure only text if compressed and images are uncompressed.

- [ ] Update commit message with change details.
- [x] Remove compress function and replace usage in other code.
