### PR TITLE
[#3299|GTK] Fix spin_share_ratio min clamps to 0.5

### DIFF
--- a/deluge/ui/gtk3/glade/preferences_dialog.ui
+++ b/deluge/ui/gtk3/glade/preferences_dialog.ui
@@ -16,7 +16,6 @@
     <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment_share_ratio">
-    <property name="lower">0.5</property>
     <property name="upper">100</property>
     <property name="value">2</property>
     <property name="step_increment">0.10000000000000001</property>


### PR DESCRIPTION
In gtkui Settings -> Queue -> "Share Ratio", we cannot set values lower than 0.5.

Attempting to set lower values results in:

    * ConfigValueChanged: stop_seed_ratio: 0.5

Deluge Web UI, Deluge Console allow setting values as low as 0.0:

    * ConfigValueChanged: stop_seed_ratio: 0.0

Fixed by decreasing the lower clamp in gtkui to match webui.