### PR TITLE
rm -c flag conflicts with --config shortcut

### DIFF
--- a/deluge/ui/console/cmdline/commands/rm.py
+++ b/deluge/ui/console/cmdline/commands/rm.py
@@ -33,7 +33,6 @@ class Command(BaseCommand):
             help=_('Also removes the torrent data'),
         )
         parser.add_argument(
-            '-c',
             '--confirm',
             action='store_true',
             default=False,


### PR DESCRIPTION
cf. https://github.com/deluge-torrent/deluge/blob/master/deluge/argparserbase.py#L191

This bug triggers "Password does not match" errors when "rm -c" is used