### PR TITLE
Remove legacy PY2 sys.argv unicode handling

### DIFF
--- a/deluge/common.py
+++ b/deluge/common.py
@@ -11,7 +11,6 @@ import base64
 import binascii
 import functools
 import glob
-import locale
 import logging
 import numbers
 import os
@@ -1313,26 +1312,6 @@ def set_env_variable(name, value):
             log.info("Failed to set Env Var '%s' (msvcrt._putenv)", name)
         else:
             log.debug("Set Env Var '%s' to '%s' (msvcrt._putenv)", name, value)
-
-
-def unicode_argv():
-    """ Gets sys.argv as list of unicode objects on any platform."""
-    # On platforms other than Windows, we have to find the likely encoding of the args and decode
-    # First check if sys.stdout or stdin have encoding set
-    encoding = getattr(sys.stdout, 'encoding') or getattr(sys.stdin, 'encoding')
-    # If that fails, check what the locale is set to
-    encoding = encoding or locale.getpreferredencoding()
-    # As a last resort, just default to utf-8
-    encoding = encoding or 'utf-8'
-
-    arg_list = []
-    for arg in sys.argv:
-        try:
-            arg_list.append(arg.decode(encoding))
-        except AttributeError:
-            arg_list.append(arg)
-
-    return arg_list
 
 
 def run_profiled(func, *args, **kwargs):

--- a/deluge/ui/ui.py
+++ b/deluge/ui/ui.py
@@ -7,6 +7,7 @@
 #
 
 import logging
+import sys
 
 import deluge.common
 import deluge.configmanager
@@ -57,7 +58,7 @@ class UI:
         return self.__options
 
     def start(self, parser=None):
-        args = deluge.common.unicode_argv()[1:]
+        args = sys.argv[1:]
         if parser is None:
             parser = self.parser
         self.__options = self.parse_args(parser, args)


### PR DESCRIPTION
When using pythonw on windows, sys.stdout and stdin are None. We had a legacy `unicode_argv` handler that was crashing in this instance. Just removed that, since sys.argv is always unicode on python 3 to fix the crash.

This is an alternate fix for #360

On a side note, the logging (to a file) also doesn't work when using pythonw. I haven't figured out the reason for that yet, but I'll open up a separate issue/PR