### PR TITLE
[Gtk] Fixed magnets not showing the prefetched metadata

### DIFF
--- a/deluge/transfer.py
+++ b/deluge/transfer.py
@@ -115,17 +115,21 @@ class DelugeTransferProtocol(Protocol):
             self._message_length = 0
             self._buffer = b''
 
-    def _handle_complete_message(self, data):
+    def _handle_complete_message(self, data, decode_utf8=True):
         """
         Handles a complete message as it is transferred on the network.
 
-        :param data: a zlib compressed string encoded with rencode.
+        Args:
+            data: a zlib compressed string encoded with rencode.
+            decode_utf8: try to decode as utf8. Default: True
 
         """
         try:
             self.message_received(
-                rencode.loads(zlib.decompress(data), decode_utf8=True)
+                rencode.loads(zlib.decompress(data), decode_utf8=decode_utf8)
             )
+        except UnicodeDecodeError:
+            self._handle_complete_message(data, decode_utf8=False)
         except Exception as ex:
             log.warning(
                 'Failed to decompress (%d bytes) and load serialized data with rencode: %s',

--- a/deluge/ui/gtk3/addtorrentdialog.py
+++ b/deluge/ui/gtk3/addtorrentdialog.py
@@ -263,6 +263,7 @@ class AddTorrentDialog(component.Component):
     def _on_uri_metadata(self, result, uri, trackers):
         """Process prefetched metadata to allow file priority selection."""
         info_hash, metadata = result
+        info_hash = info_hash.decode()  # info_hash is bytes, we need it to be Unicode
         log.debug('magnet metadata for %s (%s)', uri, info_hash)
         if info_hash not in self.prefetching_magnets:
             return


### PR DESCRIPTION
it is a combination of 2 errors:
1. Decompress issue due to UnicodeDecodeError in `transfer.py`
2. The `info_hash` of the magnet file is being saved as `str`. But after the
prefetch is done, we get it from the `core`/`RPC` as `bytes`.

Closes: deluge-torrent/deluge#334