### PR TITLE
Set alt/title attribute for better accessibility

### DIFF
--- a/deluge/ui/web/js/deluge-all/details/PeersTab.js
+++ b/deluge/ui/web/js/deluge-all/details/PeersTab.js
@@ -14,7 +14,7 @@
             return '';
         }
         return String.format(
-            '<img src="{0}flag/{1}" />',
+            '<img alt="{1}" title="{1}" src="{0}flag/{1}" />',
             deluge.config.base,
             value
         );


### PR DESCRIPTION
This allows viewing the country in textual form by hovering the flag image and displays it if the image couldn't be loaded.