### PR TITLE
[Core] Return plugin keys with get_torrents_status

### DIFF
--- a/deluge/core/core.py
+++ b/deluge/core/core.py
@@ -773,7 +773,7 @@ class Core(component.Component):
         def add_plugin_fields(args):
             status_dict, plugin_keys = args
             # Ask the plugin manager to fill in the plugin keys
-            if len(plugin_keys) > 0:
+            if len(plugin_keys) > 0 or not keys:
                 for key in status_dict:
                     status_dict[key].update(
                         self.pluginmanager.get_status(key, plugin_keys)


### PR DESCRIPTION
When requesting all keys, get_torrents_status was missing plugin added keys
This commit brings the behavior in line with get_torrent_status, and deluge 1.3

Closes: [3357](https://dev.deluge-torrent.org/ticket/3357)

Disclaimer: It's been a while since I've had a deluge development environment up, and got frustrated before I could get it working on windows. I haven't actually tested this code, but it's a pretty simple change, so I'm hoping somebody could quickly verify it does what I think, and merge it in.
🥺
🙏
👖   

(Happy to see the project get more active, and pumped for some Windows builds again! Good work everybody. I tried to get my environment set up by following the github action steps, but 🤷‍♂️ )