### PR TITLE
Remove detox

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,6 @@
 sphinx-autobuild
 tox
 tox-venv
-detox
 pre-commit
 flake8-blind-except
 flake8-builtins


### PR DESCRIPTION
As of `tox` 3.7, `detox` is no longer needed as `tox` added a native parallel environment execution.