### PR TITLE
[GTK] Fix ordering in status tab

### DIFF
--- a/deluge/ui/gtk3/glade/main_window.tabs.ui
+++ b/deluge/ui/gtk3/glade/main_window.tabs.ui
@@ -112,7 +112,7 @@
                               </object>
                               <packing>
                                 <property name="left_attach">1</property>
-                                <property name="top_attach">0</property>
+                                <property name="top_attach">3</property>
                               </packing>
                             </child>
                             <child>
@@ -312,7 +312,7 @@
                               </object>
                               <packing>
                                 <property name="left_attach">1</property>
-                                <property name="top_attach">3</property>
+                                <property name="top_attach">0</property>
                               </packing>
                             </child>
                             <child>


### PR DESCRIPTION
The {download,upload}-{total,speed} columns were a bit mixed up. This sets them right.