### PR TITLE
Replace platform.linux_distribution function

### DIFF
--- a/DEPENDS.md
+++ b/DEPENDS.md
@@ -30,6 +30,10 @@ All modules will require the [common](#common) section dependencies.
 - [Pillow] - Optional: Support for resizing tracker icons.
 - [dbus-python] - Optional: Show item location in filemanager.
 
+#### Linux and BSD
+
+- [distro] - Optional: OS platform information.
+
 #### Windows OS
 
 - [pywin32]
@@ -75,6 +79,7 @@ All modules will require the [common](#common) section dependencies.
 [pillow]: https://pypi.org/project/Pillow/
 [libtorrent]: https://libtorrent.org/
 [zope.interface]: https://pypi.org/project/zope.interface/
+[distro]: https://github.com/nir0s/distro
 [pywin32]: https://github.com/mhammond/pywin32
 [certifi]: https://pypi.org/project/certifi/
 [py2-ipaddress]: https://pypi.org/project/py2-ipaddress/

--- a/deluge/common.py
+++ b/deluge/common.py
@@ -46,9 +46,6 @@ except ImportError:
     from urlparse import urljoin  # pylint: disable=ungrouped-imports
     from urllib import pathname2url, unquote_plus  # pylint: disable=ungrouped-imports
 
-if platform.system() == 'Linux':
-    import distro
-
 # Windows workaround for HTTPS requests requiring certificate authority bundle.
 # see: https://twistedmatrix.com/trac/ticket/9209
 if platform.system() in ('Windows', 'Microsoft'):
@@ -56,12 +53,17 @@ if platform.system() in ('Windows', 'Microsoft'):
 
     os.environ['SSL_CERT_FILE'] = where()
 
-# gi makes dbus available on Window but don't import it as unused.
+
 if platform.system() not in ('Windows', 'Microsoft', 'Darwin'):
+    # gi makes dbus available on Window but don't import it as unused.
     try:
         import dbus
     except ImportError:
         dbus = None
+    try:
+        import distro
+    except ImportError:
+        distro = None
 
 log = logging.getLogger(__name__)
 
@@ -269,8 +271,8 @@ def get_os_version():
     elif osx_check():
         os_version = list(platform.mac_ver())
         os_version[1] = ''  # versioninfo always empty.
-    elif linux_check():
-        os_version = distro.linux_distribution(full_distribution_name=False)
+    elif distro:
+        os_version = distro.linux_distribution()
     else:
         os_version = (platform.release(),)
 

--- a/deluge/common.py
+++ b/deluge/common.py
@@ -46,6 +46,9 @@ except ImportError:
     from urlparse import urljoin  # pylint: disable=ungrouped-imports
     from urllib import pathname2url, unquote_plus  # pylint: disable=ungrouped-imports
 
+if platform.system() == 'Linux':
+    import distro
+
 # Windows workaround for HTTPS requests requiring certificate authority bundle.
 # see: https://twistedmatrix.com/trac/ticket/9209
 if platform.system() in ('Windows', 'Microsoft'):
@@ -267,7 +270,7 @@ def get_os_version():
         os_version = list(platform.mac_ver())
         os_version[1] = ''  # versioninfo always empty.
     elif linux_check():
-        os_version = platform.linux_distribution()
+        os_version = distro.linux_distribution(full_distribution_name=False)
     else:
         os_version = (platform.release(),)
 

--- a/deluge/tests/test_core.py
+++ b/deluge/tests/test_core.py
@@ -54,7 +54,7 @@ class PartialDownload(Resource):
             common.get_test_data_file('ubuntu-9.04-desktop-i386.iso.torrent'), 'rb'
         ) as _file:
             data = _file.read()
-        request.setHeader(b'Content-Type', len(data))
+        request.setHeader(b'Content-Type', str(len(data)))
         request.setHeader(b'Content-Type', b'application/x-bittorrent')
         if request.requestHeaders.hasHeader('accept-encoding'):
             return compress(data, request)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pywin32; sys_platform == 'win32'
 py2-ipaddress; sys_platform == 'win32' and python_version == '2'
 certifi; sys_platform == 'win32'
 zope.interface>=4.4.2
+distro; platform_system == 'Linux'

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ pywin32; sys_platform == 'win32'
 py2-ipaddress; sys_platform == 'win32' and python_version == '2'
 certifi; sys_platform == 'win32'
 zope.interface>=4.4.2
-distro; platform_system != 'Windows' and platform_system != 'Microsoft' and platform_system != 'Darwin'
+distro; 'win' not in sys_platform

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ pywin32; sys_platform == 'win32'
 py2-ipaddress; sys_platform == 'win32' and python_version == '2'
 certifi; sys_platform == 'win32'
 zope.interface>=4.4.2
-distro; platform_system == 'Linux'
+distro; platform_system != 'Windows' and platform_system != 'Microsoft' and platform_system != 'Darwin'

--- a/setup.py
+++ b/setup.py
@@ -551,6 +551,7 @@ install_requires = [
     "py2-ipaddress; sys_platform == 'win32' and python_version == '2'",
     "certifi; sys_platform == 'win32'",
     'zope.interface',
+    "distro; platform_system != 'Windows' and platform_system != 'Microsoft' and platform_system != 'Darwin'",
 ]
 tests_require = ['pytest', 'pytest-twisted']
 

--- a/setup.py
+++ b/setup.py
@@ -551,7 +551,7 @@ install_requires = [
     "py2-ipaddress; sys_platform == 'win32' and python_version == '2'",
     "certifi; sys_platform == 'win32'",
     'zope.interface',
-    "distro; platform_system != 'Windows' and platform_system != 'Microsoft' and platform_system != 'Darwin'",
+    "distro; 'win' not in sys_platform",
 ]
 tests_require = ['pytest', 'pytest-twisted']
 


### PR DESCRIPTION
Will close https://dev.deluge-torrent.org/ticket/3247

As of python 3.5, this function is marked as deprecated.
So, distro[1] is the one we will use (this package is listed at the
example package in the python's docs[2]).

[1] https://pypi.org/project/distro/
[2] https://docs.python.org/3/library/platform.html#platform.dist