### PR TITLE
Refactor prefetch_metadata for (hopefully) more clarity

### DIFF
--- a/deluge/core/rpcserver.py
+++ b/deluge/core/rpcserver.py
@@ -13,6 +13,7 @@ import sys
 import traceback
 from collections import namedtuple
 from types import FunctionType
+from typing import Callable, TypeVar, overload
 
 from twisted.internet import defer, reactor
 from twisted.internet.protocol import Factory, connectionDone
@@ -40,6 +41,18 @@ RPC_ERROR = 2
 RPC_EVENT = 3
 
 log = logging.getLogger(__name__)
+
+TCallable = TypeVar('TCallable', bound=Callable)
+
+
+@overload
+def export(func: TCallable) -> TCallable:
+    ...
+
+
+@overload
+def export(auth_level: int) -> Callable[[TCallable], TCallable]:
+    ...
 
 
 def export(auth_level=AUTH_LEVEL_DEFAULT):

--- a/deluge/tests/test_torrentmanager.py
+++ b/deluge/tests/test_torrentmanager.py
@@ -12,7 +12,7 @@ from unittest import mock
 
 import pytest
 import pytest_twisted
-from twisted.internet import task
+from twisted.internet import reactor, task
 
 from deluge import component
 from deluge.bencode import bencode
@@ -78,7 +78,9 @@ class TestTorrentmanager(BaseTestCase):
 
         magnet = 'magnet:?xt=urn:btih:ab570cdd5a17ea1b61e970bb72047de141bce173'
         d = self.tm.prefetch_metadata(magnet, 30)
-        self.tm.on_alert_metadata_received(mock_alert)
+        # Make sure to use calllater, because the above prefetch call won't
+        # actually start running until we await it.
+        reactor.callLater(0, self.tm.on_alert_metadata_received, mock_alert)
 
         expected = (
             'ab570cdd5a17ea1b61e970bb72047de141bce173',


### PR DESCRIPTION
Just trying to clean up some of the more complicated callback logic. Hopefully this implementation is a bit more clear. Okay if not, only one real bug is fixed, and that was just with the test. Notable changes:
- The test was awaiting a DeferredList. By default that will eat exceptions and just add them to the result list (including test assertion exceptions.) Added `fireOnOneErrback=True` to make sure that wasn't happening.
- Moved the logic for multiple calls to await the same response into torrentmanager from core, so no matter where the prefetch is called from it will wait for the original call.
- Implemented the multiple calls with an explicit queue of waiting callbacks, rather than a callback callback chain.
- Moved to one inline async function rather than split into a main and callback after alert function.
- Added some more type hints to the stuff I changed.

Planning on doing a few more cleanups, just trying to keep it in easy chunks.