### PR TITLE
    Add a systemd user service

### DIFF
--- a/packaging/systemd/deluged.service
+++ b/packaging/systemd/deluged.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Deluge Bittorrent Client Daemon
-Documentation=man:deluged
+Documentation=man:deluged(1)
 After=network-online.target
 
 [Service]

--- a/packaging/systemd/user/deluged.service
+++ b/packaging/systemd/user/deluged.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Deluge Bittorrent Client Daemon
+Documentation=man:deluged(1)
+
+[Service]
+UMask=007
+ExecStart=/usr/bin/deluged -d
+Restart=on-failure
+TimeoutStopSec=300
+Slice=background.slice
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
This file should be installed into /usr/lib/systemd/user/deluged.service

Unlike the existing service file, this one configures deluge to run as a desktop session user. It does not require root privileges to be controlled either.

