### PR TITLE
[Config] Add mask_funcs to help mask passwords in logs

### DIFF
--- a/deluge/ui/console/cmdline/commands/info.py
+++ b/deluge/ui/console/cmdline/commands/info.py
@@ -67,6 +67,7 @@ STATUS_KEYS = [
     'total_payload_download',
     'total_payload_upload',
     'time_added',
+    'label',
 ]
 
 # Add filter specific state to torrent states
@@ -421,10 +422,14 @@ class Command(BaseCommand):
                 self.console.write(s)
 
             s = '{!info!}Download Folder: {!input!}%s' % status['download_location']
-            self.console.write(s + '\n')
+            self.console.write(s)
+
+            if 'label' in status:
+                s = '{!info!}Label: {!input!}%s' % status['label']
+                self.console.write(s)
 
             if detailed:
-                self.console.write('{!info!}Files in torrent')
+                self.console.write('\n{!info!}Files in torrent')
                 self.show_file_info(torrent_id, status)
                 self.console.write('{!info!}Connected peers')
                 self.show_peer_info(torrent_id, status)

--- a/deluge/ui/hostlist.py
+++ b/deluge/ui/hostlist.py
@@ -84,6 +84,14 @@ def migrate_config_2_to_3(config):
     return config
 
 
+def mask_hosts_password(hosts):
+    """Replace passwords in hosts list with *'s for log output"""
+    if not hosts:
+        return hosts
+
+    return [list(host)[:-1] + ['*' * 10] for host in hosts]
+
+
 class HostList:
     """This class contains methods for adding, removing and looking up hosts in hostlist.conf."""
 
@@ -94,6 +102,7 @@ class HostList:
             default_hostlist(),
             config_dir=get_config_dir(),
             file_version=3,
+            log_mask_funcs={'hosts': mask_hosts_password},
         )
         self.config.run_converter((1, 2), 3, migrate_config_2_to_3)
         self.config.save()

--- a/setup.py
+++ b/setup.py
@@ -481,6 +481,10 @@ if not windows_check() and not osx_check():
 
 _entry_points['console_scripts'] = [
     'deluge-console = deluge.ui.console:start',
+]
+# On Windows use gui_scripts to hide cmd popup
+script_type = 'gui_scripts' if windows_check() else 'console_scripts'
+_entry_points[script_type] = [
     'deluge-web = deluge.ui.web:start',
     'deluged = deluge.core.daemon_entry:start_daemon',
 ]


### PR DESCRIPTION
Added a new Config class parameter `mask_funcs` to enable config
instances hide sensitive information that would appear in config debug
logs.