### PR TITLE
[Logging] Fix Python 3.8 compatibility

### DIFF
--- a/deluge/log.py
+++ b/deluge/log.py
@@ -86,7 +86,7 @@ class Logging(LoggingLoggerClass):
     def exception(self, msg, *args, **kwargs):
         yield LoggingLoggerClass.exception(self, msg, *args, **kwargs)
 
-    def findCaller(self, stack_info=False):  # NOQA: N802
+    def findCaller(self, *args, **kwargs):  # NOQA: N802
         f = logging.currentframe().f_back
         rv = '(unknown file)', 0, '(unknown function)'
         while hasattr(f, 'f_code'):

--- a/deluge/log.py
+++ b/deluge/log.py
@@ -88,7 +88,7 @@ class Logging(LoggingLoggerClass):
 
     def findCaller(self, *args, **kwargs):  # NOQA: N802
         f = logging.currentframe().f_back
-        rv = '(unknown file)', 0, '(unknown function)'
+        rv = ('(unknown file)', 0, '(unknown function)', None)
         while hasattr(f, 'f_code'):
             co = f.f_code
             filename = os.path.normcase(co.co_filename)
@@ -98,12 +98,12 @@ class Logging(LoggingLoggerClass):
             ):
                 f = f.f_back
                 continue
-            if common.PY2:
-                rv = (filename, f.f_lineno, co.co_name)
-            else:
-                rv = (filename, f.f_lineno, co.co_name, None)
+            rv = (co.co_filename, f.f_lineno, co.co_name, None)
             break
-        return rv
+        if common.PY2:
+            return rv[:-1]
+        else:
+            return rv
 
 
 levels = {


### PR DESCRIPTION
Deluge's logger class extends Python's `logging.Logger`. Since Python
3.8, it takes an additional argument `stacklevel`.
The implementation in Deluge does not support that. Instead of working
around the problem by adding the parameter and ignoring it (or copying
code from `logging`), remove the brittle override.
Log messages still seem to work correctly.