### PR TITLE
Remove nonexistent web argument from Linux docs

### DIFF
--- a/docs/source/how-to/systemd-service.md
+++ b/docs/source/how-to/systemd-service.md
@@ -136,7 +136,7 @@ ExecStart=/usr/bin/deluged -d -l /var/log/deluge/daemon.log -L warning
 ```
 
 ```
-ExecStart=/usr/bin/deluge-web -d -l /var/log/deluge/web.log -L warning
+ExecStart=/usr/bin/deluge-web -l /var/log/deluge/web.log -L warning
 ```
 
 See `deluged -h` for all available log-levels.

--- a/packaging/systemd/deluge-web.service
+++ b/packaging/systemd/deluge-web.service
@@ -8,7 +8,7 @@ Wants=deluged.service
 Type=simple
 UMask=027
 
-ExecStart=/usr/bin/deluge-web -d
+ExecStart=/usr/bin/deluge-web
 
 Restart=on-failure
 


### PR DESCRIPTION
This commit fixes the issue that the docs for setting up a systemd service specify a `-d` argument for both deluged and deluge-web, that does not actually exist (anymore?) for deluge-web:
https://github.com/deluge-torrent/deluge/blob/b1cdc32f7357e9777eb6cc2d90094c7d122af2eb/deluge/ui/web/web.py