### PR TITLE
Add Keywords property to desktop file

### DIFF
--- a/deluge/ui/data/share/applications/deluge.desktop.in
+++ b/deluge/ui/data/share/applications/deluge.desktop.in
@@ -4,6 +4,7 @@ _Name=Deluge
 _GenericName=BitTorrent Client
 _X-GNOME-FullName=Deluge BitTorrent Client
 _Comment=Download and share files over BitTorrent
+_Keywords=bittorrent;torrent;magnet;download;p2p;torrents;downloading;uploading;share;sharing;
 TryExec=deluge-gtk
 Exec=deluge-gtk %U
 Icon=deluge


### PR DESCRIPTION
Deluge fails to appear in some app launchers (GNOME app search, Albert launcher) when searching for just "torrent" or other keywords, rather than "bittorrent". This is due to the lack of a Keywords header/property in its desktop entry file. Adding this line should solve the issue. 

I don't know if the underscore "_" is actually necessary for this line, I just copied the appearance of the lines above it when inserting. Please check that this comes out without the underscore in the final file after processing.