### PR TITLE
Enable file_completed_alert handling

### DIFF
--- a/deluge/core/alertmanager.py
+++ b/deluge/core/alertmanager.py
@@ -46,6 +46,7 @@ class AlertManager(component.Component):
             | lt.alert.category_t.status_notification
             | lt.alert.category_t.ip_block_notification
             | lt.alert.category_t.performance_warning
+            | lt.alert.category_t.file_progress_notification
         )
 
         self.session.apply_settings({'alert_mask': alert_mask})


### PR DESCRIPTION
Without adding file_progress to the alert mask, the
TorrentFileCompletedEvent would never fire.

Closes: https://dev.deluge-torrent.org/ticket/3421