### PR TITLE
[WebUI] Fix filelistings md5sum

### DIFF
--- a/deluge/tests/data/md5sum.torrent
+++ b/deluge/tests/data/md5sum.torrent
@@ -1,0 +1,1 @@
+d8:announce25:lol.this.is.not.a.tracker7:comment36:created with py3createtorrent v0.9.610:created by23:py3createtorrent v0.9.613:creation datei1590076175e4:infod5:filesld6:lengthi4e6:md5sum32:59bcc3ad6775562f845953cf016242254:pathl3:loleed6:lengthi5e6:md5sum32:10245815f893d79f3d779690774f0b434:pathl4:rofleee4:name4:test12:piece lengthi16384e6:pieces20:û8éß6A¢Ú²ú-Y>+S]\/ßee

--- a/deluge/tests/test_web_api.py
+++ b/deluge/tests/test_web_api.py
@@ -9,6 +9,7 @@
 
 from __future__ import unicode_literals
 
+import json
 from io import BytesIO
 
 from twisted.internet import defer, reactor
@@ -128,6 +129,16 @@ class WebAPITestCase(WebServerTestBase):
         ret = self.deluge_web.web_api.get_torrent_info(filename)
         self.assertEqual(ret['name'], 'azcvsupdater_2.6.2.jar')
         self.assertEqual(ret['info_hash'], 'ab570cdd5a17ea1b61e970bb72047de141bce173')
+        self.assertTrue('files_tree' in ret)
+
+    def test_get_torrent_info_with_md5(self):
+        filename = common.get_test_data_file('md5sum.torrent')
+        ret = self.deluge_web.web_api.get_torrent_info(filename)
+        # JSON dumping happens during response creation in normal usage
+        # JSON serialization may fail if any of the dictionary items are byte arrays rather than strings
+        ret = json.loads(json.dumps(ret))
+        self.assertEqual(ret['name'], 'test')
+        self.assertEqual(ret['info_hash'], 'f6408ba9944cf9fe01b547b28f336b3ee6ec32c5')
         self.assertTrue('files_tree' in ret)
 
     def test_get_magnet_info(self):

--- a/deluge/ui/common.py
+++ b/deluge/ui/common.py
@@ -262,9 +262,11 @@ class TorrentInfo(object):
 
                 def walk(path, item):
                     if item['type'] == 'dir':
-                        item.update(dirs[path])
+                        item['length'] = dirs[path]['length']
                     else:
-                        item.update(paths[path])
+                        item['path'] = paths[path]['path']
+                        item['length'] = paths[path]['length']
+                        item['index'] = paths[path]['index']
                     item['download'] = True
 
                 file_tree = FileTree2(list(paths))


### PR DESCRIPTION
I encountered a bug in the web-ui when uploading a torrent file with file md5sums (as created by py3createtorrent when using the --md5 flag). No files would be shown in the file list for such files, the torrent could not be added.

This PR adds a test with an example torrent file as well as a fix. The fix relies on explicitly selecting expected dictionary fields, thereby avoiding a situation where json serialization is performed on a dictionary containing a byte array (which fails).

As far as I can tell other modules in deluge which also retrieve the metadata using libtorrent already do a variant of the explicit selection process that I added.

Let me know what you need to get this merged :)