### PR TITLE
[Label] fix torrent deletion not removes from config

### DIFF
--- a/deluge/plugins/Label/deluge_label/core.py
+++ b/deluge/plugins/Label/deluge_label/core.py
@@ -137,6 +137,7 @@ class Core(CorePluginBase):
         log.debug('post_torrent_remove')
         if torrent_id in self.torrent_labels:
             del self.torrent_labels[torrent_id]
+            self.config.save()
 
     # Utils #
     def clean_config(self):
@@ -191,8 +192,7 @@ class Core(CorePluginBase):
         """remove a label"""
         check_input(label_id in self.labels, _('Unknown Label'))
         del self.labels[label_id]
-        self.clean_config()
-        self.config.save()
+        self.save_config()
 
     def _set_torrent_options(self, torrent_id, label_id):
         options = self.labels[label_id]


### PR DESCRIPTION
when deleting a torrent, the on deletion hook deletes the torrent from
the local config but does not save the new config to disk.
note that when setting a new label to a torrent, the config does save.

closes: https://dev.deluge-torrent.org/ticket/3545