### PR TITLE
Fix deluge-web.service systemctl

### DIFF
--- a/packaging/systemd/deluge-web.service
+++ b/packaging/systemd/deluge-web.service
@@ -8,7 +8,7 @@ Wants=deluged.service
 Type=simple
 UMask=027
 
-ExecStart=/usr/bin/deluge-web -d
+ExecStart=/usr/bin/deluge-web
 
 Restart=on-failure
 


### PR DESCRIPTION
Because deluge-web don't have `-d` option, delete it.
```
deluge-web: error: no such option: -d
deluge-web.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
```