### PR TITLE
Fallback functionality for dbus file manager

### DIFF
--- a/deluge/common.py
+++ b/deluge/common.py
@@ -363,7 +363,7 @@ def show_file(path, timestamp=None):
             bus = dbus.SessionBus()
             try:
                 filemanager1 = bus.get_object(DBUS_FM_ID, DBUS_FM_PATH)
-            except dbus.exceptions.DBusException as e:
+            except dbus.exceptions.DBusException as ex:
                 log.debug('Unable to get dbus file manager: %s', ex)
                 # Fallback to xdg-open
             else:

--- a/deluge/common.py
+++ b/deluge/common.py
@@ -368,9 +368,7 @@ def show_file(path, timestamp=None):
                 # Fallback to xdg-open
             else:
                 paths = [urljoin('file:', pathname2url(path))]
-                filemanager1.ShowItems(
-                    paths, startup_id, dbus_interface=DBUS_FM_ID
-                )
+                filemanager1.ShowItems(paths, startup_id, dbus_interface=DBUS_FM_ID)
                 return
 
         env = os.environ.copy()


### PR DESCRIPTION
Fallback to the xdg-open option in case, when D-Bus is failing to give us File Manager.
Fixes: https://dev.deluge-torrent.org/ticket/3272