### PR TITLE
Automatically refresh and expire the torrent status cache

### DIFF
--- a/deluge/core/torrent.py
+++ b/deluge/core/torrent.py
@@ -16,6 +16,7 @@ Attributes:
 import logging
 import os
 import socket
+import time
 from urllib.parse import urlparse
 
 from twisted.internet.defer import Deferred, DeferredList
@@ -234,7 +235,8 @@ class Torrent:
         self.handle = handle
 
         self.magnet = magnet
-        self.status = self.handle.status()
+        self._status = None
+        self._status_last_update = 0
 
         self.torrent_info = self.handle.torrent_file()
         self.has_metadata = self.status.has_metadata
@@ -267,7 +269,6 @@ class Torrent:
         self.prev_status = {}
         self.waiting_on_folder_rename = []
 
-        self.update_status(self.handle.status())
         self._create_status_funcs()
         self.set_options(self.options)
         self.update_state()
@@ -641,7 +642,7 @@ class Torrent:
 
     def update_state(self):
         """Updates the state, based on libtorrent's torrent state"""
-        status = self.handle.status()
+        status = self.update_status()
         session_paused = component.get('Core').session.is_paused()
         old_state = self.state
         self.set_status_message()
@@ -709,7 +710,7 @@ class Torrent:
             restart_to_resume (bool, optional): Prevent resuming clearing the error, only restarting
                 session can resume.
         """
-        status = self.handle.status()
+        status = self.update_status()
         self._set_handle_flags(
             flag=lt.torrent_flags.auto_managed,
             set_flag=False,
@@ -1024,7 +1025,7 @@ class Torrent:
             dict: a dictionary of the status keys and their values
         """
         if update:
-            self.update_status(self.handle.status())
+            self.update_status()
 
         if all_keys:
             keys = list(self.status_funcs)
@@ -1054,13 +1055,35 @@ class Torrent:
 
         return status_dict
 
-    def update_status(self, status):
+    def update_status(self):
+        """Get the torrent status fresh, not from cache.
+
+        This should be used when a guaranteed fresh status is needed rather than
+        `torrent.handle.status()` because it will update the cache as well.
+        """
+        self.status = self.handle.status()
+        return self.status
+
+    @property
+    def status(self):
+        """Cached copy of the libtorrent status for this torrent.
+
+        If it has not been updated within the last five seconds, it will be
+        automatically refreshed.
+        """
+        if self._status_last_update < (time.time() - 5):
+            self.status = self.handle.status()
+        return self._status
+
+    @status.setter
+    def status(self, status):
         """Updates the cached status.
 
         Args:
             status (libtorrent.torrent_status): a libtorrent torrent status
         """
-        self.status = status
+        self._status = status
+        self._status_last_update = time.time()
 
     def _create_status_funcs(self):
         """Creates the functions for getting torrent status"""

--- a/deluge/core/torrent.py
+++ b/deluge/core/torrent.py
@@ -17,6 +17,7 @@ import logging
 import os
 import socket
 import time
+from typing import Optional
 from urllib.parse import urlparse
 
 from twisted.internet.defer import Deferred, DeferredList
@@ -235,8 +236,8 @@ class Torrent:
         self.handle = handle
 
         self.magnet = magnet
-        self._status = None
-        self._status_last_update = 0
+        self._status: 'Optional[lt.torrent_status]' = None
+        self._status_last_update: float = 0.0
 
         self.torrent_info = self.handle.torrent_file()
         self.has_metadata = self.status.has_metadata
@@ -1055,7 +1056,7 @@ class Torrent:
 
         return status_dict
 
-    def update_status(self):
+    def update_status(self) -> 'lt.torrent_status':
         """Get the torrent status fresh, not from cache.
 
         This should be used when a guaranteed fresh status is needed rather than
@@ -1065,7 +1066,7 @@ class Torrent:
         return self.status
 
     @property
-    def status(self):
+    def status(self) -> 'lt.torrent_status':
         """Cached copy of the libtorrent status for this torrent.
 
         If it has not been updated within the last five seconds, it will be
@@ -1076,11 +1077,11 @@ class Torrent:
         return self._status
 
     @status.setter
-    def status(self, status):
+    def status(self, status: 'lt.torrent_status') -> None:
         """Updates the cached status.
 
         Args:
-            status (libtorrent.torrent_status): a libtorrent torrent status
+            status: a libtorrent torrent status
         """
         self._status = status
         self._status_last_update = time.time()

--- a/deluge/core/torrent.py
+++ b/deluge/core/torrent.py
@@ -643,7 +643,7 @@ class Torrent:
 
     def update_state(self):
         """Updates the state, based on libtorrent's torrent state"""
-        status = self.update_status()
+        status = self.get_lt_status()
         session_paused = component.get('Core').session.is_paused()
         old_state = self.state
         self.set_status_message()
@@ -711,7 +711,7 @@ class Torrent:
             restart_to_resume (bool, optional): Prevent resuming clearing the error, only restarting
                 session can resume.
         """
-        status = self.update_status()
+        status = self.get_lt_status()
         self._set_handle_flags(
             flag=lt.torrent_flags.auto_managed,
             set_flag=False,
@@ -1026,7 +1026,7 @@ class Torrent:
             dict: a dictionary of the status keys and their values
         """
         if update:
-            self.update_status()
+            self.get_lt_status()
 
         if all_keys:
             keys = list(self.status_funcs)
@@ -1056,7 +1056,7 @@ class Torrent:
 
         return status_dict
 
-    def update_status(self) -> 'lt.torrent_status':
+    def get_lt_status(self) -> 'lt.torrent_status':
         """Get the torrent status fresh, not from cache.
 
         This should be used when a guaranteed fresh status is needed rather than

--- a/deluge/core/torrentmanager.py
+++ b/deluge/core/torrentmanager.py
@@ -1354,7 +1354,7 @@ class TorrentManager(component.Component):
         torrent.set_tracker_status('Announce OK')
 
         # Check for peer information from the tracker, if none then send a scrape request.
-        torrent.update_status()
+        torrent.get_lt_status()
         if torrent.status.num_complete == -1 or torrent.status.num_incomplete == -1:
             torrent.scrape_tracker()
 

--- a/deluge/tests/test_torrent.py
+++ b/deluge/tests/test_torrent.py
@@ -365,10 +365,10 @@ class TestTorrent(BaseTestCase):
             torrent = Torrent(handle, {})
             counter = itertools.count()
             handle.status = mock.Mock(side_effect=counter.__next__)
-            first_status = torrent.update_status()
+            first_status = torrent.get_lt_status()
             assert first_status == 0, 'sanity check'
             assert first_status == torrent.status, 'cached status should be used'
-            assert torrent.update_status() == 1, 'status should update'
+            assert torrent.get_lt_status() == 1, 'status should update'
             assert torrent.status == 1
             # Advance time and verify cache expires and updates
             mock_time.return_value += 10


### PR DESCRIPTION
Stop at ratio was not working when no clients were connected, because
it was using a cached version of the torrent status, and never calling
for a refresh. When a client connected, it called for the refresh and
started working properly.

This fix turns `Torrent.status` into a property, which checks when the last refresh was, and automatically refreshes before returning if it was not recent (currently 5 seconds.) When setting the property it automatically stores the update time for the cache. Any place that wants `torrent.handle.status()` should instead use `torrent.status`, or `torrent.update_status()`, (which also returns said updated status,) after this change.

Closes: https://dev.deluge-torrent.org/ticket/3497

Questions:
- Is this method reasonable?
  _Seems like it_
- How long should it be before the status cache is considered expired?
  _Chose 5 seconds for now_
- There are a few methods in `Torrent` which grab `self.handle.status()` directly. Should those be converted to use the cache? If not, they should be changed to update the cache, to avoid extra cache refreshes.
  _Converted any of these to use `torrent.update_status()` which refreshes the cache (and returns the new status)_