### PR TITLE
[#3309|GTK] Fix cmp function for None types

### DIFF
--- a/deluge/tests/test_ui_gtk3.py
+++ b/deluge/tests/test_ui_gtk3.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Deluge and is licensed under GNU General Public License 3.0, or later, with
+# the additional special exception to link portions of this program with the OpenSSL library.
+# See LICENSE for more details.
+#
+
+from __future__ import unicode_literals
+
+import sys
+
+import mock
+import pytest
+from twisted.trial import unittest
+
+
+@pytest.mark.gtkui
+class GTK3CommonTestCase(unittest.TestCase):
+    def setUp(self):
+        sys.modules['gi.repository'] = mock.MagicMock()
+
+    def tearDown(self):
+        pass
+
+    def test_cmp(self):
+        from deluge.ui.gtk3.common import cmp
+
+        self.assertEqual(cmp(None, None), 0)
+        self.assertEqual(cmp(1, None), 1)
+        self.assertEqual(cmp(0, None), 1)
+        self.assertEqual(cmp(None, 7), -1)
+        self.assertEqual(cmp(None, 'bar'), -1)
+        self.assertEqual(cmp('foo', None), 1)
+        self.assertEqual(cmp('', None), 1)

--- a/deluge/ui/gtk3/common.py
+++ b/deluge/ui/gtk3/common.py
@@ -42,7 +42,18 @@ def cmp(x, y):
     and strictly positive if x > y.
     """
 
-    return (x > y) - (x < y)
+    try:
+        return (x > y) - (x < y)
+    except TypeError:
+        # Handle NoneType comparison
+        if x is None:
+            if y is None:
+                return 0
+            return -1
+        elif y is None:
+            return 1
+        else:
+            raise
 
 
 def create_blank_pixbuf(size=16):


### PR DESCRIPTION
Comparisons on Python 3 are much stricter resulting in the following
error comparing with None:

    TypeError: '>' not supported between instances of 'NoneType' and 'str'

Fix this by getting the type of the other value and getting it's default
value.