### PR TITLE
[GTK] Added a torrent menu option for magnet copy

### DIFF
--- a/deluge/ui/gtk3/dialogs.py
+++ b/deluge/ui/gtk3/dialogs.py
@@ -458,13 +458,14 @@ class CopyMagnetDialog(BaseDialog):
     """
     Displays a dialog with a magnet URI
     """
+
     def __init__(self, torrent_magnet='', parent=None):
         super().__init__(
             header=_('Copy Magnet URI'),
             text='',
             icon='magnet_copy.svg',
             buttons=(_('_Close'), Gtk.ResponseType.CLOSE),
-            parent=parent
+            parent=parent,
         )
         self.copied = False
 

--- a/deluge/ui/gtk3/dialogs.py
+++ b/deluge/ui/gtk3/dialogs.py
@@ -244,12 +244,12 @@ class AuthenticationDialog(BaseDialog):
 
 class AccountDialog(BaseDialog):
     def __init__(
-        self,
-        username=None,
-        password=None,
-        authlevel=None,
-        levels_mapping=None,
-        parent=None,
+            self,
+            username=None,
+            password=None,
+            authlevel=None,
+            levels_mapping=None,
+            parent=None,
     ):
         if username:
             super().__init__(
@@ -347,7 +347,7 @@ class OtherDialog(BaseDialog):
     """
 
     def __init__(
-        self, header, text='', unit_text='', icon=None, default=0, parent=None
+            self, header, text='', unit_text='', icon=None, default=0, parent=None
     ):
         self.value_type = type(default)
         if self.value_type not in (int, float):
@@ -452,3 +452,49 @@ class PasswordDialog(BaseDialog):
 
     def on_password_activate(self, widget):
         self.response(Gtk.ResponseType.OK)
+
+
+class CopyMagnetDialog(BaseDialog):
+    """
+    Displays a dialog with a magnet URI
+    """
+
+    def __init__(self, torrent_magnet='', parent=None):
+        """
+        Args:
+            torrent_magnet (str): the magnet uri to show
+            parent:
+        """
+        super().__init__(
+            header=_('Copy Magnet URI'),
+            text='',
+            icon='magnet_copy.svg',
+            buttons=(_('_Close'), Gtk.ResponseType.CLOSE),
+            parent=parent
+        )
+        self.copied = False
+
+        table = Gtk.Table(1, 2, False)
+        self.magnet_entry = Gtk.Entry()
+        self.magnet_entry.set_text(torrent_magnet)
+        self.magnet_entry.set_editable(False)
+        self.magnet_entry.connect('copy-clipboard', self.on_copy_emitted)
+        table.attach(self.magnet_entry, 0, 1, 0, 1)
+
+        copy_button = Gtk.Button.new_with_label(_('Copy'))
+        copy_button.connect('clicked', self.on_copy_clicked)
+        table.attach(copy_button, 1, 2, 0, 1)
+
+        self.vbox.pack_start(table, False, False, padding=5)
+        self.set_focus(self.magnet_entry)
+
+        self.show_all()
+
+    def on_copy_clicked(self, widget):
+        self.magnet_entry.select_region(0, -1)
+        self.magnet_entry.copy_clipboard()
+        self.magnet_entry.set_position(0)
+        self.copied = True
+
+    def on_copy_emitted(self, widget):
+        self.copied = True

--- a/deluge/ui/gtk3/dialogs.py
+++ b/deluge/ui/gtk3/dialogs.py
@@ -244,12 +244,12 @@ class AuthenticationDialog(BaseDialog):
 
 class AccountDialog(BaseDialog):
     def __init__(
-            self,
-            username=None,
-            password=None,
-            authlevel=None,
-            levels_mapping=None,
-            parent=None,
+        self,
+        username=None,
+        password=None,
+        authlevel=None,
+        levels_mapping=None,
+        parent=None,
     ):
         if username:
             super().__init__(
@@ -347,7 +347,7 @@ class OtherDialog(BaseDialog):
     """
 
     def __init__(
-            self, header, text='', unit_text='', icon=None, default=0, parent=None
+        self, header, text='', unit_text='', icon=None, default=0, parent=None
     ):
         self.value_type = type(default)
         if self.value_type not in (int, float):
@@ -458,13 +458,7 @@ class CopyMagnetDialog(BaseDialog):
     """
     Displays a dialog with a magnet URI
     """
-
     def __init__(self, torrent_magnet='', parent=None):
-        """
-        Args:
-            torrent_magnet (str): the magnet uri to show
-            parent:
-        """
         super().__init__(
             header=_('Copy Magnet URI'),
             text='',

--- a/deluge/ui/gtk3/glade/torrent_menu.ui
+++ b/deluge/ui/gtk3/glade/torrent_menu.ui
@@ -31,6 +31,11 @@
     <property name="icon_name">media-playback-pause-symbolic</property>
     <property name="icon_size">1</property>
   </object>
+  <object class="GtkImage" id="menu-item-image15">
+    <property name="can_focus">False</property>
+    <property name="icon_name">edit-copy-symbolic</property>
+    <property name="icon_size">1</property>
+  </object>
   <object class="GtkImage" id="menu-item-image19">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -152,6 +157,17 @@
       <object class="GtkSeparatorMenuItem" id="menuitem1">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkImageMenuItem" id="menuitem_copymagnet">
+        <property name="label" translatable="yes">_Copy Magnet URI</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="use_underline">True</property>
+        <property name="image">menu-item-image15</property>
+        <property name="use_stock">False</property>
+        <signal name="activate" handler="on_menuitem_copymagnet_activate" swapped="no"/>
       </object>
     </child>
     <child>

--- a/deluge/ui/gtk3/mainwindow.py
+++ b/deluge/ui/gtk3/mainwindow.py
@@ -338,7 +338,8 @@ class MainWindow(component.Component):
                 return
             self.previous_clipboard_text = text
             if text and (
-                (is_url(text) and text.endswith('.torrent')) or is_magnet(text)
+                (is_url(text) and text.endswith('.torrent'))
+                or is_magnet(text)
                 and not component.get('MenuBar').magnet_copied()
             ):
                 component.get('AddTorrentDialog').show()

--- a/deluge/ui/gtk3/mainwindow.py
+++ b/deluge/ui/gtk3/mainwindow.py
@@ -339,6 +339,7 @@ class MainWindow(component.Component):
             self.previous_clipboard_text = text
             if text and (
                 (is_url(text) and text.endswith('.torrent')) or is_magnet(text)
+                and not component.get('MenuBar').magnet_copied()
             ):
                 component.get('AddTorrentDialog').show()
                 component.get('AddTorrentDialog').on_button_url_clicked(window)

--- a/deluge/ui/gtk3/menubar.py
+++ b/deluge/ui/gtk3/menubar.py
@@ -297,6 +297,7 @@ class MenuBar(component.Component):
         log.debug('on_menuitem_copymagnet_activate')
         torrent_ids = component.get('TorrentView').get_selected_torrents()
         if torrent_ids:
+
             def _on_magnet_uri(magnet_uri):
                 def update_copied(response_id):
                     if dialog.copied:
@@ -304,6 +305,7 @@ class MenuBar(component.Component):
 
                 dialog = CopyMagnetDialog(magnet_uri)
                 dialog.run().addCallback(update_copied)
+
             client.core.get_magnet_uri(torrent_ids[0]).addCallback(_on_magnet_uri)
 
     def on_menuitem_updatetracker_activate(self, data=None):


### PR DESCRIPTION
this will lined-up with the WebUI, which already have this option.
in addition, it will not open the Add Torrent URL dialog after copied,
which happens automatically when there is torrent/magnet URIs in the clipboard.

closes https://dev.deluge-torrent.org/ticket/3489