### PR TITLE
[Build] Fix entry point build errors

### DIFF
--- a/packaging/win/delugewin.spec
+++ b/packaging/win/delugewin.spec
@@ -125,7 +125,7 @@ executables = {
         'console': True,
         'gtk': False,
     },
-    'deluged-script.py': {
+    'deluged-script.pyw': {
         'name': 'deluged',
         'console': False,
         'gtk': False,
@@ -137,12 +137,12 @@ executables = {
     },
     'deluge-web-debug-script.py': {
         'name': 'deluge-web-debug',
-        'console': False,
+        'console': True,
         'gtk': False,
     },
-    'deluge-web-script.py': {
+    'deluge-web-script.pyw': {
         'name': 'deluge-web',
-        'console': True,
+        'console': False,
         'gtk': False,
     },
 }

--- a/setup.py
+++ b/setup.py
@@ -479,15 +479,21 @@ if not windows_check() and not osx_check():
     if os.path.isfile(appdata_data):
         _data_files.append(('share/appdata', [appdata_data]))
 
+
+# Entry Points
 _entry_points['console_scripts'] = [
     'deluge-console = deluge.ui.console:start',
 ]
-# On Windows use gui_scripts to hide cmd popup
-script_type = 'gui_scripts' if windows_check() else 'console_scripts'
-_entry_points[script_type] = [
+
+# On Windows use gui_scripts to hide cmd popup (no effect on Linux/MacOS)
+_entry_points['gui_scripts'] = [
+    'deluge = deluge.ui.ui_entry:start_ui',
+    'deluge-gtk = deluge.ui.gtk3:start',
     'deluge-web = deluge.ui.web:start',
     'deluged = deluge.core.daemon_entry:start_daemon',
 ]
+
+# Provide Windows 'debug' exes for stdin/stdout e.g. logging/errors
 if windows_check():
     _entry_points['console_scripts'].extend(
         [
@@ -496,10 +502,7 @@ if windows_check():
             'deluged-debug = deluge.core.daemon_entry:start_daemon',
         ]
     )
-_entry_points['gui_scripts'] = [
-    'deluge = deluge.ui.ui_entry:start_ui',
-    'deluge-gtk = deluge.ui.gtk3:start',
-]
+
 _entry_points['deluge.ui'] = [
     'console = deluge.ui.console:Console',
     'web = deluge.ui.web:Web',


### PR DESCRIPTION
Fixed a mistake settings entry points in setup.py. Replaced with simpler
logic since gui_scripts only affect Windows.

Fixed entry point changes affecting pyinstaller build

Corrected deluge-web.exe to have no console instead of
deluge-web-debug.exe