### PR TITLE
remove deluge-web -d param

### DIFF
--- a/docs/source/how-to/systemd-service.md
+++ b/docs/source/how-to/systemd-service.md
@@ -136,7 +136,7 @@ ExecStart=/usr/bin/deluged -d -l /var/log/deluge/daemon.log -L warning
 ```
 
 ```
-ExecStart=/usr/bin/deluge-web -d -l /var/log/deluge/web.log -L warning
+ExecStart=/usr/bin/deluge-web -l /var/log/deluge/web.log -L warning
 ```
 
 See `deluged -h` for all available log-levels.


### PR DESCRIPTION
deluge-web does not support a -d parameter, which results in a problem, when one tries to start it like in this tutorial. I would therefore recommend to remove it. I dont know, if the parameter was removed or something, but it is not valid at the moment.