### PR TITLE
[Core] Changed on_alert_tracker_error behavior for lt >= 1.2

### DIFF
--- a/deluge/core/torrent.py
+++ b/deluge/core/torrent.py
@@ -991,6 +991,8 @@ class Torrent(object):
                 call to get_status based on the session_id
             update (bool): If True the status will be updated from libtorrent
                 if False, the cached values will be returned
+            all_keys (bool): If True return all keys while ignoring the keys param
+                if False, return only the requested keys
 
         Returns:
             dict: a dictionary of the status keys and their values


### PR DESCRIPTION
libtorrent 1.2 added endpoint struct to each tracker, to prevent false updates
we will need to verify that at least one endpoint to the errored tracker is working.
if there is at least one working, it will not set the tracker status to error and set it to
`Announce OK`. otherwise, it will use the error message from the alert.

Should handle [3384](https://dev.deluge-torrent.org/ticket/3384).