### PR TITLE
[GTKUI] Added detection of torrent URL on GTK UI focus 

### DIFF
--- a/deluge/core/preferencesmanager.py
+++ b/deluge/core/preferencesmanager.py
@@ -231,7 +231,7 @@ class PreferencesManager(component.Component):
         self.core.apply_session_settings(
             {
                 'listen_system_port_fallback': self.config['listen_use_sys_port'],
-                'listen_interfaces': ''.join(interfaces),
+                'listen_interfaces': ','.join(interfaces),
             }
         )
 

--- a/deluge/ui/gtk3/glade/preferences_dialog.ui
+++ b/deluge/ui/gtk3/glade/preferences_dialog.ui
@@ -505,6 +505,33 @@ and daemon (does not apply in Standalone mode).</property>
                                           </packing>
                                         </child>
                                         <child>
+                                          <object class="GtkCheckButton" id="urldetect_toggle">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="tooltip_text" translatable="yes">When checked, 
+Deluge will automatically pop up the Add Torrent dialog when
+a torrent URL is detected on the clipboard</property>
+                                            <property name="draw_indicator">True</property>
+                                            <signal name="toggled" handler="on_urldetect_toggle_toggled" swapped="no"/>
+                                            <child>
+                                              <object class="GtkLabel" id="label63">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="halign">start</property>
+                                                <property name="label" translatable="yes">Detect torrent URLs from clipboard.</property>
+                                                <property name="use_markup">True</property>
+                                              </object>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">True</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">2</property>
+                                          </packing>
+                                        </child>
+ 
+                                        <child>
                                           <object class="GtkExpander" id="piecebar_colors_expander">
                                             <property name="can_focus">True</property>
                                             <child>

--- a/deluge/ui/gtk3/gtkui.py
+++ b/deluge/ui/gtk3/gtkui.py
@@ -129,6 +129,7 @@ DEFAULT_PREFS = {
     'show_rate_in_title': False,
     'createtorrent.trackers': [],
     'show_piecesbar': False,
+    'detect_urls': True,
     'pieces_color_missing': [65535, 0, 0],
     'pieces_color_waiting': [4874, 56494, 0],
     'pieces_color_downloading': [65535, 55255, 0],

--- a/deluge/ui/gtk3/mainwindow.py
+++ b/deluge/ui/gtk3/mainwindow.py
@@ -14,17 +14,17 @@ import os.path
 from hashlib import sha1 as sha
 
 import gi
-from gi.repository import Gdk, Gtk
+from gi.repository import Gtk
 from gi.repository.Gdk import DragAction, WindowState
 from twisted.internet import reactor
 from twisted.internet.error import ReactorNotRunning
 
 import deluge.component as component
-from deluge.common import decode_bytes, fspeed, resource_filename, is_url, is_magnet
+from deluge.common import decode_bytes, fspeed, is_magnet, is_url, resource_filename
 from deluge.configmanager import ConfigManager
 from deluge.ui.client import client
 
-from .common import get_deluge_icon, windowing, get_clipboard_text
+from .common import get_clipboard_text, get_deluge_icon, windowing
 from .dialogs import PasswordDialog
 from .ipcinterface import process_args
 
@@ -148,7 +148,7 @@ class MainWindow(component.Component):
             'NewVersionAvailableEvent', self.on_newversionavailable_event
         )
 
-        self.previous_text = ''
+        self.previous_clipboard_text = ''
         self.first_run = True
 
     def connect_signals(self, mapping_or_class):
@@ -334,12 +334,11 @@ class MainWindow(component.Component):
         component.get('SystemTray').blink(False)
 
     def on_focus(self, window, param):
-        if window.props.is_active and not self.first_run:
+        if window.props.is_active and not self.first_run and self.config['detect_urls']:
             text = get_clipboard_text()
-            if text == self.previous_text:
+            if text == self.previous_clipboard_text:
                 return
-            else:
-                self.previous_text = text
+            self.previous_clipboard_text = text
             if text and ((is_url(text) and text.endswith('.torrent')) or is_magnet(text)):
                 component.get('AddTorrentDialog').show()
                 component.get('AddTorrentDialog').on_button_url_clicked(window)
@@ -397,4 +396,3 @@ class MainWindow(component.Component):
                     return win.is_on_workspace(active_wksp)
                 return False
         return True
-

--- a/deluge/ui/gtk3/mainwindow.py
+++ b/deluge/ui/gtk3/mainwindow.py
@@ -339,7 +339,9 @@ class MainWindow(component.Component):
             if text == self.previous_clipboard_text:
                 return
             self.previous_clipboard_text = text
-            if text and ((is_url(text) and text.endswith('.torrent')) or is_magnet(text)):
+            if text and (
+                (is_url(text) and text.endswith('.torrent')) or is_magnet(text)
+            ):
                 component.get('AddTorrentDialog').show()
                 component.get('AddTorrentDialog').on_button_url_clicked(window)
         self.first_run = False

--- a/deluge/ui/gtk3/preferences.py
+++ b/deluge/ui/gtk3/preferences.py
@@ -571,6 +571,9 @@ class Preferences(component.Component):
         self.builder.get_object('piecesbar_toggle').set_active(
             self.gtkui_config['show_piecesbar']
         )
+        self.builder.get_object('urldetect_toggle').set_active(
+            self.gtkui_config['detect_urls']
+        )
         self.__set_color('completed', from_config=True)
         self.__set_color('downloading', from_config=True)
         self.__set_color('waiting', from_config=True)
@@ -1462,6 +1465,9 @@ class Preferences(component.Component):
         self.gtkui_config['show_piecesbar'] = widget.get_active()
         colors_widget = self.builder.get_object('piecebar_colors_expander')
         colors_widget.set_visible(widget.get_active())
+
+    def on_urldetect_toggle_toggled(self, widget):
+        self.gtkui_config['detect_urls'] = widget.get_active()
 
     def on_checkbutton_language_toggled(self, widget):
         self.language_combo.set_visible(not self.language_checkbox.get_active())


### PR DESCRIPTION
There is a feature in Transmission Remote GUI that pops up the "Add torrent" dialog automatically if it detects that there is a torrent URL on the clipboard when the program gets focus. This is a preliminary implementation of that feature in Deluge.

At the moment, it works, but it does not have the intelligence to check if the torrent on the clipboard is already being downloaded. On IRC, I was adviced to "grab the .torrent and check to see if the hash already exists", but this seems like a rather heavy operation to perform each time the program gets focus with a torrent URL on the clipboard. 