### PR TITLE
[Packaging] Pinned Pyinstaller to v4.10 and readme update

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -71,12 +71,12 @@ jobs:
 
       - name: Install Python dependencies
         run: >
-          python -m pip install --find-links="C:\GTK\release\python" pycairo PyGObject
+          python -m pip install --no-index --find-links="C:\GTK\release\python" pycairo PyGObject
 
           python -m pip install
           twisted[tls]==22.2.0rc1
           libtorrent==${{ matrix.libtorrent }}
-          pyinstaller
+          pyinstaller==4.10
           pygame
           -r requirements.txt
 

--- a/packaging/win/README.md
+++ b/packaging/win/README.md
@@ -11,13 +11,15 @@ Instructions for building the Deluge NSIS Installer for Windows Vista/7/8/8.1/10
 == Build Steps ==
 
 1.  Build and Install Deluge on Windows.
-2.  Run the pyinstaller from the deluge\packaging\win directory.spec:
+2.  Run pyinstaller from the deluge\packaging\win directory:
 
-    `pyinstaller --clean delugewin.spec --distpath .\packaging\win\freeze`
+    `pyinstaller --clean delugewin.spec --distpath freeze`
 
     The result is a PyInstaller version of Deluge in `packaging\win\freeze`.
 
-3.  Run the NSIS script:
+3.  Run the NSIS scripts:
+
+    `python setup_nsis.py`
 
     64-bit python:
 


### PR DESCRIPTION
Pin Pyinstaller to latest v4.x until issue of aborting upon missing typelibs for various unbuilt gst-modules can be properly investigated and resolved. Specific error for one of the modules being:

    36738 INFO: Loading module hook 'hook-gi.repository.Gst.py' from 'C:\\hostedtoolcache\\windows\\Python\\3.9.13\\x64\\lib\\site-packages\\PyInstaller\\hooks'...
    Traceback (most recent call last):
      File "<string>", line 7, in <module>
    gi.repository.GLib.GError: g-irepository-error-quark: Typelib file for namespace 'Gst', version '1.0' not found (0)
    36870 ERROR: gi repository 'GIRepository 2.0' not found. Please make sure corresponding package is installed.
    Traceback (most recent call last):
      File "<string>", line 4, in <module>
      File "C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\site-packages\gi\__init__.py", line 139, in require_version
        raise ValueError('Namespace %s not available' % namespace)
    ValueError: Namespace Gst not available