### PR TITLE
Add maybe_coroutine decorator to easily mix in async/await syntax

### DIFF
--- a/deluge/core/core.py
+++ b/deluge/core/core.py
@@ -38,7 +38,7 @@ from deluge.core.pluginmanager import PluginManager
 from deluge.core.preferencesmanager import PreferencesManager
 from deluge.core.rpcserver import export
 from deluge.core.torrentmanager import TorrentManager
-from deluge.decorators import deprecated
+from deluge.decorators import deprecated, maybe_coroutine
 from deluge.error import (
     AddTorrentError,
     DelugeError,
@@ -498,13 +498,13 @@ class Core(component.Component):
 
         """
 
-        @defer.inlineCallbacks
-        def add_torrents():
+        @maybe_coroutine
+        async def add_torrents():
             errors = []
             last_index = len(torrent_files) - 1
             for idx, torrent in enumerate(torrent_files):
                 try:
-                    yield self.add_torrent_file_async(
+                    await self.add_torrent_file_async(
                         torrent[0], torrent[1], torrent[2], save_state=idx == last_index
                     )
                 except AddTorrentError as ex:
@@ -769,14 +769,14 @@ class Core(component.Component):
         )
 
     @export
-    @defer.inlineCallbacks
-    def get_torrents_status(self, filter_dict, keys, diff=False):
+    @maybe_coroutine
+    async def get_torrents_status(self, filter_dict, keys, diff=False):
         """
         returns all torrents , optionally filtered by filter_dict.
         """
         all_keys = not keys
         torrent_ids = self.filtermanager.filter_torrent_ids(filter_dict)
-        status_dict, plugin_keys = yield self.torrentmanager.torrents_status_update(
+        status_dict, plugin_keys = await self.torrentmanager.torrents_status_update(
             torrent_ids, keys, diff=diff
         )
         # Ask the plugin manager to fill in the plugin keys

--- a/deluge/core/torrentmanager.py
+++ b/deluge/core/torrentmanager.py
@@ -33,6 +33,7 @@ from deluge.common import (
 from deluge.configmanager import ConfigManager, get_config_dir
 from deluge.core.authmanager import AUTH_LEVEL_ADMIN
 from deluge.core.torrent import Torrent, TorrentOptions, sanitize_filepath
+from deluge.decorators import maybe_coroutine
 from deluge.error import AddTorrentError, InvalidTorrentError
 from deluge.event import (
     ExternalIPEvent,
@@ -247,8 +248,8 @@ class TorrentManager(component.Component):
         self.save_resume_data_timer.start(190, False)
         self.prev_status_cleanup_loop.start(10)
 
-    @defer.inlineCallbacks
-    def stop(self):
+    @maybe_coroutine
+    async def stop(self):
         # Stop timers
         if self.save_state_timer.running:
             self.save_state_timer.stop()
@@ -260,11 +261,11 @@ class TorrentManager(component.Component):
             self.prev_status_cleanup_loop.stop()
 
         # Save state on shutdown
-        yield self.save_state()
+        await self.save_state()
 
         self.session.pause()
 
-        result = yield self.save_resume_data(flush_disk_cache=True)
+        result = await self.save_resume_data(flush_disk_cache=True)
         # Remove the temp_file to signify successfully saved state
         if result and os.path.isfile(self.temp_file):
             os.remove(self.temp_file)

--- a/deluge/decorators.py
+++ b/deluge/decorators.py
@@ -202,7 +202,7 @@ _RetT = TypeVar('_RetT')
 
 def maybe_coroutine(
     f: Callable[..., Coroutine[Any, Any, _RetT]]
-) -> Callable[..., defer.Deferred[_RetT]]:
+) -> 'Callable[..., defer.Deferred[_RetT]]':
     """Wraps a coroutine function to make it usable as a normal function that returns a Deferred."""
 
     @wraps(f)

--- a/deluge/log.py
+++ b/deluge/log.py
@@ -20,7 +20,6 @@ from twisted.internet import defer
 from twisted.python.log import PythonLoggingObserver
 
 from deluge import common
-from deluge.decorators import maybe_coroutine
 
 __all__ = ('setup_logger', 'set_logger_level', 'get_plugin_logger', 'LOG')
 
@@ -52,38 +51,30 @@ class Logging(LoggingLoggerClass):
                     )
                 )
 
-    @maybe_coroutine
-    async def garbage(self, msg, *args, **kwargs):
+    def garbage(self, msg, *args, **kwargs):
         LoggingLoggerClass.log(self, 1, msg, *args, **kwargs)
 
-    @maybe_coroutine
-    async def trace(self, msg, *args, **kwargs):
+    def trace(self, msg, *args, **kwargs):
         LoggingLoggerClass.log(self, 5, msg, *args, **kwargs)
 
-    @maybe_coroutine
-    async def debug(self, msg, *args, **kwargs):
+    def debug(self, msg, *args, **kwargs):
         LoggingLoggerClass.debug(self, msg, *args, **kwargs)
 
-    @maybe_coroutine
-    async def info(self, msg, *args, **kwargs):
+    def info(self, msg, *args, **kwargs):
         LoggingLoggerClass.info(self, msg, *args, **kwargs)
 
-    @maybe_coroutine
-    async def warning(self, msg, *args, **kwargs):
+    def warning(self, msg, *args, **kwargs):
         LoggingLoggerClass.warning(self, msg, *args, **kwargs)
 
     warn = warning
 
-    @maybe_coroutine
-    async def error(self, msg, *args, **kwargs):
+    def error(self, msg, *args, **kwargs):
         LoggingLoggerClass.error(self, msg, *args, **kwargs)
 
-    @maybe_coroutine
-    async def critical(self, msg, *args, **kwargs):
+    def critical(self, msg, *args, **kwargs):
         LoggingLoggerClass.critical(self, msg, *args, **kwargs)
 
-    @maybe_coroutine
-    async def exception(self, msg, *args, **kwargs):
+    def exception(self, msg, *args, **kwargs):
         LoggingLoggerClass.exception(self, msg, *args, **kwargs)
 
     def findCaller(self, *args, **kwargs):  # NOQA: N802

--- a/deluge/log.py
+++ b/deluge/log.py
@@ -20,6 +20,7 @@ from twisted.internet import defer
 from twisted.python.log import PythonLoggingObserver
 
 from deluge import common
+from deluge.decorators import maybe_coroutine
 
 __all__ = ('setup_logger', 'set_logger_level', 'get_plugin_logger', 'LOG')
 
@@ -51,39 +52,39 @@ class Logging(LoggingLoggerClass):
                     )
                 )
 
-    @defer.inlineCallbacks
-    def garbage(self, msg, *args, **kwargs):
-        yield LoggingLoggerClass.log(self, 1, msg, *args, **kwargs)
+    @maybe_coroutine
+    async def garbage(self, msg, *args, **kwargs):
+        LoggingLoggerClass.log(self, 1, msg, *args, **kwargs)
 
-    @defer.inlineCallbacks
-    def trace(self, msg, *args, **kwargs):
-        yield LoggingLoggerClass.log(self, 5, msg, *args, **kwargs)
+    @maybe_coroutine
+    async def trace(self, msg, *args, **kwargs):
+        LoggingLoggerClass.log(self, 5, msg, *args, **kwargs)
 
-    @defer.inlineCallbacks
-    def debug(self, msg, *args, **kwargs):
-        yield LoggingLoggerClass.debug(self, msg, *args, **kwargs)
+    @maybe_coroutine
+    async def debug(self, msg, *args, **kwargs):
+        LoggingLoggerClass.debug(self, msg, *args, **kwargs)
 
-    @defer.inlineCallbacks
-    def info(self, msg, *args, **kwargs):
-        yield LoggingLoggerClass.info(self, msg, *args, **kwargs)
+    @maybe_coroutine
+    async def info(self, msg, *args, **kwargs):
+        LoggingLoggerClass.info(self, msg, *args, **kwargs)
 
-    @defer.inlineCallbacks
-    def warning(self, msg, *args, **kwargs):
-        yield LoggingLoggerClass.warning(self, msg, *args, **kwargs)
+    @maybe_coroutine
+    async def warning(self, msg, *args, **kwargs):
+        LoggingLoggerClass.warning(self, msg, *args, **kwargs)
 
     warn = warning
 
-    @defer.inlineCallbacks
-    def error(self, msg, *args, **kwargs):
-        yield LoggingLoggerClass.error(self, msg, *args, **kwargs)
+    @maybe_coroutine
+    async def error(self, msg, *args, **kwargs):
+        LoggingLoggerClass.error(self, msg, *args, **kwargs)
 
-    @defer.inlineCallbacks
-    def critical(self, msg, *args, **kwargs):
-        yield LoggingLoggerClass.critical(self, msg, *args, **kwargs)
+    @maybe_coroutine
+    async def critical(self, msg, *args, **kwargs):
+        LoggingLoggerClass.critical(self, msg, *args, **kwargs)
 
-    @defer.inlineCallbacks
-    def exception(self, msg, *args, **kwargs):
-        yield LoggingLoggerClass.exception(self, msg, *args, **kwargs)
+    @maybe_coroutine
+    async def exception(self, msg, *args, **kwargs):
+        LoggingLoggerClass.exception(self, msg, *args, **kwargs)
 
     def findCaller(self, *args, **kwargs):  # NOQA: N802
         f = logging.currentframe().f_back

--- a/deluge/tests/test_maybe_coroutine.py
+++ b/deluge/tests/test_maybe_coroutine.py
@@ -1,0 +1,213 @@
+#
+# This file is part of Deluge and is licensed under GNU General Public License 3.0, or later, with
+# the additional special exception to link portions of this program with the OpenSSL library.
+# See LICENSE for more details.
+#
+import pytest
+import pytest_twisted
+import twisted.python.failure
+from twisted.internet import defer, reactor, task
+from twisted.internet.defer import maybeDeferred
+
+from deluge.decorators import maybe_coroutine
+
+
+@defer.inlineCallbacks
+def inline_func():
+    result = yield task.deferLater(reactor, 0, lambda: 'function_result')
+    return result
+
+
+@defer.inlineCallbacks
+def inline_error():
+    raise Exception('function_error')
+    yield
+
+
+@maybe_coroutine
+async def coro_func():
+    result = await task.deferLater(reactor, 0, lambda: 'function_result')
+    return result
+
+
+@maybe_coroutine
+async def coro_error():
+    raise Exception('function_error')
+
+
+@defer.inlineCallbacks
+def coro_func_from_inline():
+    result = yield coro_func()
+    return result
+
+
+@defer.inlineCallbacks
+def coro_error_from_inline():
+    result = yield coro_error()
+    return result
+
+
+@maybe_coroutine
+async def coro_func_from_coro():
+    return await coro_func()
+
+
+@maybe_coroutine
+async def coro_error_from_coro():
+    return await coro_error()
+
+
+@maybe_coroutine
+async def inline_func_from_coro():
+    return await inline_func()
+
+
+@maybe_coroutine
+async def inline_error_from_coro():
+    return await inline_error()
+
+
+@pytest_twisted.inlineCallbacks
+def test_standard_twisted():
+    """Sanity check that twisted tests work how we expect.
+
+    Not really testing deluge code at all.
+    """
+    result = yield inline_func()
+    assert result == 'function_result'
+
+    with pytest.raises(Exception, match='function_error'):
+        yield inline_error()
+
+
+@pytest.mark.parametrize(
+    'function',
+    [
+        inline_func,
+        coro_func,
+        coro_func_from_coro,
+        coro_func_from_inline,
+        inline_func_from_coro,
+    ],
+)
+@pytest_twisted.inlineCallbacks
+def test_from_inline(function):
+    """Test our coroutines wrapped with maybe_coroutine as if they returned plain twisted deferreds."""
+    result = yield function()
+    assert result == 'function_result'
+
+    def cb(result):
+        assert result == 'function_result'
+
+    d = function()
+    d.addCallback(cb)
+    yield d
+
+
+@pytest.mark.parametrize(
+    'function',
+    [
+        inline_error,
+        coro_error,
+        coro_error_from_coro,
+        coro_error_from_inline,
+        inline_error_from_coro,
+    ],
+)
+@pytest_twisted.inlineCallbacks
+def test_error_from_inline(function):
+    """Test our coroutines wrapped with maybe_coroutine as if they returned plain twisted deferreds that raise."""
+    with pytest.raises(Exception, match='function_error'):
+        yield function()
+
+    def eb(result):
+        assert isinstance(result, twisted.python.failure.Failure)
+        assert result.getErrorMessage() == 'function_error'
+
+    d = function()
+    d.addErrback(eb)
+    yield d
+
+
+@pytest.mark.parametrize(
+    'function',
+    [
+        inline_func,
+        coro_func,
+        coro_func_from_coro,
+        coro_func_from_inline,
+        inline_func_from_coro,
+    ],
+)
+@pytest_twisted.ensureDeferred
+async def test_from_coro(function):
+    """Test our coroutines wrapped with maybe_coroutine work from another coroutine."""
+    result = await function()
+    assert result == 'function_result'
+
+
+@pytest.mark.parametrize(
+    'function',
+    [
+        inline_error,
+        coro_error,
+        coro_error_from_coro,
+        coro_error_from_inline,
+        inline_error_from_coro,
+    ],
+)
+@pytest_twisted.ensureDeferred
+async def test_error_from_coro(function):
+    """Test our coroutines wrapped with maybe_coroutine work from another coroutine with errors."""
+    with pytest.raises(Exception, match='function_error'):
+        await function()
+
+
+@pytest_twisted.ensureDeferred
+async def test_tracebacks_preserved():
+    with pytest.raises(Exception) as exc:
+        await coro_error_from_coro()
+    traceback_lines = [
+        'await coro_error_from_coro()',
+        'return await coro_error()',
+        "raise Exception('function_error')",
+    ]
+    # If each coroutine got wrapped with ensureDeferred, the traceback will be mangled
+    # verify the coroutines passed through by checking the traceback.
+    for expected, actual in zip(traceback_lines, exc.traceback):
+        assert expected in str(actual)
+
+
+@pytest_twisted.ensureDeferred
+async def test_maybe_deferred_coroutine():
+    result = await maybeDeferred(coro_func)
+    assert result == 'function_result'
+
+
+@pytest_twisted.ensureDeferred
+async def test_callback_before_await():
+    def cb(res):
+        assert res == 'function_result'
+        return res
+
+    d = coro_func()
+    d.addCallback(cb)
+    result = await d
+    assert result == 'function_result'
+
+
+@pytest_twisted.ensureDeferred
+async def test_callback_after_await():
+    """If it has already been used as a coroutine, can't be retroactively turned into a Deferred.
+    This limitation could be fixed, but the extra complication doesn't feel worth it.
+    """
+
+    def cb(res):
+        pass
+
+    d = coro_func()
+    await d
+    with pytest.raises(
+        Exception, match='Cannot add callbacks to an already awaited coroutine'
+    ):
+        d.addCallback(cb)


### PR DESCRIPTION
Continuation of #351 and #352. Started fresh again, this time with some tests.

Goals:
- Clean up callback hell by making more code inline
- Use async/await syntax as it has more modern niceties than inlineCallbacks
  - Also gets us closer if we want to transition to asyncio in the future
  - `await` is usable in places that `yield` is not. e.g. `return await thething` `func(await thething, 'otherparam')`
  - IDEs know async semantics of async/await syntax to help more than with `inlineCallbacks`
- `maybe_coroutine` decorator has nice property (over `ensureDeferred`) that when used in a chain of other coroutines, they won't be wrapped in deferreds on each level, and so traceback will show each `await` call leading to the error.
- All async functions wrapped in `maybe_coroutine` are 100% backwards compatible with a regular Deferred returning function. Whether called from a coroutine or not.