### PR TITLE
Ctl+Q to quit Deluge GTK without killing daemon

### DIFF
--- a/deluge/ui/gtk3/glade/main_window.ui
+++ b/deluge/ui/gtk3/glade/main_window.ui
@@ -174,6 +174,7 @@
                         <property name="use_stock">False</property>
                         <property name="accel_group">accelgroup1</property>
                         <signal name="activate" handler="on_menuitem_quit_activate" swapped="no"/>
+                        <accelerator key="Q" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                       </object>
                     </child>
                   </object>


### PR DESCRIPTION
I'm missing this shortcut, and would like to avoid killing the daemon when quitting the UI