### PR TITLE
[WebUI] Move HTML entity encoding to client

### DIFF
--- a/deluge/ui/web/js/deluge-all/Deluge.js
+++ b/deluge/ui/web/js/deluge-all/Deluge.js
@@ -25,11 +25,6 @@ Ext.state.Manager.setProvider(
 // Add some additional functions to ext and setup some of the
 // configurable parameters
 Ext.apply(Ext, {
-    escapeHTML: function (text) {
-        text = String(text).replace('<', '&lt;').replace('>', '&gt;');
-        return text.replace('&', '&amp;');
-    },
-
     isObjectEmpty: function (obj) {
         for (var i in obj) {
             return false;

--- a/deluge/ui/web/js/deluge-all/EditTrackersWindow.js
+++ b/deluge/ui/web/js/deluge-all/EditTrackersWindow.js
@@ -57,6 +57,7 @@ Deluge.EditTrackersWindow = Ext.extend(Ext.Window, {
                     header: _('Tracker'),
                     width: 0.9,
                     dataIndex: 'url',
+                    tpl: new Ext.XTemplate('{url:htmlEncode}'),
                 },
             ],
             columnSort: {

--- a/deluge/ui/web/js/deluge-all/FilterPanel.js
+++ b/deluge/ui/web/js/deluge-all/FilterPanel.js
@@ -171,5 +171,5 @@ Deluge.FilterPanel.templates = {
     tracker_host:
         '<div class="x-deluge-filter" style="background-image: url(' +
         deluge.config.base +
-        'tracker/{filter});">{filter} ({count})</div>',
+        'tracker/{filter});">{filter:htmlEncode} ({count})</div>',
 };

--- a/deluge/ui/web/js/deluge-all/TorrentGrid.js
+++ b/deluge/ui/web/js/deluge-all/TorrentGrid.js
@@ -17,7 +17,7 @@
         return String.format(
             '<div class="torrent-name x-deluge-{0}">{1}</div>',
             r.data['state'].toLowerCase(),
-            value
+            Ext.util.Format.htmlEncode(value)
         );
     }
     function torrentSpeedRenderer(value) {
@@ -62,7 +62,7 @@
             '<div style="background: url(' +
                 deluge.config.base +
                 'tracker/{0}) no-repeat; padding-left: 20px;">{0}</div>',
-            value
+            Ext.util.Format.htmlEncode(value)
         );
     }
 

--- a/deluge/ui/web/js/deluge-all/add/AddWindow.js
+++ b/deluge/ui/web/js/deluge-all/add/AddWindow.js
@@ -64,20 +64,6 @@ Deluge.add.AddWindow = Ext.extend(Deluge.add.Window, {
         this.addButton(_('Cancel'), this.onCancelClick, this);
         this.addButton(_('Add'), this.onAddClick, this);
 
-        function torrentRenderer(value, p, r) {
-            if (r.data['info_hash']) {
-                return String.format(
-                    '<div class="x-deluge-add-torrent-name">{0}</div>',
-                    value
-                );
-            } else {
-                return String.format(
-                    '<div class="x-deluge-add-torrent-name-loading">{0}</div>',
-                    value
-                );
-            }
-        }
-
         this.list = new Ext.list.ListView({
             store: new Ext.data.SimpleStore({
                 fields: [
@@ -91,7 +77,6 @@ Deluge.add.AddWindow = Ext.extend(Deluge.add.Window, {
                     id: 'torrent',
                     width: 150,
                     sortable: true,
-                    renderer: torrentRenderer,
                     dataIndex: 'text',
                     tpl: new Ext.XTemplate(
                         '<div class="x-deluge-add-torrent-name">{text:htmlEncode}</div>'

--- a/deluge/ui/web/js/deluge-all/add/AddWindow.js
+++ b/deluge/ui/web/js/deluge-all/add/AddWindow.js
@@ -93,6 +93,9 @@ Deluge.add.AddWindow = Ext.extend(Deluge.add.Window, {
                     sortable: true,
                     renderer: torrentRenderer,
                     dataIndex: 'text',
+                    tpl: new Ext.XTemplate(
+                        '<div class="x-deluge-add-torrent-name">{text:htmlEncode}</div>'
+                    ),
                 },
             ],
             stripeRows: true,

--- a/deluge/ui/web/js/deluge-all/add/FilesTab.js
+++ b/deluge/ui/web/js/deluge-all/add/FilesTab.js
@@ -28,6 +28,7 @@ Deluge.add.FilesTab = Ext.extend(Ext.ux.tree.TreeGrid, {
             header: _('Filename'),
             width: 295,
             dataIndex: 'filename',
+            tpl: new Ext.XTemplate('{filename:htmlEncode}'),
         },
         {
             header: _('Size'),

--- a/deluge/ui/web/js/deluge-all/details/DetailsTab.js
+++ b/deluge/ui/web/js/deluge-all/details/DetailsTab.js
@@ -91,7 +91,9 @@ Deluge.details.DetailsTab = Ext.extend(Ext.Panel, {
         for (var field in this.fields) {
             if (!Ext.isDefined(data[field])) continue; // This is a field we are not responsible for.
             if (data[field] == this.oldData[field]) continue;
-            this.fields[field].dom.innerHTML = Ext.escapeHTML(data[field]);
+            this.fields[field].dom.innerHTML = Ext.util.Format.htmlEncode(
+                data[field]
+            );
         }
         this.oldData = data;
     },

--- a/deluge/ui/web/js/deluge-all/details/FilesTab.js
+++ b/deluge/ui/web/js/deluge-all/details/FilesTab.js
@@ -18,6 +18,7 @@ Deluge.details.FilesTab = Ext.extend(Ext.ux.tree.TreeGrid, {
             header: _('Filename'),
             width: 330,
             dataIndex: 'filename',
+            tpl: new Ext.XTemplate('{filename:htmlEncode}'),
         },
         {
             header: _('Size'),

--- a/deluge/ui/web/js/deluge-all/details/PeersTab.js
+++ b/deluge/ui/web/js/deluge-all/details/PeersTab.js
@@ -73,7 +73,7 @@
                             header: _('Client'),
                             width: 125,
                             sortable: true,
-                            renderer: fplain,
+                            renderer: 'htmlEncode',
                             dataIndex: 'client',
                         },
                         {

--- a/deluge/ui/web/js/deluge-all/preferences/PreferencesWindow.js
+++ b/deluge/ui/web/js/deluge-all/preferences/PreferencesWindow.js
@@ -46,7 +46,6 @@ Deluge.preferences.PreferencesWindow = Ext.extend(Ext.Window, {
             columns: [
                 {
                     id: 'name',
-                    renderer: fplain,
                     dataIndex: 'name',
                 },
             ],


### PR DESCRIPTION
[[WebUI] Fix encoding HTML entities for torrent attributes](https://github.com/deluge-torrent/deluge/pull/375/commits/a5503c0c606e196f368a58ea3d1b8457e76a3a31)

Ensure all torrent attributes that might contain malicious HTML entities
are encoded.

By allowing HTML entities to be rendered it enable malicious torrent
files to perform XSS attacks.

Resolves: https://dev.deluge-torrent.org/ticket/3459

[[WebUI] Move HTML entity encoding to client](https://github.com/deluge-torrent/deluge/pull/375/commits/8ece036770484e170d5a728cdb25062088068f71)

We should not be mangling the torrent data in the JSON API since this
can have unintended consquences with names and filepaths that can be
edited. If we escape those symbols in the JSON API then the data no
longer matches that stored by core. Therefore shift the encoding to the
client and consider dealing separetely with these entities when the user
first adds a torrent.

* Created a modified htmlEncode in Deluge Formatter based on extjs
method that also encodes single quotes.
* Removed renderers in ListViews since only templates specified via tpl
are used and any render attribute specified was a no-op.
* Removed old buggy escapeHtml

Resolves: https://dev.deluge-torrent.org/ticket/3459
Ref: https://docs.sencha.com/extjs/6.5.3/modern/src/String.js.html#Ext.String-method-htmlEncode
Ref: https://docs.sencha.com/extjs/3.4.0/source/Format.html#Ext-util-Format-method-htmlEncode