### PR TITLE
[lint] update black package

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ exclude: >
   )$
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
         name: Fmt Black


### PR DESCRIPTION
Previous version (22.1.0) didn't support `click` version 8.1.0.
Updating to 22.3.0 to resolve.

See: https://github.com/psf/black/issues/2964