### PR TITLE
Update deluge-web.service

### DIFF
--- a/packaging/systemd/deluge-web.service
+++ b/packaging/systemd/deluge-web.service
@@ -8,7 +8,7 @@ Wants=deluged.service
 Type=simple
 UMask=027
 
-ExecStart=/usr/bin/deluge-web -d
+ExecStart=/usr/bin/deluge-web
 
 Restart=on-failure
 


### PR DESCRIPTION
deluge-web doesn't seem to have a -d option. This bit gives me this error message:

Jul 23 19:00:33 raspberrypi systemd[1]: deluge-web.service: Main process exited, code=exited, status=2/INVALIDARGUMENT
Jul 23 19:00:33 raspberrypi systemd[1]: deluge-web.service: Failed with result 'exit-code'.