### PR TITLE
[GTK] Switched port check loading gif with GtkSpinner

### DIFF
--- a/deluge/ui/gtk3/glade/preferences_dialog.ui
+++ b/deluge/ui/gtk3/glade/preferences_dialog.ui
@@ -2728,6 +2728,24 @@ used sparingly.</property>
                                               </packing>
                                             </child>
                                             <child>
+                                              <object class="GtkAlignment" id="alignment31">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="left_padding">10</property>
+                                                <child>
+                                                  <object class="GtkSpinner" id="port_spinner">
+                                                    <property name="visible">False</property>
+                                                    <property name="can_focus">False</property>
+                                                  </object>
+                                                </child>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">2</property>
+                                              </packing>
+                                            </child>
+                                            <child>
                                               <object class="GtkAlignment" id="alignment48">
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
@@ -2742,7 +2760,7 @@ used sparingly.</property>
                                               <packing>
                                                 <property name="expand">False</property>
                                                 <property name="fill">True</property>
-                                                <property name="position">2</property>
+                                                <property name="position">3</property>
                                               </packing>
                                             </child>
                                           </object>

--- a/deluge/ui/gtk3/preferences.py
+++ b/deluge/ui/gtk3/preferences.py
@@ -940,6 +940,7 @@ class Preferences(component.Component):
 
     def hide(self):
         self.window_open = False
+        self.builder.get_object('port_spinner').stop()
         self.builder.get_object('port_img').hide()
         self.pref_dialog.hide()
 
@@ -1084,6 +1085,8 @@ class Preferences(component.Component):
         log.debug('on_test_port_clicked')
 
         def on_get_test(status):
+            self.builder.get_object('port_spinner').stop()
+            self.builder.get_object('port_spinner').hide()
             if status:
                 self.builder.get_object('port_img').set_from_icon_name(
                     'emblem-ok-symbolic', Gtk.IconSize.MENU
@@ -1096,12 +1099,8 @@ class Preferences(component.Component):
                 self.builder.get_object('port_img').show()
 
         client.core.test_listen_port().addCallback(on_get_test)
-        # XXX: Consider using gtk.Spinner() instead of the loading gif
-        #      It requires gtk.ver > 2.12
-        self.builder.get_object('port_img').set_from_file(
-            deluge.common.get_pixmap('loading.gif')
-        )
-        self.builder.get_object('port_img').show()
+        self.builder.get_object('port_spinner').start()
+        self.builder.get_object('port_spinner').show()
         client.force_call()
 
     def on_plugin_toggled(self, renderer, path):


### PR DESCRIPTION
this switched was motivated by an error which happened each time the check
port button was clicked, and was caused by the GtkImage when loading the
loading.gif file.

The error is:
```
07:49:52.787 [DEBUG   ][deluge.ui.gtk3.preferences        :64  ] on_test_port_clicked
C:\develops\python\deluge\deluge\ui\gtk3\preferences.py:1101: Warning: cannot register existing type 'GdkPixbufGdipAnim'
  self.builder.get_object('port_img').set_from_file(
C:\develops\python\deluge\deluge\ui\gtk3\preferences.py:1101: Warning: g_once_init_leave: assertion 'result != 0' failed
  self.builder.get_object('port_img').set_from_file(
C:\develops\python\deluge\deluge\ui\gtk3\preferences.py:1101: Warning: g_object_new_with_properties: assertion 'G_TYPE_IS_OBJECT (object_type)' failed
  self.builder.get_object('port_img').set_from_file(

Process finished with exit code -1073741819 (0xC0000005)
```