### PR TITLE
[Notifications] Fix UnicodeEncodeError upon non-ascii torrent name

### DIFF
--- a/deluge/plugins/Notifications/deluge_notifications/core.py
+++ b/deluge/plugins/Notifications/deluge_notifications/core.py
@@ -148,7 +148,9 @@ Date: %(date)s
 
         try:
             try:
-                server.sendmail(self.config['smtp_from'], to_addrs, message)
+                server.sendmail(
+                    self.config['smtp_from'], to_addrs, message.encode('utf-8')
+                )
             except smtplib.SMTPException as ex:
                 err_msg = (
                     _('There was an error sending the notification email: %s') % ex


### PR DESCRIPTION
smtplib.SMTP.sendmail expects 'msg' in string of ascii chars or bytes, where the former gets encoded to bytes through ascii codec, hence raising said error, but now fixed by encoding to bytes ourself through utf-8