### PR TITLE
AutoAdd Function does not apply 'Label' - This should fix that.

### DIFF
--- a/deluge/plugins/AutoAdd/deluge_autoadd/core.py
+++ b/deluge/plugins/AutoAdd/deluge_autoadd/core.py
@@ -340,6 +340,8 @@ class Core(CorePluginBase):
                     d = component.get('Core').add_torrent_magnet(
                         filedump.strip(), options
                     )
+                    d.addCallback(on_torrent_added, filename, filepath)
+                    d.addErrback(fail_torrent_add, filepath, magnet)
                 else:
                     d = component.get('Core').add_torrent_file_async(
                         filename, b64encode(filedump), options


### PR DESCRIPTION
The autoadd function does not apply labels to torrents that are added via magnet files. 
Those magnet files are also renamed ".Magnet.Invalid". 

Here are two threads discussing the issue, which still exists. 

- https://forum.deluge-torrent.org/viewtopic.php?t=55539
- https://dev.deluge-torrent.org/ticket/3295

Here is what Deluged.log shows when the problem occurs:

```
21:51:38 [ERROR   ][deluge_autoadd.core           :333 ] Cannot Autoadd magnet: /Torrents/TorrentFiles/FileName.magnet: Torrent already in session (e1e0f33b656cb74532dcddc04f2ec52771ef1c26).
21:56:38 [ERROR   ][deluge_autoadd.core           :333 ] Cannot Autoadd magnet: /Torrents/TorrentFiles/FileName2.magnet: Torrent already in session (ef839d84d113cc35719b6fd616a4d8e220de7d32).
```

After looking at the code, what appears to be happening is the magnet link is added, but then a second scan of the folder occurs. Since the magnet file was never renamed, it will attempt to add it again, error out, then rename the file "magnet.invalid". 

The only difference between the torrents working properly and magnets having the issue is the two lines I copy-pasted into the magnet IF statement. This should resolve the issue. 