### PR TITLE
[WebUI] Fixed ETA sorting in WebUI

### DIFF
--- a/deluge/ui/web/js/deluge-all/TorrentGrid.js
+++ b/deluge/ui/web/js/deluge-all/TorrentGrid.js
@@ -67,7 +67,9 @@
     }
 
     function etaSorter(eta) {
-        return eta * -1;
+        if (eta === 0) return Number.MAX_VALUE;
+        if (eta <= -1) return Number.MAX_SAFE_INTEGER;
+        return eta;
     }
 
     function dateOrNever(date) {
@@ -75,7 +77,9 @@
     }
 
     function timeOrInf(time) {
-        return time < 0 ? '&infin;' : ftime(time);
+        if (time === 0) return '';
+        if (time <= -1) return '&infin;';
+        return ftime(time);
     }
 
     /**


### PR DESCRIPTION
When sorting the according to ETA values, all torrents with infinite value were being
considered a lower value (INF -> 12 -> 32) instead of largest (12 -> 32 -> INF).
This is due to the fact that the INF symbol is placed to lower value (<= 0).
Now the lower values are being treated as the largest JS number when sorting.

Closes https://dev.deluge-torrent.org/ticket/3413