### PR TITLE
Support libtorrent 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ deluge/ui/web/js/extjs/ext-extensions*.js
 osx/app
 RELEASE-VERSION
 .venv*
+# used by setuptools to cache downloaded eggs
+/.eggs

--- a/deluge/core/core.py
+++ b/deluge/core/core.py
@@ -358,8 +358,8 @@ class Core(component.Component):
 
         if blocks_read:
             self.session_status['read_hit_ratio'] = (
-                self.session_status['disk.num_blocks_cache_hits'] / blocks_read
-            )
+                blocks_read - self.session_status['disk.num_read_ops']
+            ) / blocks_read
         else:
             self.session_status['read_hit_ratio'] = 0.0
 


### PR DESCRIPTION
Minor fixes to support libtorrent 2:

- The `disk.num_blocks_cache_hits` stat was removed entirely (see https://github.com/arvidn/libtorrent/commit/569d47c3914d1f4a8672b92166ee461b4ae33aef)
- Fix continuous warnings about nonexistent stats from the stats plugin

~~The following patch to libtorrent is needed to fix a binding issue with torrent file progress: https://github.com/arvidn/libtorrent/pull/6350~~ https://github.com/arvidn/libtorrent/pull/6369 was merged

Tests hang on my machine for some reason, but I have tested manually and it works with libtorrent 2.0.4.