### PR TITLE
[GTK3UI] Fix too low upper limit of upload/download in add torrent dialog

### DIFF
--- a/deluge/ui/gtk3/glade/add_torrent_dialog.ui
+++ b/deluge/ui/gtk3/glade/add_torrent_dialog.ui
@@ -4,13 +4,13 @@
   <requires lib="gtk+" version="3.0"/>
   <object class="GtkAdjustment" id="adjustment1">
     <property name="lower">-1</property>
-    <property name="upper">9999</property>
+    <property name="upper">2097151</property>
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment2">
     <property name="lower">-1</property>
-    <property name="upper">9999</property>
+    <property name="upper">2097151</property>
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
   </object>


### PR DESCRIPTION
The original upper limit of those settings is set to 9999 (KiB/s). Changed to match the ones in setting dialog (i.e. 2097151).