### PR TITLE
Fix pytest and travis issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
+os: linux
 dist: xenial
-sudo: required
 
 language: python
 python:
@@ -17,7 +17,7 @@ git:
   # Set greater depth to get version from tags.
   depth: 1000
 
-matrix:
+jobs:
   include:
     - name: Unit tests
       env: TOX_ENV=py3
@@ -58,7 +58,7 @@ addons:
 
 # Install dependencies
 install:
-  - pip install tox tox-venv
+  - pip install tox
   # GTKUI tests
   - "if [ $TOX_ENV == 'gtkui' ]; then
     sudo apt install python3-gi python3-gi-cairo gir1.2-gtk-3.0;

--- a/docs/source/devguide/tutorials/01-setup.md
+++ b/docs/source/devguide/tutorials/01-setup.md
@@ -17,7 +17,7 @@ system.
 #### Build tools
 
     sudo apt install git intltool closure-compiler python3-pip
-    pip3 install --user tox tox-venv
+    pip3 install --user tox
 
 You might need to add `~/.local/bin` to your PATH.
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,6 @@
 -r requirements-tests.txt
 sphinx-autobuild
 tox
-tox-venv
 pre-commit
 flake8-blind-except
 flake8-builtins

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,4 +1,4 @@
-pytest != 5.2.3
+pytest != 5.2.3, < 5.4
 pytest-twisted
 pytest-cov
 mock

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ addopts = -p no:warnings --basetemp=_pytest_temp
 [basesetup]
 # Minimum pip and setuptools versions to fix system and travis issues.
 deps =
-    pip >= 10, <= 18.1
+    pip >= 10
     setuptools >= 40
 
 [basetests]
@@ -53,7 +53,7 @@ install_command = python -m pip install --ignore-installed {opts} {packages}
 passenv = DISPLAY PYTHONPATH
 setenv =
     PYTHONPATH = {toxinidir}
-    PYTEST_ADDOPTS = -v -s
+    PYTEST_ADDOPTS = --verbose --capture=no
 sitepackages = True
 deps = {[basetests]deps}
 commands =


### PR DESCRIPTION
 * Error occurring with Pytest 5.4 so pin to below that version.
 * Fix minor issues with Travis config.
 * Use full command-switches for pytest in tox config.