### PR TITLE
[Plugins] Fix allow enabling any plugin Python version

### DIFF
--- a/deluge/pluginmanagerbase.py
+++ b/deluge/pluginmanagerbase.py
@@ -105,7 +105,7 @@ class PluginManagerBase(object):
 
         for dirname in plugin_dirs:
             pkg_resources.working_set.add_entry(dirname)
-        self.pkg_env = pkg_resources.Environment(plugin_dirs, None)
+        self.pkg_env = pkg_resources.Environment(plugin_dirs, platform=None, python=None)
 
         self.available_plugins = []
         for name in self.pkg_env:


### PR DESCRIPTION
Properly fix allow enabling any plugin Python version, first attempted in previous commit 3433a91