### PR TITLE
fixing encoding issue with deluge-console config --set

### DIFF
--- a/deluge/ui/console/cmdline/commands/config.py
+++ b/deluge/ui/console/cmdline/commands/config.py
@@ -41,7 +41,7 @@ def atom(src, token):
             else:
                 if token[1].startswith('0x'):
                     # Hex number so return unconverted as string.
-                    return token[1].decode('string-escape')
+                    return token[1].encode('utf-8').decode('unicode-escape')
                 else:
                     return int(token[1], 0)
         except ValueError:
@@ -54,11 +54,11 @@ def atom(src, token):
     elif token[1].lower() == 'false':
         return False
     elif token[0] is tokenize.STRING or token[1] == '/':
-        return token[-1].decode('string-escape')
+        return token[-1].encode('utf-8').decode('unicode-escape')
     elif token[1].isalpha():
         # Parse Windows paths e.g. 'C:\\xyz' or 'C:/xyz'.
         if next()[1] == ':' and next()[1] in '\\/':
-            return token[-1].decode('string-escape')
+            return token[-1].encode('utf-8').decode('unicode-escape')
 
     raise SyntaxError('malformed expression (%s)' % token[1])
 


### PR DESCRIPTION
Config settings are not decoded correctly, this error can be reproduced with a command like `deluge-console -c /config/ "config --set download_location /downloads"`

```
'str' object has no attribute 'decode'
14:52:04 [ERROR   ][deluge.ui.console.cmdline.command                     :138 ] 'str' object has no attribute 'decode'
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/deluge/ui/console/cmdline/command.py", line 135, in exec_command
    ret = self._commands[options.command].handle(options)
  File "/usr/lib/python3/dist-packages/deluge/ui/console/cmdline/commands/config.py", line 104, in handle
    return self._set_config(options)
  File "/usr/lib/python3/dist-packages/deluge/ui/console/cmdline/commands/config.py", line 143, in _set_config
    val = simple_eval(val)
  File "/usr/lib/python3/dist-packages/deluge/ui/console/cmdline/commands/config.py", line 72, in simple_eval
    res = atom(src, next(src))
  File "/usr/lib/python3/dist-packages/deluge/ui/console/cmdline/commands/config.py", line 57, in atom
    return token[-1].decode('string-escape')
AttributeError: 'str' object has no attribute 'decode'
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/deluge/ui/console/cmdline/command.py", line 135, in exec_command
    ret = self._commands[options.command].handle(options)
  File "/usr/lib/python3/dist-packages/deluge/ui/console/cmdline/commands/config.py", line 104, in handle
    return self._set_config(options)
  File "/usr/lib/python3/dist-packages/deluge/ui/console/cmdline/commands/config.py", line 143, in _set_config
    val = simple_eval(val)
  File "/usr/lib/python3/dist-packages/deluge/ui/console/cmdline/commands/config.py", line 72, in simple_eval
    res = atom(src, next(src))
  File "/usr/lib/python3/dist-packages/deluge/ui/console/cmdline/commands/config.py", line 57, in atom
    return token[-1].decode('string-escape')
AttributeError: 'str' object has no attribute 'decode'
```