### PR TITLE
[Common] Replace distro.linux_distribution function

### DIFF
--- a/deluge/common.py
+++ b/deluge/common.py
@@ -265,7 +265,7 @@ def get_os_version():
         os_version = list(platform.mac_ver())
         os_version[1] = ''  # versioninfo always empty.
     elif distro:
-        os_version = distro.linux_distribution()
+        os_version = (distro.name(), distro.version(), distro.codename())
     else:
         os_version = (platform.release(),)
 


### PR DESCRIPTION
As of distro (1.6.0)[1], this function is marked as deprecated.
Instead, we will use the underlying functions directly, as explained in the (docs)[2].

[1] https://github.com/python-distro/distro/issues/263#issuecomment-927098357
[2] https://distro.readthedocs.io/en/latest/#distro.linux_distribution