### PR TITLE
[WebUI] Fix base path not being honored

### DIFF
--- a/deluge/ui/web/server.py
+++ b/deluge/ui/web/server.py
@@ -453,8 +453,14 @@ class TopLevel(resource.Resource):
         'css/deluge.css',
     ]
 
-    def __init__(self):
+    def __init__(self, children: dict = None):
         resource.Resource.__init__(self)
+
+        if children is not None:
+            for path, child in children.items():
+                self.putChild(path, child)
+            self.js = children[b'js']
+            return
 
         self.putChild(b'css', LookupResource('Css', rpath('css')))
         if os.path.isfile(rpath('js', 'gettext.js')):
@@ -681,7 +687,8 @@ class DelugeWeb(component.Component):
 
         if self.base != '/':
             # Strip away slashes and serve on the base path as well as root path
-            self.top_level.putChild(self.base.strip('/').encode(), self.top_level)
+            base = TopLevel(self.top_level.children)
+            self.top_level.putChild(self.base.strip('/').encode(), base)
 
         setup_translation()
 


### PR DESCRIPTION
Twisted requires a child as `bytes`, not `str` to work as expected.
In addition, it adds the ability to call base in an infinite loop of
calls, i.e. `hostname/base/base/base/...`.

The solution is to build the tree as served.

This is an alternative PR to #390.