### PR TITLE
[GTK3] Support using the Ayatana fork of indicators.

### DIFF
--- a/deluge/ui/gtk3/systemtray.py
+++ b/deluge/ui/gtk3/systemtray.py
@@ -30,8 +30,12 @@ from .common import build_menu_radio_list, get_logo
 from .dialogs import OtherDialog
 
 try:
-    require_version('AppIndicator3', '0.1')
-    from gi.repository import AppIndicator3
+    try:
+        require_version('AyatanaAppIndicator3', '0.1')
+        from gi.repository import AyatanaAppIndicator3 as AppIndicator3
+    except (ValueError, ImportError):
+        require_version('AppIndicator3', '0.1')
+        from gi.repository import AppIndicator3
 except (ValueError, ImportError):
     AppIndicator3 = None
 


### PR DESCRIPTION
As this fork is maintained in Debian, and as of Impish/21.10 is the supported variant in Ubuntu as well, as such try it first.