### PR TITLE
[3536][UI] Add a way to change themes

### DIFF
--- a/deluge/ui/gtk3/glade/preferences_dialog.ui
+++ b/deluge/ui/gtk3/glade/preferences_dialog.ui
@@ -430,6 +430,77 @@
                               </packing>
                             </child>
                             <child>
+                              <object class="GtkFrame" id="frame_theme">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0</property>
+                                <property name="shadow_type">none</property>
+                                <child>
+                                  <object class="GtkAlignment" id="alignment_theme">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="top_padding">3</property>
+                                    <property name="left_padding">10</property>
+                                    <child>
+                                      <object class="GtkBox" id="hbox_theme">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <child>
+                                          <object class="GtkRadioButton" id="radio_theme_light">
+                                            <property name="label" translatable="yes">Light</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="tooltip_text" translatable="yes">The light theme</property>
+                                            <property name="active">True</property>
+                                            <property name="draw_indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkRadioButton" id="radio_theme_dark">
+                                            <property name="label" translatable="yes">Dark</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="tooltip_text" translatable="yes">The dark theme</property>
+                                            <property name="draw_indicator">True</property>
+                                            <property name="group">radio_theme_light</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="padding">7</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child type="label">
+                                  <object class="GtkLabel" id="label_theme">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="label" translatable="yes">Theme</property>
+                                    <attributes>
+                                      <attribute name="weight" value="bold"/>
+                                    </attributes>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="padding">5</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                            <child>
                               <object class="GtkFrame" id="frame29">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
@@ -736,7 +807,7 @@ and daemon (does not apply in Standalone mode).</property>
                                 <property name="expand">False</property>
                                 <property name="fill">False</property>
                                 <property name="padding">5</property>
-                                <property name="position">1</property>
+                                <property name="position">2</property>
                               </packing>
                             </child>
                             <child>
@@ -964,7 +1035,7 @@ and daemon (does not apply in Standalone mode).</property>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
                                 <property name="padding">5</property>
-                                <property name="position">2</property>
+                                <property name="position">3</property>
                               </packing>
                             </child>
                             <child>
@@ -1024,7 +1095,7 @@ and daemon (does not apply in Standalone mode).</property>
                                 <property name="expand">False</property>
                                 <property name="fill">False</property>
                                 <property name="padding">5</property>
-                                <property name="position">3</property>
+                                <property name="position">4</property>
                               </packing>
                             </child>
                             <child>
@@ -1101,7 +1172,7 @@ and daemon (does not apply in Standalone mode).</property>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">4</property>
+                                <property name="position">5</property>
                               </packing>
                             </child>
                           </object>

--- a/deluge/ui/gtk3/gtkui.py
+++ b/deluge/ui/gtk3/gtkui.py
@@ -84,6 +84,7 @@ except ImportError:
 
 DEFAULT_PREFS = {
     'standalone': True,
+    'dark_theme': False,
     'interactive_add': True,
     'focus_add_dialog': True,
     'enable_system_tray': True,

--- a/deluge/ui/gtk3/mainwindow.py
+++ b/deluge/ui/gtk3/mainwindow.py
@@ -73,6 +73,12 @@ class MainWindow(component.Component):
         self.config = ConfigManager('gtk3ui.conf')
         self.main_builder = Gtk.Builder()
 
+        # Set theme
+        Gtk.Settings.get_default().set_property(
+            'gtk-application-prefer-dark-theme',
+            self.config['dark_theme'],
+        )
+
         # Patch this GtkBuilder to avoid connecting signals from elsewhere
         #
         # Think about splitting up  mainwindow gtkbuilder file into the necessary parts

--- a/deluge/ui/gtk3/preferences.py
+++ b/deluge/ui/gtk3/preferences.py
@@ -13,7 +13,7 @@ from hashlib import sha1 as sha
 from urllib.parse import urlparse
 
 from gi import require_version
-from gi.repository import Gtk
+from gi.repository import GObject, Gtk
 from gi.repository.Gdk import Color
 
 import deluge.common
@@ -167,6 +167,14 @@ class Preferences(component.Component):
 
         # Radio buttons to choose between systray and appindicator
         self.builder.get_object('alignment_tray_type').set_visible(appindicator)
+
+        # Initialize a binding for dark theme
+        Gtk.Settings.get_default().bind_property(
+            'gtk-application-prefer-dark-theme',
+            self.builder.get_object('radio_theme_dark'),
+            'active',
+            GObject.BindingFlags.BIDIRECTIONAL | GObject.BindingFlags.SYNC_CREATE,
+        )
 
         from .gtkui import DEFAULT_PREFS
 
@@ -554,6 +562,9 @@ class Preferences(component.Component):
         self.builder.get_object('radio_thinclient').set_active(
             not self.gtkui_config['standalone']
         )
+        self.builder.get_object('radio_theme_dark').set_active(
+            self.gtkui_config['dark_theme']
+        )
         self.builder.get_object('chk_show_rate_in_title').set_active(
             self.gtkui_config['show_rate_in_title']
         )
@@ -738,6 +749,9 @@ class Preferences(component.Component):
         ).get_active()
 
         # Interface tab #
+        new_gtkui_config['dark_theme'] = self.builder.get_object(
+            'radio_theme_dark'
+        ).get_active()
         new_gtkui_config['enable_system_tray'] = self.builder.get_object(
             'chk_use_tray'
         ).get_active()
@@ -1071,6 +1085,10 @@ class Preferences(component.Component):
 
     def on_button_cancel_clicked(self, data):
         log.debug('on_button_cancel_clicked')
+        Gtk.Settings.get_default().set_property(
+            'gtk-application-prefer-dark-theme',
+            self.gtkui_config['dark_theme'],
+        )
         self.hide()
         return True
 

--- a/deluge/ui/web/js/deluge-all/preferences/InterfacePage.js
+++ b/deluge/ui/web/js/deluge-all/preferences/InterfacePage.js
@@ -88,6 +88,33 @@ Deluge.preferences.Interface = Ext.extend(Ext.form.FormPanel, {
             })
         );
 
+        var themePanel = this.add({
+            xtype: 'fieldset',
+            border: false,
+            title: _('Theme'),
+            style: 'margin-bottom: 0px; padding-bottom: 5px; padding-top: 5px',
+            autoHeight: true,
+            labelWidth: 1,
+            defaultType: 'checkbox',
+        });
+        this.theme = om.bind(
+            'theme',
+            themePanel.add({
+                xtype: 'combo',
+                name: 'theme',
+                labelSeparator: '',
+                mode: 'local',
+                width: 200,
+                store: new Ext.data.ArrayStore({
+                    fields: ['id', 'text'],
+                }),
+                editable: false,
+                triggerAction: 'all',
+                valueField: 'id',
+                displayField: 'text',
+            })
+        );
+
         fieldset = this.add({
             xtype: 'fieldset',
             border: false,
@@ -217,6 +244,24 @@ Deluge.preferences.Interface = Ext.extend(Ext.form.FormPanel, {
                     icon: Ext.MessageBox.QUESTION,
                 });
             }
+            if ('theme' in changed) {
+                deluge.client.web.set_theme(changed['theme']);
+                Ext.Msg.show({
+                    title: _('WebUI Theme Changed'),
+                    msg: _(
+                        'Do you want to refresh the page now to use the new theme?'
+                    ),
+                    buttons: {
+                        yes: _('Refresh'),
+                        no: _('Close'),
+                    },
+                    multiline: false,
+                    fn: function (btnText) {
+                        if (btnText === 'yes') location.reload();
+                    },
+                    icon: Ext.MessageBox.QUESTION,
+                });
+            }
         }
         if (this.oldPassword.getValue() || this.newPassword.getValue()) {
             this.onPasswordChange();
@@ -235,6 +280,11 @@ Deluge.preferences.Interface = Ext.extend(Ext.form.FormPanel, {
         info.unshift(['', _('System Default')]);
         this.language.store.loadData(info);
         this.language.setValue(this.optionsManager.get('language'));
+    },
+
+    onGotThemes: function (info, obj, response, request) {
+        this.theme.store.loadData(info);
+        this.theme.setValue(this.optionsManager.get('theme'));
     },
 
     onPasswordChange: function () {
@@ -293,6 +343,10 @@ Deluge.preferences.Interface = Ext.extend(Ext.form.FormPanel, {
         });
         deluge.client.webutils.get_languages({
             success: this.onGotLanguages,
+            scope: this,
+        });
+        deluge.client.webutils.get_themes({
+            success: this.onGotThemes,
             scope: this,
         });
     },

--- a/deluge/ui/web/json_api.py
+++ b/deluge/ui/web/json_api.py
@@ -979,6 +979,16 @@ class WebApi(JSONComponent):
         """
         return self.event_queue.get_events(__request__.session_id)
 
+    @export
+    def set_theme(self, theme):
+        """
+        Sets a new Theme to the WebUI
+
+        Args:
+            theme (str): the theme to apply
+        """
+        component.get('DelugeWeb').set_theme(theme)
+
 
 class WebUtils(JSONComponent):
     """
@@ -997,3 +1007,13 @@ class WebUtils(JSONComponent):
              list: of tuples ``[(lang-id, language-name), ...]``
         """
         return get_languages()
+
+    @export
+    def get_themes(self):
+        """
+        Get the available themes
+
+        Returns:
+            list: of themes ``[theme1, theme2, ...]``
+        """
+        return component.get('DelugeWeb').get_themes_list()


### PR DESCRIPTION
Currently, there is no normal way to change the theme for both UIs (Gtk and Web).
In WebUI, the only way to change the themes is by manually set a value
in the `web.conf` file itself.
In Gtk, the only way to change the themes is by manually set a value
in the command line or set it as env variable.

Closes: https://dev.deluge-torrent.org/ticket/3536