### PR TITLE
[Gtk] Fixed edit torrents dialogs windows close issues

### DIFF
--- a/deluge/ui/gtk3/edittrackersdialog.py
+++ b/deluge/ui/gtk3/edittrackersdialog.py
@@ -134,6 +134,11 @@ class EditTrackersDialog(object):
         self.dialog.connect('response', self._on_response)
         self.treeview.connect('button_press_event', self.on_button_press_event)
 
+        self.add_tracker_dialog.connect('key-press-event', self.on_key_add_press_event)
+        self.add_tracker_dialog.connect('delete-event', self.on_delete_event_add)
+        self.edit_tracker_entry.connect('key-press-event', self.on_key_edit_press_event)
+        self.edit_tracker_entry.connect('delete-event', self.on_delete_event_edit)
+
     def run(self):
         # Make sure we have a torrent_id.. if not just return
         if self.torrent_id is None:
@@ -208,6 +213,7 @@ class EditTrackersDialog(object):
         # Show the add tracker dialog
         self.add_tracker_dialog.show()
         self.builder.get_object('textview_trackers').grab_focus()
+        self.dialog.set_sensitive(False)
 
     def on_button_remove_clicked(self, widget):
         log.debug('on_button_remove_clicked')
@@ -236,10 +242,26 @@ class EditTrackersDialog(object):
             self.edit_tracker_entry.grab_focus()
             self.dialog.set_sensitive(False)
 
-    def on_button_edit_cancel_clicked(self, widget):
-        log.debug('on_button_edit_cancel_clicked')
+    def _close_edit_dialog(self):
         self.dialog.set_sensitive(True)
         self.edit_tracker_entry.hide()
+
+    def on_button_edit_cancel_clicked(self, widget):
+        """handles the cancel button"""
+        log.debug('on_button_edit_cancel_clicked')
+        self._close_edit_dialog()
+
+    def on_key_edit_press_event(self, widget, event):
+        """handles Escape key press"""
+        if event.keyval == Gdk.KEY_Escape:
+            log.debug('on_key_edit_press_event')
+            self._close_edit_dialog()
+
+    def on_delete_event_edit(self, widget, event):
+        """handles the Top-Right X button"""
+        log.debug('on_delete_event_edit')
+        self._close_edit_dialog()
+        return True
 
     def on_button_edit_ok_clicked(self, widget):
         log.debug('on_button_edit_ok_clicked')
@@ -301,11 +323,29 @@ class EditTrackersDialog(object):
 
         # Clear the entry widget and hide the dialog
         textview_buf.set_text('')
+        self.dialog.set_sensitive(True)
         self.add_tracker_dialog.hide()
 
-    def on_button_add_cancel_clicked(self, widget):
-        log.debug('on_button_add_cancel_clicked')
+    def _discard_and_close_add_dialog(self):
         # Clear the entry widget and hide the dialog
         b = Gtk.TextBuffer()
         self.builder.get_object('textview_trackers').set_buffer(b)
+        self.dialog.set_sensitive(True)
         self.add_tracker_dialog.hide()
+
+    def on_button_add_cancel_clicked(self, widget):
+        """handles the cancel button"""
+        log.debug('on_button_add_cancel_clicked')
+        self._discard_and_close_add_dialog()
+
+    def on_key_add_press_event(self, widget, event):
+        """handles Escape key press"""
+        if event.keyval == Gdk.KEY_Escape:
+            log.debug('on_key_add_press_event')
+            self._discard_and_close_add_dialog()
+
+    def on_delete_event_add(self, widget, event):
+        """handles the Top-Right X button"""
+        log.debug('on_delete_event_add')
+        self._discard_and_close_add_dialog()
+        return True


### PR DESCRIPTION
Up until now, when closing the Add or Edit dialogs, of the `Edit Torrents`, using the top-right X
button or using the Escape key, they were being destroyed without any way to reopening them, and
it was breaking the `Edit Torrents` window itself.
Now both dialogs have the right handlers for handing the closing process without breaking anything.