### PR TITLE
Simplify methods using inlineCallbacks

### DIFF
--- a/deluge/core/core.py
+++ b/deluge/core/core.py
@@ -442,17 +442,7 @@ class Core(component.Component):
             Deferred: A tuple of (torrent_id (str), metadata (str)) for the magnet.
 
         """
-
-        def on_metadata(result, result_d):
-            """Return result of torrent_id and metadata"""
-            result_d.callback(result)
-            return result
-
-        d = self.torrentmanager.prefetch_metadata(magnet, timeout)
-        # Use a separate callback chain to handle existing prefetching magnet.
-        result_d = defer.Deferred()
-        d.addBoth(on_metadata, result_d)
-        return result_d
+        return self.torrentmanager.prefetch_metadata(magnet, timeout)
 
     @export
     def add_torrent_file(self, filename, filedump, options):

--- a/deluge/tests/test_core.py
+++ b/deluge/tests/test_core.py
@@ -433,14 +433,10 @@ class CoreTestCase(BaseTestCase):
         self.assertEqual(self.core.get_free_space('/someinvalidpath'), -1)
 
     @pytest.mark.slow
+    @defer.inlineCallbacks
     def test_test_listen_port(self):
-        d = self.core.test_listen_port()
-
-        def result(r):
-            self.assertTrue(r in (True, False))
-
-        d.addCallback(result)
-        return d
+        result = yield self.core.test_listen_port()
+        self.assertTrue(result in (True, False))
 
     def test_sanitize_filepath(self):
         pathlist = {

--- a/deluge/tests/test_core.py
+++ b/deluge/tests/test_core.py
@@ -83,7 +83,7 @@ class CoreTestCase(BaseTestCase):
         self.core = Core()
         self.core.config.config['lsd'] = False
         self.clock = task.Clock()
-        self.core.torrentmanager.callLater = self.clock.callLater
+        self.core.torrentmanager.clock = self.clock
         self.listen_port = 51242
         return component.start().addCallback(self.start_web_server)
 


### PR DESCRIPTION
Just trying to clean up some of the code and make it more readable and easier to reason about. Opening this PR up for comments while in draft form. Some of these bits I think are easy wins, and some are a bit more complicated to figure if it's worth it. Maybe I should split off some into separate PRs so it's easier to merge simple ones without letting more complicated bits tie things up. I've been keeping the commits self contained, so it's probably easier to evaluate per commit rather than the whole diff.