### PR TITLE
[Console] Fix setting 'Skip' priority

### DIFF
--- a/deluge/ui/console/modes/torrentdetail.py
+++ b/deluge/ui/console/modes/torrentdetail.py
@@ -710,7 +710,7 @@ class TorrentDetail(BaseMode, PopupsHandler):
                 'skip_priority',
                 '_Skip',
                 foreground='red',
-                cb_arg=FILE_PRIORITY['Low'],
+                cb_arg=FILE_PRIORITY['Skip'],
                 was_empty=was_empty,
             )
             popup.add_line(


### PR DESCRIPTION
Selecting priorities 'Low' and 'Skip' on console will both set the actual priority to 'Low'. This PR fixes that. 