### PR TITLE
Fix serving from custom base path

### DIFF
--- a/deluge/ui/web/server.py
+++ b/deluge/ui/web/server.py
@@ -682,7 +682,7 @@ class DelugeWeb(component.Component):
 
         if self.base != '/':
             # Strip away slashes and serve on the base path as well as root path
-            self.top_level.putChild(self.base.strip('/'), self.top_level)
+            self.top_level.putChild(self.base.strip('/').encode('utf8'), self.top_level)
 
         setup_translation()
 


### PR DESCRIPTION
Twisted requires a child as bytes, not str to work as expected

See also https://stackoverflow.com/questions/42346264/python-twisted-putchild-not-forwarding-expectedly

Possibly same issue encountered here:
https://dev.deluge-torrent.org/ticket/3105
https://dev.deluge-torrent.org/ticket/2677
https://forum.deluge-torrent.org/viewtopic.php?t=56022
https://forum.deluge-torrent.org/viewtopic.php?t=54520
https://forum.deluge-torrent.org/viewtopic.php?t=54668