### PR TITLE
[GTK3]Fix Deprecated Functions

### DIFF
--- a/deluge/ui/gtk3/filtertreeview.py
+++ b/deluge/ui/gtk3/filtertreeview.py
@@ -89,10 +89,13 @@ class FilterTreeView(component.Component):
         self.treeview.set_headers_visible(False)
         self.treeview.set_level_indentation(-21)
         # Force theme to use expander-size so we don't cut out entries due to indentation hack.
-        Gtk.rc_parse_string(
-            """style "treeview-style" {GtkTreeView::expander-size = 7}
-                            class "GtkTreeView" style "treeview-style" """
-        )
+        style_provider = Gtk.CssProvider()
+        css = b""" * { -GtkTreeView-expander-size: 7;} """
+        try:
+            style_provider.load_from_data(css)
+        except Glib.Error as ex:
+            log.error("Failed to set expander size in filtertreeview", ex)
+            pass
 
         self.treeview.set_model(self.treestore)
         self.treeview.get_selection().connect('changed', self.on_selection_changed)

--- a/deluge/ui/gtk3/listview.py
+++ b/deluge/ui/gtk3/listview.py
@@ -144,7 +144,6 @@ class ListView(object):
         self.liststore = None
         self.model_filter = None
 
-        self.treeview.set_rules_hint(True)
         self.treeview.set_reorderable(False)
         self.treeview.set_rubber_banding(True)  # Enable mouse multi-row selection.
         self.treeview.get_selection().set_mode(Gtk.SelectionMode.MULTIPLE)

--- a/deluge/ui/gtk3/statusbar.py
+++ b/deluge/ui/gtk3/statusbar.py
@@ -143,7 +143,10 @@ class StatusBar(component.Component):
         # Add hbox to the statusbar after removing the initial label widget
         self.hbox = Gtk.Box.new(Gtk.Orientation.HORIZONTAL, spacing=10)
         align = Gtk.Alignment()
-        align.set_padding(2, 0, 3, 0)
+        self.statusbar.set_margin_bottom(10)
+        self.statusbar.set_margin_start(10)
+        self.statusbar.set_margin_end(10)
+        self.statusbar.set_margin_top(10)
         align.add(self.hbox)
         frame = self.statusbar.get_children()[0]
         frame.remove(frame.get_children()[0])


### PR DESCRIPTION
https://developer.gnome.org/gtk3/stable/GtkAlignment.html
gtk_alignment_set_padding has been deprecated since version 3.14 and should not be used in newly-written code.

Use GtkWidget alignment and margin properties

https://developer.gnome.org/gtk3/stable/GtkExpander.html#GtkExpander--s-expander-size
GtkExpander:expander-size has been deprecated since version 3.20 and should not be used in newly-written code.

Use CSS min-width and min-height instead.

TODO Gio.Notification as alternative