### PR TITLE
[UI] fix tracker icon download function in python3

### DIFF
--- a/deluge/ui/tracker_icons.py
+++ b/deluge/ui/tracker_icons.py
@@ -12,6 +12,7 @@ from __future__ import unicode_literals
 import logging
 import os
 from tempfile import mkstemp
+from six import string_types
 
 from twisted.internet import defer, threads
 from twisted.web.error import PageRedirect
@@ -178,7 +179,10 @@ class TrackerIcons(Component):
         :returns: the TrackerIcon for the host
         :rtype: TrackerIcon
         """
-        host = host.lower()
+        if isinstance(host, string_types):
+            host = host.lower()
+        else:
+            host = host.lower().decode()
         if host in self.icons:
             return self.icons[host]
         else:
@@ -195,7 +199,10 @@ class TrackerIcons(Component):
         :returns: a Deferred which fires with the TrackerIcon for the given host
         :rtype: Deferred
         """
-        host = host.lower()
+        if isinstance(host, string_types):
+            host = host.lower()
+        else:
+            host = host.lower().decode()
         if host in self.icons:
             # We already have it, so let's return it
             d = defer.succeed(self.icons[host])

--- a/deluge/ui/tracker_icons.py
+++ b/deluge/ui/tracker_icons.py
@@ -12,7 +12,6 @@ from __future__ import unicode_literals
 import logging
 import os
 from tempfile import mkstemp
-from six import string_types
 
 from twisted.internet import defer, threads
 from twisted.web.error import PageRedirect
@@ -179,10 +178,7 @@ class TrackerIcons(Component):
         :returns: the TrackerIcon for the host
         :rtype: TrackerIcon
         """
-        if isinstance(host, string_types):
-            host = host.lower()
-        else:
-            host = host.lower().decode()
+        host = host.lower()
         if host in self.icons:
             return self.icons[host]
         else:
@@ -199,10 +195,7 @@ class TrackerIcons(Component):
         :returns: a Deferred which fires with the TrackerIcon for the given host
         :rtype: Deferred
         """
-        if isinstance(host, string_types):
-            host = host.lower()
-        else:
-            host = host.lower().decode()
+        host = host.lower()
         if host in self.icons:
             # We already have it, so let's return it
             d = defer.succeed(self.icons[host])

--- a/deluge/ui/web/server.py
+++ b/deluge/ui/web/server.py
@@ -32,8 +32,6 @@ from deluge.ui.web.common import Template
 from deluge.ui.web.json_api import JSON, WebApi, WebUtils
 from deluge.ui.web.pluginmanager import PluginManager
 
-from six import string_types
-
 log = logging.getLogger(__name__)
 
 CONFIG_DEFAULTS = {
@@ -176,10 +174,7 @@ class Tracker(resource.Resource):
             self.tracker_icons = TrackerIcons()
 
     def getChild(self, path, request):  # NOQA: N802
-        if isinstance(path, string_types):
-            request.tracker_name = path
-        else:
-            request.tracker_name = path.decode()
+        request.tracker_name = path
         return self
 
     def on_got_icon(self, icon, request):
@@ -196,7 +191,7 @@ class Tracker(resource.Resource):
             request.finish()
 
     def render(self, request):
-        d = self.tracker_icons.fetch(request.tracker_name)
+        d = self.tracker_icons.fetch(request.tracker_name.decode())
         d.addCallback(self.on_got_icon, request)
         return server.NOT_DONE_YET
 

--- a/deluge/ui/web/server.py
+++ b/deluge/ui/web/server.py
@@ -32,6 +32,8 @@ from deluge.ui.web.common import Template
 from deluge.ui.web.json_api import JSON, WebApi, WebUtils
 from deluge.ui.web.pluginmanager import PluginManager
 
+from six import string_types
+
 log = logging.getLogger(__name__)
 
 CONFIG_DEFAULTS = {
@@ -174,7 +176,10 @@ class Tracker(resource.Resource):
             self.tracker_icons = TrackerIcons()
 
     def getChild(self, path, request):  # NOQA: N802
-        request.tracker_name = path
+        if isinstance(path, string_types):
+            request.tracker_name = path
+        else:
+            request.tracker_name = path.decode()
         return self
 
     def on_got_icon(self, icon, request):


### PR DESCRIPTION
to avoid such error in python3 caused by different string type
```
Error occurred downloading file from "http://b'acg.rip'/": invalid hostname: b'acg.rip'
```