### PR TITLE
[Console, Gtk] Fix formatting of time units

### DIFF
--- a/deluge/common.py
+++ b/deluge/common.py
@@ -568,7 +568,7 @@ def ftime(secs):
 
     Examples:
         >>> ftime(23011)
-        '6h 23m'
+        '6 h 23 min'
 
     Note:
         This function has been refactored for perfomance.
@@ -580,17 +580,17 @@ def ftime(secs):
     if secs <= 0:
         time_str = ''
     elif secs < 60:
-        time_str = '{}s'.format(secs)
+        time_str = '{} s'.format(secs)
     elif secs < 3600:
-        time_str = '{}m {}s'.format(secs // 60, secs % 60)
+        time_str = '{} min {} s'.format(secs // 60, secs % 60)
     elif secs < 86400:
-        time_str = '{}h {}m'.format(secs // 3600, secs // 60 % 60)
+        time_str = '{} h {} min'.format(secs // 3600, secs // 60 % 60)
     elif secs < 604800:
-        time_str = '{}d {}h'.format(secs // 86400, secs // 3600 % 24)
+        time_str = '{} d {} h'.format(secs // 86400, secs // 3600 % 24)
     elif secs < 31449600:
-        time_str = '{}w {}d'.format(secs // 604800, secs // 86400 % 7)
+        time_str = '{} wk {} d'.format(secs // 604800, secs // 86400 % 7)
     else:
-        time_str = '{}y {}w'.format(secs // 31449600, secs // 604800 % 52)
+        time_str = '{} y {} wk'.format(secs // 31449600, secs // 604800 % 52)
 
     return time_str
 

--- a/deluge/tests/test_common.py
+++ b/deluge/tests/test_common.py
@@ -70,16 +70,16 @@ class CommonTestCase(unittest.TestCase):
 
     def test_ftime(self):
         self.assertEqual(ftime(0), '')
-        self.assertEqual(ftime(5), '5s')
-        self.assertEqual(ftime(100), '1m 40s')
-        self.assertEqual(ftime(3789), '1h 3m')
-        self.assertEqual(ftime(23011), '6h 23m')
-        self.assertEqual(ftime(391187), '4d 12h')
-        self.assertEqual(ftime(604800), '1w 0d')
-        self.assertEqual(ftime(13893086), '22w 6d')
-        self.assertEqual(ftime(59740269), '1y 46w')
-        self.assertEqual(ftime(61.25), '1m 1s')
-        self.assertEqual(ftime(119.9), '1m 59s')
+        self.assertEqual(ftime(5), '5 s')
+        self.assertEqual(ftime(100), '1 min 40 s')
+        self.assertEqual(ftime(3789), '1 h 3 min')
+        self.assertEqual(ftime(23011), '6 h 23 min')
+        self.assertEqual(ftime(391187), '4 d 12 h')
+        self.assertEqual(ftime(604800), '1 wk 0 d')
+        self.assertEqual(ftime(13893086), '22 wk 6 d')
+        self.assertEqual(ftime(59740269), '1 y 46 wk')
+        self.assertEqual(ftime(61.25), '1 min 1 s')
+        self.assertEqual(ftime(119.9), '1 min 59 s')
 
     def test_fdate(self):
         self.assertTrue(fdate(-1) == '')

--- a/deluge/ui/web/js/deluge-all/Formatters.js
+++ b/deluge/ui/web/js/deluge-all/Formatters.js
@@ -120,7 +120,7 @@ Deluge.Formatters = {
         }
         time = time.toFixed(0);
         if (time < 60) {
-            return time + 's';
+            return time + ' s';
         } else {
             time = time / 60;
         }
@@ -129,9 +129,9 @@ Deluge.Formatters = {
             var minutes = Math.floor(time);
             var seconds = Math.round(60 * (time - minutes));
             if (seconds > 0) {
-                return minutes + 'm ' + seconds + 's';
+                return minutes + ' min ' + seconds + ' s';
             } else {
-                return minutes + 'm';
+                return minutes + ' min';
             }
         } else {
             time = time / 60;
@@ -141,9 +141,9 @@ Deluge.Formatters = {
             var hours = Math.floor(time);
             var minutes = Math.round(60 * (time - hours));
             if (minutes > 0) {
-                return hours + 'h ' + minutes + 'm';
+                return hours + ' h ' + minutes + ' min';
             } else {
-                return hours + 'h';
+                return hours + ' h';
             }
         } else {
             time = time / 24;
@@ -152,9 +152,9 @@ Deluge.Formatters = {
         var days = Math.floor(time);
         var hours = Math.round(24 * (time - days));
         if (hours > 0) {
-            return days + 'd ' + hours + 'h';
+            return days + ' d ' + hours + ' h';
         } else {
-            return days + 'd';
+            return days + ' d';
         }
     },
 


### PR DESCRIPTION
This commits fixes the formatting of time units to be compliant
with the SI. It also updates the abbreviation of the week to the
prevalent one.