### PR TITLE
[Plugin] Fix argument type for the notification popup hint

### DIFF
--- a/deluge/plugins/Notifications/deluge_notifications/gtkui.py
+++ b/deluge/plugins/Notifications/deluge_notifications/gtkui.py
@@ -18,7 +18,7 @@ import logging
 from os.path import basename
 
 from gi import require_version
-from gi.repository import Gtk, GLib
+from gi.repository import GLib, Gtk
 from twisted.internet import defer
 
 import deluge.common

--- a/deluge/plugins/Notifications/deluge_notifications/gtkui.py
+++ b/deluge/plugins/Notifications/deluge_notifications/gtkui.py
@@ -18,7 +18,7 @@ import logging
 from os.path import basename
 
 from gi import require_version
-from gi.repository import Gtk
+from gi.repository import Gtk, GLib
 from twisted.internet import defer
 
 import deluge.common
@@ -178,7 +178,7 @@ class GtkUiNotifications(CustomNotifications):
 
         if Notify.init('Deluge'):
             self.note = Notify.Notification.new(title, message, 'deluge-panel')
-            self.note.set_hint('desktop-entry', 'deluge')
+            self.note.set_hint('desktop-entry', GLib.Variant('s', 'deluge'))
             if not self.note.show():
                 err_msg = _('Failed to popup notification')
                 log.warning(err_msg)


### PR DESCRIPTION
As per the documentation, since Notify >= 0.6, Notification.set_hint method gets string key and GLib.Variant (instead of string) value.
Ref: http://lazka.github.io/pgi-docs/#Notify-0.7/classes/Notification.html#Notify.Notification.set_hint
http://lazka.github.io/pgi-docs/GLib-2.0/classes/Variant.html#GLib.Variant

Fixes: [#3267](https://dev.deluge-torrent.org/ticket/3267)