### PR TITLE
[#3439] Execute plugin fails to run on Windows, exception thrown 

### DIFF
--- a/deluge/plugins/Execute/deluge_execute/core.py
+++ b/deluge/plugins/Execute/deluge_execute/core.py
@@ -135,7 +135,7 @@ class Core(CorePluginBase):
                 ]
                 if windows_check():
                     # Escape ampersand on windows (see #2784)
-                    cmd_args = [cmd_arg.replace('&', '^^^&') for cmd_arg in cmd_args]
+                    cmd_args = [cmd_arg.replace(b'&', b'^^^&') for cmd_arg in cmd_args]
 
                 if os.path.isfile(command) and os.access(command, os.X_OK):
                     log.debug('Running %s with args: %s', command, cmd_args)


### PR DESCRIPTION
Execute plugin fails to run on Windows. Issue is due to the migration from Python 2 to Python 3, and the different handling of strings and bytes. Following exception is thrown when attempting to execute a script: 

```
Traceback (most recent call last):
  File "c:\users\chris\appdata\roaming\deluge\plugins\execute-1.3d-py3.8.egg\deluge_execute\core.py", line 139, in execute_commands
    cmd_args = [cmd_arg.replace('&', '^^^&') for cmd_arg in cmd_args]
  File "c:\users\chris\appdata\roaming\deluge\plugins\execute-1.3d-py3.8.egg\deluge_execute\core.py", line 139, in <listcomp>
    cmd_args = [cmd_arg.replace('&', '^^^&') for cmd_arg in cmd_args]
TypeError: a bytes-like object is required, not 'str'
```