### PR TITLE
[WiP] Update to libtorrent-1.2

### DIFF
--- a/deluge/_libtorrent.py
+++ b/deluge/_libtorrent.py
@@ -24,8 +24,8 @@ try:
 except ImportError:
     import libtorrent as lt
 
-REQUIRED_VERSION = '1.1.2.0'
-LT_VERSION = lt.__version__
+REQUIRED_VERSION = '1.2.0.0'
+LT_VERSION = lt.version
 
 if VersionSplit(LT_VERSION) < VersionSplit(REQUIRED_VERSION):
     raise ImportError(

--- a/deluge/core/preferencesmanager.py
+++ b/deluge/core/preferencesmanager.py
@@ -426,7 +426,7 @@ class PreferencesManager(component.Component):
     def _on_set_proxy(self, key, value):
         # Initialise with type none and blank hostnames.
         proxy_settings = {
-            'proxy_type': lt.proxy_type.none,
+            'proxy_type': lt.proxy_type_t.none,
             'i2p_hostname': '',
             'proxy_hostname': '',
             'proxy_hostnames': value['proxy_hostnames'],
@@ -436,15 +436,15 @@ class PreferencesManager(component.Component):
             'anonymous_mode': value['anonymous_mode'],
         }
 
-        if value['type'] == lt.proxy_type.i2p_proxy:
+        if value['type'] == lt.proxy_type_t.i2p_proxy:
             proxy_settings.update(
                 {
-                    'proxy_type': lt.proxy_type.i2p_proxy,
+                    'proxy_type': lt.proxy_type_t.i2p_proxy,
                     'i2p_hostname': value['hostname'],
                     'i2p_port': value['port'],
                 }
             )
-        elif value['type'] != lt.proxy_type.none:
+        elif value['type'] != lt.proxy_type_t.none:
             proxy_settings.update(
                 {
                     'proxy_type': value['type'],

--- a/deluge/core/torrentmanager.py
+++ b/deluge/core/torrentmanager.py
@@ -45,10 +45,10 @@ from deluge.event import (
 log = logging.getLogger(__name__)
 
 LT_DEFAULT_ADD_TORRENT_FLAGS = (
-    lt.add_torrent_params_flags_t.flag_paused
-    | lt.add_torrent_params_flags_t.flag_auto_managed
-    | lt.add_torrent_params_flags_t.flag_update_subscribe
-    | lt.add_torrent_params_flags_t.flag_apply_ip_filter
+    lt.torrent_flags.paused
+    | lt.torrent_flags.auto_managed
+    | lt.torrent_flags.update_subscribe
+    | lt.torrent_flags.apply_ip_filter
 )
 
 
@@ -361,11 +361,11 @@ class TorrentManager(component.Component):
         add_torrent_params['flags'] = (
             (
                 LT_DEFAULT_ADD_TORRENT_FLAGS
-                | lt.add_torrent_params_flags_t.flag_duplicate_is_error
-                | lt.add_torrent_params_flags_t.flag_upload_mode
+                | lt.torrent_flags.duplicate_is_error
+                | lt.torrent_flags.upload_mode
             )
-            ^ lt.add_torrent_params_flags_t.flag_auto_managed
-            ^ lt.add_torrent_params_flags_t.flag_paused
+            ^ lt.torrent_flags.auto_managed
+            ^ lt.torrent_flags.paused
         )
 
         torrent_handle = self.session.add_torrent(add_torrent_params)
@@ -477,15 +477,13 @@ class TorrentManager(component.Component):
         # Set flags: enable duplicate_is_error & override_resume_data, disable auto_managed.
         add_torrent_params['flags'] = (
             LT_DEFAULT_ADD_TORRENT_FLAGS
-            | lt.add_torrent_params_flags_t.flag_duplicate_is_error
+            | lt.torrent_flags.duplicate_is_error
             | lt.add_torrent_params_flags_t.flag_override_resume_data
-        ) ^ lt.add_torrent_params_flags_t.flag_auto_managed
+        ) ^ lt.torrent_flags.auto_managed
         if options['seed_mode']:
-            add_torrent_params['flags'] |= lt.add_torrent_params_flags_t.flag_seed_mode
+            add_torrent_params['flags'] |= lt.torrent_flags.seed_mode
         if options['super_seeding']:
-            add_torrent_params[
-                'flags'
-            ] |= lt.add_torrent_params_flags_t.flag_super_seeding
+            add_torrent_params['flags'] |= lt.torrent_flags.super_seeding
 
         return torrent_id, add_torrent_params
 

--- a/deluge/tests/test_core.py
+++ b/deluge/tests/test_core.py
@@ -23,6 +23,7 @@ from twisted.web.static import File
 import deluge.common
 import deluge.component as component
 import deluge.core.torrent
+from deluge._libtorrent import lt
 from deluge.core.core import Core
 from deluge.core.rpcserver import RPCServer
 from deluge.error import AddTorrentError, InvalidTorrentError
@@ -116,7 +117,13 @@ class CoreTestCase(BaseTestCase):
     def add_torrent(self, filename, paused=False):
         if not paused:
             # Patch libtorrent flags starting torrents paused
-            self.patch(deluge.core.torrentmanager, 'LT_DEFAULT_ADD_TORRENT_FLAGS', 592)
+            self.patch(
+                deluge.core.torrentmanager,
+                'LT_DEFAULT_ADD_TORRENT_FLAGS',
+                lt.torrent_flags.auto_managed
+                | lt.torrent_flags.update_subscribe
+                | lt.torrent_flags.apply_ip_filter,
+            )
         options = {'add_paused': paused, 'auto_managed': False}
         filepath = common.get_test_data_file(filename)
         with open(filepath, 'rb') as _file:

--- a/deluge/tests/test_torrent.py
+++ b/deluge/tests/test_torrent.py
@@ -73,12 +73,14 @@ class TorrentTestCase(BaseTestCase):
         filename = common.get_test_data_file(filename)
         with open(filename, 'rb') as _file:
             info = lt.torrent_info(lt.bdecode(_file.read()))
-        atp = {'ti': info}
-        atp['save_path'] = os.getcwd()
-        atp['storage_mode'] = lt.storage_mode_t.storage_mode_sparse
-        atp['add_paused'] = False
-        atp['auto_managed'] = True
-        atp['duplicate_is_error'] = True
+        atp = lt.add_torrent_params()
+        atp.ti = info
+        atp.save_path = os.getcwd()
+        atp.storage_mode = lt.storage_mode_t.storage_mode_sparse
+        atp.flags |= (
+            lt.torrent_flags.auto_managed
+            | lt.torrent_flags.duplicate_is_error & ~lt.torrent_flags.paused
+        )
         return atp
 
     def test_set_file_priorities(self):


### PR DESCRIPTION
Update libtorrent to version >= 1.2.
Info about the upgrade:
https://github.com/arvidn/libtorrent/blob/RC_1_2/docs/upgrade_to_1.2.rst

TODOs (may change):
- [ ] Change test environments to lt-1.2
- [ ] Fix usage and handling of resume-data
- [ ] Alerts