### PR TITLE
[Console] Fix incorrect test for when a host is online

### DIFF
--- a/deluge/ui/console/widgets/popup.py
+++ b/deluge/ui/console/widgets/popup.py
@@ -11,6 +11,8 @@ from __future__ import unicode_literals
 
 import logging
 
+import six
+
 from deluge.decorators import overrides
 from deluge.ui.console.modes.basemode import InputKeyHandler
 from deluge.ui.console.utils import curses_util as util
@@ -341,6 +343,10 @@ class MessagePopup(Popup, BaseInputPane):
         width_req=0.5,
         **kwargs
     ):
+        if not isinstance(message, six.string_types):
+            log.warn("Expected string type for message. Got '%s'", type(message))
+            message = str(message)
+
         self.message = message
         Popup.__init__(
             self,


### PR DESCRIPTION
The tests in connectionmanager for when a host is online are broken
and always considers a host as online.

When an error occurs in e.g. in _on_connect_fail, report_message()
in PopupsHandler expects the message to be string, not a Twisted Failure.
Fix by checking if message is string and log a warning before converting
to string.