### PR TITLE
[3498][Core] Fixed KeyError in sessionproxy after torrent delete

### DIFF
--- a/deluge/ui/sessionproxy.py
+++ b/deluge/ui/sessionproxy.py
@@ -145,11 +145,14 @@ class SessionProxy(component.Component):
 
                 def on_status(result, torrent_id):
                     t = time()
-                    self.torrents[torrent_id][0] = t
-                    self.torrents[torrent_id][1].update(result)
-                    for key in keys_to_get:
-                        self.cache_times[torrent_id][key] = t
-                    return self.create_status_dict([torrent_id], keys)[torrent_id]
+                    try:
+                        self.torrents[torrent_id][0] = t
+                        self.torrents[torrent_id][1].update(result)
+                        for key in keys_to_get:
+                            self.cache_times[torrent_id][key] = t
+                        return self.create_status_dict([torrent_id], keys)[torrent_id]
+                    except KeyError:
+                        return {}
 
                 return d.addCallback(on_status, torrent_id)
         else:


### PR DESCRIPTION
When several torrents are being removed from session, an exception was
being raised in a callback function `on_status` with the `torrent_id` of
one (or more) of the removed torrents.
Now we will catch when the torrent does not exist anymore and print a
debug log about it.

Closes: https://dev.deluge-torrent.org/ticket/3498