### PR TITLE
bugfix for peers tab failing to set flag location request.country returns bytes not a string

### DIFF
--- a/deluge/ui/web/server.py
+++ b/deluge/ui/web/server.py
@@ -202,7 +202,7 @@ class Flag(resource.Resource):
         return self
 
     def render(self, request):
-        path = ('ui', 'data', 'pixmaps', 'flags', request.country.lower() + '.png')
+        path = ('ui', 'data', 'pixmaps', 'flags', request.country.decode("utf-8").lower() + '.png')
         filename = common.resource_filename('deluge', os.path.join(*path))
         if os.path.exists(filename):
             request.setHeader(


### PR DESCRIPTION
Running into this downstream: 

https://github.com/linuxserver/docker-deluge/issues/66

Tested locally and flags work for me with this change. 