### PR TITLE
Enable Windows tests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@
 .gitignore export-ignore
 *.py diff=python
 ext-all.js diff=minjs
+*.state -merge -text

--- a/deluge/i18n/util.py
+++ b/deluge/i18n/util.py
@@ -119,7 +119,7 @@ def setup_translation():
                 try:
                     libintl = ctypes.cdll.LoadLibrary(library)
                 except OSError as ex:
-                    errors.append(ex)
+                    errors.append(str(ex))
                 else:
                     break
 

--- a/deluge/tests/basetest.py
+++ b/deluge/tests/basetest.py
@@ -40,8 +40,7 @@ class BaseTestCase(unittest.TestCase):
         d = maybeDeferred(self.tear_down)
 
         def on_teardown_failed(error):
-            warnings.warn('Error caught in test teardown!\n%s' % error.getTraceback())
-            self.fail()
+            self.fail('Error caught in test teardown!\n%s' % error.getTraceback())
 
         def on_teardown_complete(result):
             component._ComponentRegistry.components.clear()

--- a/deluge/tests/common.py
+++ b/deluge/tests/common.py
@@ -21,7 +21,7 @@ import deluge.core.preferencesmanager
 import deluge.log
 from deluge.common import get_localhost_auth
 from deluge.error import DelugeError
-from deluge.ui.client import client
+from deluge.ui.client import Client
 
 # This sets log level to critical, so use log.critical() to debug while running unit tests
 deluge.log.setup_logger('none')
@@ -156,7 +156,8 @@ class ProcessOutputHandler(protocol.ProcessProtocol):
             yield shutdown
         except Exception:
             self.transport.signalProcess('TERM')
-        yield self.quit_d
+        result = yield self.quit_d
+        return result
 
     def _kill_watchdogs(self):
         """"Cancel all watchdogs"""
@@ -305,6 +306,7 @@ except Exception:
     @defer.inlineCallbacks
     def shutdown_daemon():
         username, password = get_localhost_auth()
+        client = Client()
         yield client.connect(
             'localhost', listen_port, username=username, password=password
         )

--- a/deluge/tests/daemon_base.py
+++ b/deluge/tests/daemon_base.py
@@ -11,7 +11,6 @@ from twisted.internet import defer
 from twisted.internet.error import CannotListenError
 
 import deluge.component as component
-from deluge.common import windows_check
 
 from . import common
 
@@ -19,9 +18,6 @@ from . import common
 @pytest.mark.usefixtures('get_pytest_basetemp')
 class DaemonBase:
     basetemp = None
-
-    if windows_check():
-        skip = 'windows cant start_core not enough arguments for format string'
 
     @pytest.fixture
     def get_pytest_basetemp(self, request):

--- a/deluge/tests/test_files_tab.py
+++ b/deluge/tests/test_files_tab.py
@@ -8,7 +8,6 @@ import pytest
 from twisted.trial import unittest
 
 import deluge.component as component
-from deluge.common import windows_check
 from deluge.configmanager import ConfigManager
 from deluge.i18n import setup_translation
 
@@ -98,39 +97,35 @@ class FilesTabTestCase(BaseTestCase):
         self.assertTrue(ret)
 
     def test_files_tab2(self):
-        if windows_check():
-            raise unittest.SkipTest('on windows \\ != / for path names')
         self.filestab.files_list[self.t_id] = (
-            {'index': 0, 'path': '1/1/test_10.txt', 'offset': 0, 'size': 13},
-            {'index': 1, 'path': 'test_100.txt', 'offset': 13, 'size': 14},
+            {'index': 0, 'path': '1/1/test_100.txt', 'offset': 0, 'size': 13},
+            {'index': 1, 'path': 'test_101.txt', 'offset': 13, 'size': 14},
         )
         self.filestab.update_files()
         self.filestab._on_torrentfilerenamed_event(
-            self.t_id, self.index, '1/1/test_100.txt'
+            self.t_id, self.index, '1/1/test_101.txt'
         )
 
         ret = self.verify_treestore(
             self.filestab.treestore,
-            [['1/', [['1/', [['test_100.txt'], ['test_10.txt']]]]]],
+            [['1/', [['1/', [['test_100.txt'], ['test_101.txt']]]]]],
         )
         if not ret:
             self.print_treestore('Treestore not expected:', self.filestab.treestore)
         self.assertTrue(ret)
 
     def test_files_tab3(self):
-        if windows_check():
-            raise unittest.SkipTest('on windows \\ != / for path names')
         self.filestab.files_list[self.t_id] = (
-            {'index': 0, 'path': '1/test_10.txt', 'offset': 0, 'size': 13},
-            {'index': 1, 'path': 'test_100.txt', 'offset': 13, 'size': 14},
+            {'index': 0, 'path': '1/test_100.txt', 'offset': 0, 'size': 13},
+            {'index': 1, 'path': 'test_101.txt', 'offset': 13, 'size': 14},
         )
         self.filestab.update_files()
         self.filestab._on_torrentfilerenamed_event(
-            self.t_id, self.index, '1/test_100.txt'
+            self.t_id, self.index, '1/test_101.txt'
         )
 
         ret = self.verify_treestore(
-            self.filestab.treestore, [['1/', [['test_100.txt'], ['test_10.txt']]]]
+            self.filestab.treestore, [['1/', [['test_100.txt'], ['test_101.txt']]]]
         )
         if not ret:
             self.print_treestore('Treestore not expected:', self.filestab.treestore)
@@ -138,36 +133,34 @@ class FilesTabTestCase(BaseTestCase):
 
     def test_files_tab4(self):
         self.filestab.files_list[self.t_id] = (
-            {'index': 0, 'path': '1/test_10.txt', 'offset': 0, 'size': 13},
-            {'index': 1, 'path': '1/test_100.txt', 'offset': 13, 'size': 14},
+            {'index': 0, 'path': '1/test_100.txt', 'offset': 0, 'size': 13},
+            {'index': 1, 'path': '1/test_101.txt', 'offset': 13, 'size': 14},
         )
         self.filestab.update_files()
         self.filestab._on_torrentfilerenamed_event(
-            self.t_id, self.index, '1/2/test_100.txt'
+            self.t_id, self.index, '1/2/test_101.txt'
         )
 
         ret = self.verify_treestore(
             self.filestab.treestore,
-            [['1/', [['2/', [['test_100.txt']]], ['test_10.txt']]]],
+            [['1/', [['2/', [['test_101.txt']]], ['test_100.txt']]]],
         )
         if not ret:
             self.print_treestore('Treestore not expected:', self.filestab.treestore)
         self.assertTrue(ret)
 
     def test_files_tab5(self):
-        if windows_check():
-            raise unittest.SkipTest('on windows \\ != / for path names')
         self.filestab.files_list[self.t_id] = (
-            {'index': 0, 'path': '1/test_10.txt', 'offset': 0, 'size': 13},
-            {'index': 1, 'path': '2/test_100.txt', 'offset': 13, 'size': 14},
+            {'index': 0, 'path': '1/test_100.txt', 'offset': 0, 'size': 13},
+            {'index': 1, 'path': '2/test_101.txt', 'offset': 13, 'size': 14},
         )
         self.filestab.update_files()
         self.filestab._on_torrentfilerenamed_event(
-            self.t_id, self.index, '1/test_100.txt'
+            self.t_id, self.index, '1/test_101.txt'
         )
 
         ret = self.verify_treestore(
-            self.filestab.treestore, [['1/', [['test_100.txt'], ['test_10.txt']]]]
+            self.filestab.treestore, [['1/', [['test_100.txt'], ['test_101.txt']]]]
         )
         if not ret:
             self.print_treestore('Treestore not expected:', self.filestab.treestore)

--- a/deluge/tests/test_maketorrent.py
+++ b/deluge/tests/test_maketorrent.py
@@ -10,7 +10,6 @@ import tempfile
 from twisted.trial import unittest
 
 from deluge import maketorrent
-from deluge.common import windows_check
 
 
 def check_torrent(filename):
@@ -51,21 +50,16 @@ class MakeTorrentTestCase(unittest.TestCase):
         os.remove(tmp_file)
 
     def test_save_singlefile(self):
-        if windows_check():
-            raise unittest.SkipTest('on windows file not released')
-        tmp_data = tempfile.mkstemp('testdata')[1]
-        with open(tmp_data, 'wb') as _file:
-            _file.write(b'a' * (2314 * 1024))
-        t = maketorrent.TorrentMetadata()
-        t.data_path = tmp_data
-        tmp_fd, tmp_file = tempfile.mkstemp('.torrent')
-        t.save(tmp_file)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_data = tmp_dir + '/data'
+            with open(tmp_data, 'wb') as _file:
+                _file.write(b'a' * (2314 * 1024))
+            t = maketorrent.TorrentMetadata()
+            t.data_path = tmp_data
+            tmp_file = tmp_dir + '/.torrent'
+            t.save(tmp_file)
 
-        check_torrent(tmp_file)
-
-        os.remove(tmp_data)
-        os.close(tmp_fd)
-        os.remove(tmp_file)
+            check_torrent(tmp_file)
 
     def test_save_multifile_padded(self):
         # Create a temporary folder for torrent creation

--- a/deluge/tests/test_metafile.py
+++ b/deluge/tests/test_metafile.py
@@ -10,7 +10,6 @@ import tempfile
 from twisted.trial import unittest
 
 from deluge import metafile
-from deluge.common import windows_check
 
 
 def check_torrent(filename):
@@ -49,17 +48,12 @@ class MetafileTestCase(unittest.TestCase):
         os.remove(tmp_file)
 
     def test_save_singlefile(self):
-        if windows_check():
-            raise unittest.SkipTest('on windows \\ != / for path names')
-        tmp_path = tempfile.mkstemp('testdata')[1]
-        with open(tmp_path, 'wb') as tmp_file:
-            tmp_file.write(b'a' * (2314 * 1024))
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_data = tmp_dir + '/testdata'
+            with open(tmp_data, 'wb') as tmp_file:
+                tmp_file.write(b'a' * (2314 * 1024))
 
-        tmp_fd, tmp_file = tempfile.mkstemp('.torrent')
-        metafile.make_meta_file(tmp_path, '', 32768, target=tmp_file)
+            tmp_torrent = tmp_dir + '/.torrent'
+            metafile.make_meta_file(tmp_data, '', 32768, target=tmp_torrent)
 
-        check_torrent(tmp_file)
-
-        os.remove(tmp_path)
-        os.close(tmp_fd)
-        os.remove(tmp_file)
+            check_torrent(tmp_torrent)

--- a/deluge/tests/test_torrent.py
+++ b/deluge/tests/test_torrent.py
@@ -17,7 +17,7 @@ import deluge.component as component
 import deluge.core.torrent
 import deluge.tests.common as common
 from deluge._libtorrent import lt
-from deluge.common import VersionSplit, utf8_encode_structure, windows_check
+from deluge.common import VersionSplit, utf8_encode_structure
 from deluge.core.core import Core
 from deluge.core.rpcserver import RPCServer
 from deluge.core.torrent import Torrent
@@ -173,8 +173,6 @@ class TorrentTestCase(BaseTestCase):
         # self.print_priority_list(priorities)
 
     def test_torrent_error_data_missing(self):
-        if windows_check():
-            raise unittest.SkipTest('unexpected end of file in bencoded string')
         options = {'seed_mode': True}
         filename = common.get_test_data_file('test_torrent.file.torrent')
         with open(filename, 'rb') as _file:
@@ -191,8 +189,6 @@ class TorrentTestCase(BaseTestCase):
         self.assert_state(torrent, 'Error')
 
     def test_torrent_error_resume_original_state(self):
-        if windows_check():
-            raise unittest.SkipTest('unexpected end of file in bencoded string')
         options = {'seed_mode': True, 'add_paused': True}
         filename = common.get_test_data_file('test_torrent.file.torrent')
         with open(filename, 'rb') as _file:
@@ -212,8 +208,6 @@ class TorrentTestCase(BaseTestCase):
         torrent.force_recheck()
 
     def test_torrent_error_resume_data_unaltered(self):
-        if windows_check():
-            raise unittest.SkipTest('unexpected end of file in bencoded string')
         if VersionSplit(lt.__version__) >= VersionSplit('1.2.0.0'):
             raise unittest.SkipTest('Test not working as expected on lt 1.2 or greater')
 

--- a/deluge/tests/test_torrentmanager.py
+++ b/deluge/tests/test_torrentmanager.py
@@ -12,11 +12,9 @@ from unittest import mock
 
 import pytest
 from twisted.internet import defer, task
-from twisted.trial import unittest
 
 from deluge import component
 from deluge.bencode import bencode
-from deluge.common import windows_check
 from deluge.core.core import Core
 from deluge.core.rpcserver import RPCServer
 from deluge.error import InvalidTorrentError
@@ -141,10 +139,6 @@ class TorrentmanagerTestCase(BaseTestCase):
             common.get_test_data_file('utf8_filename_torrents.state'),
             os.path.join(self.config_dir, 'state', 'torrents.state'),
         )
-        if windows_check():
-            raise unittest.SkipTest(
-                'Windows ModuleNotFoundError due to Linux line ending'
-            )
 
         state = self.tm.open_state()
         self.assertEqual(len(state.torrents), 1)

--- a/deluge/tests/test_torrentview.py
+++ b/deluge/tests/test_torrentview.py
@@ -63,6 +63,7 @@ class TorrentviewTestCase(BaseTestCase):
         'Added',
         'Completed',
         'Complete Seen',
+        'Last Transfer',
         'Tracker',
         'Download Folder',
         'Owner',
@@ -93,6 +94,7 @@ class TorrentviewTestCase(BaseTestCase):
         int,
         float,
         float,  # ETA, Ratio, Avail
+        int,
         int,
         int,
         int,
@@ -128,7 +130,7 @@ class TorrentviewTestCase(BaseTestCase):
             TorrentviewTestCase.default_liststore_columns,
         )
         self.assertEqual(
-            self.torrentview.columns['Download Folder'].column_indices, [29]
+            self.torrentview.columns['Download Folder'].column_indices, [30]
         )
 
     def test_add_column(self):
@@ -145,7 +147,7 @@ class TorrentviewTestCase(BaseTestCase):
             len(TorrentviewTestCase.default_column_index) + 1,
         )
         self.assertEqual(self.torrentview.column_index[-1], test_col)
-        self.assertEqual(self.torrentview.columns[test_col].column_indices, [32])
+        self.assertEqual(self.torrentview.columns[test_col].column_indices, [33])
 
     def test_add_columns(self):
 
@@ -167,11 +169,11 @@ class TorrentviewTestCase(BaseTestCase):
         )
         # test_col
         self.assertEqual(self.torrentview.column_index[-2], test_col)
-        self.assertEqual(self.torrentview.columns[test_col].column_indices, [32])
+        self.assertEqual(self.torrentview.columns[test_col].column_indices, [33])
 
         # test_col2
         self.assertEqual(self.torrentview.column_index[-1], test_col2)
-        self.assertEqual(self.torrentview.columns[test_col2].column_indices, [33])
+        self.assertEqual(self.torrentview.columns[test_col2].column_indices, [34])
 
     def test_remove_column(self):
 
@@ -196,7 +198,7 @@ class TorrentviewTestCase(BaseTestCase):
             self.torrentview.columns[
                 TorrentviewTestCase.default_column_index[-1]
             ].column_indices,
-            [31],
+            [32],
         )
 
     def test_remove_columns(self):
@@ -218,7 +220,7 @@ class TorrentviewTestCase(BaseTestCase):
             len(TorrentviewTestCase.default_column_index) + 1,
         )
         self.assertEqual(self.torrentview.column_index[-1], test_col2)
-        self.assertEqual(self.torrentview.columns[test_col2].column_indices, [32])
+        self.assertEqual(self.torrentview.columns[test_col2].column_indices, [33])
 
         # Remove test_col2
         self.torrentview.remove_column(test_col2)
@@ -238,7 +240,7 @@ class TorrentviewTestCase(BaseTestCase):
             self.torrentview.columns[
                 TorrentviewTestCase.default_column_index[-1]
             ].column_indices,
-            [31],
+            [32],
         )
 
     def test_add_remove_column_multiple_types(self):
@@ -257,7 +259,7 @@ class TorrentviewTestCase(BaseTestCase):
             len(TorrentviewTestCase.default_column_index) + 1,
         )
         self.assertEqual(self.torrentview.column_index[-1], test_col3)
-        self.assertEqual(self.torrentview.columns[test_col3].column_indices, [32, 33])
+        self.assertEqual(self.torrentview.columns[test_col3].column_indices, [33, 34])
 
         # Remove multiple column-types column
         self.torrentview.remove_column(test_col3)
@@ -278,5 +280,5 @@ class TorrentviewTestCase(BaseTestCase):
             self.torrentview.columns[
                 TorrentviewTestCase.default_column_index[-1]
             ].column_indices,
-            [31],
+            [32],
         )

--- a/deluge/tests/test_ui_common.py
+++ b/deluge/tests/test_ui_common.py
@@ -7,7 +7,6 @@
 #
 from twisted.trial import unittest
 
-from deluge.common import windows_check
 from deluge.ui.common import TorrentInfo
 
 from . import common
@@ -122,8 +121,6 @@ class UICommonTestCase(unittest.TestCase):
         self.assertTrue('azcvsupdater_2.6.2.jar' in ti.files_tree)
 
     def test_utf8_encoded_paths2(self):
-        if windows_check():
-            raise unittest.SkipTest('on windows KeyError: unicode_filenames')
         filename = common.get_test_data_file('unicode_filenames.torrent')
         filepath1 = '\u30c6\u30af\u30b9\u30fb\u30c6\u30af\u30b5\u30f3.mkv'
         filepath2 = (

--- a/deluge/tests/test_webserver.py
+++ b/deluge/tests/test_webserver.py
@@ -34,7 +34,8 @@ class WebServerTestCase(WebServerTestBase, WebServerMockBase):
         # UnicodeDecodeError: 'utf8' codec can't decode byte 0xe5 in position 0: invalid continuation byte
         filename = get_test_data_file('filehash_field.torrent')
         input_file = (
-            '{"params": ["%s"], "method": "web.get_torrent_info", "id": 22}' % filename
+            '{"params": ["%s"], "method": "web.get_torrent_info", "id": 22}'
+            % filename.replace('\\', '\\\\')
         )
         headers = {
             b'User-Agent': ['Twisted Web Client Example'],


### PR DESCRIPTION
Working on fixing up some tests that are being unnecessarily skipped on Windows
- Uses the RPC to shutdown the daemon process started for tests. On windows sending the SIGINT caused the process to exit with a 1 exit code, which would fail the tests.
- Fixed up some handling of paths, either escaping backslashes from windows paths, or just using forward slashes on windows.
- The torrentview tests were never updated after a new default column was added, fixed those tests for both platforms. (though they aren't run by github actions)
- Apparently the sort order in listviews is different on linux vs windows, (whether punctuation comes before or after alphanum,) renamed the example filenames so that this doesn't come in to play.
- Some tests involving temp files weren't closing the file descriptor before deleting the file, which causes an exception on Windows. Just cleaned these up to use more modern tempfile context manager handlers where we don't have to worry about that.