### PR TITLE
Update deluge-web.service

### DIFF
--- a/packaging/systemd/deluge-web.service
+++ b/packaging/systemd/deluge-web.service
@@ -8,7 +8,7 @@ Wants=deluged.service
 Type=simple
 UMask=027
 
-ExecStart=/usr/bin/deluge-web -d
+ExecStart=/usr/bin/deluge-web
 
 Restart=on-failure
 


### PR DESCRIPTION
The flag -d does not exist and will cause the following error:

deluge-web -d -l /var/log/deluge/web.log -L warning
Usage: deluge-web [options] [actions]

deluge-web: error: no such option: -d

uname -srvo
Linux 4.19.0-17-amd64 #1 SMP Debian 4.19.194-3 (2021-07-18) GNU/Linux