### PR TITLE
Fix warning related to gettext

### DIFF
--- a/deluge/i18n/util.py
+++ b/deluge/i18n/util.py
@@ -114,7 +114,7 @@ def setup_translation():
         # Workaround for Python 2 unicode gettext (keyword removed in Py3).
         kwargs = {} if not deluge.common.PY2 else {'unicode': True}
 
-        gettext.install(I18N_DOMAIN, translations_path, names='ngettext', **kwargs)
+        gettext.install(I18N_DOMAIN, translations_path, names=['ngettext'], **kwargs)
         builtins.__dict__['_n'] = builtins.__dict__['ngettext']
 
         libintl = None


### PR DESCRIPTION
According to the upstream documentation, the name parameter of gettext.install should be a sequence of strings, not a string itself: https://docs.python.org/3.8/library/gettext.html#gettext.install

This was causing a warning when deluge was built against python 3.8.