### PR TITLE
[Packaging] Bump PyInstaller to 5.2

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -66,7 +66,7 @@ jobs:
           python -m pip install
           twisted[tls]==22.4.0
           libtorrent==${{ matrix.libtorrent }}
-          pyinstaller==4.10
+          pyinstaller==5.2
           pygame
           -r requirements.txt
 


### PR DESCRIPTION
With release of PyInstaller 5.2 no longer need to pin back to 4.10 to resolve issue of gi-hooks making freeze error out.