### PR TITLE
[TrackerIcon] fixed icon download issues

### DIFF
--- a/deluge/tests/test_tracker_icons.py
+++ b/deluge/tests/test_tracker_icons.py
@@ -14,7 +14,6 @@ from . import common
 from .basetest import BaseTestCase
 
 common.set_tmp_config_dir()
-deluge.ui.tracker_icons.PIL_INSTALLED = False
 common.disable_new_release_check()
 
 
@@ -41,6 +40,15 @@ class TrackerIconsTestCase(BaseTestCase):
         # So instead we'll grab its favicon.ico
         icon = TrackerIcon(common.get_test_data_file('google.ico'))
         d = self.icons.fetch('www.google.com')
+        d.addCallback(self.assertNotIdentical, None)
+        d.addCallback(self.assertEqual, icon)
+        return d
+
+    def test_get_google_ico_hebrew(self):
+        # Google.co.il page must be read as UTF-8
+        # So we'll test whether it can be read
+        icon = TrackerIcon(common.get_test_data_file('google.ico'))
+        d = self.icons.fetch('www.google.co.il')
         d.addCallback(self.assertNotIdentical, None)
         d.addCallback(self.assertEqual, icon)
         return d

--- a/deluge/ui/tracker_icons.py
+++ b/deluge/ui/tracker_icons.py
@@ -479,14 +479,17 @@ class TrackerIcons(Component):
         # Requires Pillow(PIL) to resize.
         if icon and Image:
             filename = icon.get_filename()
+            remove_old = False
             with Image.open(filename) as img:
                 if img.size > (16, 16):
                     new_filename = filename.rpartition('.')[0] + '.png'
                     img = img.resize((16, 16), Image.ANTIALIAS)
                     img.save(new_filename)
                     if new_filename != filename:
-                        os.remove(filename)
-                        icon = TrackerIcon(new_filename)
+                        remove_old = True
+            if remove_old:
+                os.remove(filename)
+                icon = TrackerIcon(new_filename)
         return icon
 
     def store_icon(self, icon, host):

--- a/deluge/ui/tracker_icons.py
+++ b/deluge/ui/tracker_icons.py
@@ -22,6 +22,11 @@ from deluge.decorators import proxy
 from deluge.httpdownloader import download_file
 
 try:
+    import chardet
+except ImportError:
+    chardet = None
+
+try:
     from PIL import Image
 except ImportError:
     Image = None
@@ -289,7 +294,13 @@ class TrackerIcons(Component):
         :returns: a Deferred which callbacks a list of available favicons (url, type)
         :rtype: Deferred
         """
-        with open(page) as _file:
+        encoding = 'UTF-8'
+        if chardet:
+            with open(page, 'rb') as _file:
+                result = chardet.detect(_file.read())
+                encoding = result['encoding']
+
+        with open(page, encoding=encoding) as _file:
             parser = FaviconParser()
             for line in _file:
                 parser.feed(line)


### PR DESCRIPTION
This PR contains 2 commits:

1. Fixed parse error on UTF-8 sites with non-english chars
I got the exception 
```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 2158: character maps to <undefined>
```
2. Fixed old-large icon removal 
After successful download of the icon, it wasn't shown in the UI.
Only after closing it I got, for each of the icons, the exception:
```
builtins.PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'C:\\Users\\user\\AppData\\Roaming\\deluge\\icons\\site.ico'
```

closes: [#3479](https://dev.deluge-torrent.org/ticket/3479)