### PR TITLE
deluge-web has no option -d

### DIFF
--- a/packaging/systemd/deluge-web.service
+++ b/packaging/systemd/deluge-web.service
@@ -8,7 +8,7 @@ Wants=deluged.service
 Type=simple
 UMask=027
 
-ExecStart=/usr/bin/deluge-web -d
+ExecStart=/usr/bin/deluge-web
 
 Restart=on-failure
 


### PR DESCRIPTION
fixed an error that threw me off while following the instructions on https://deluge.readthedocs.io/en/latest/how-to/systemd-service.html
removed option -d and it works as expected