### PR TITLE
[3566][WebUI] Fix `TypeError` in DelugeWeb constractor

### DIFF
--- a/deluge/ui/web/server.py
+++ b/deluge/ui/web/server.py
@@ -682,7 +682,9 @@ class DelugeWeb(component.Component):
 
         if self.base != '/':
             # Strip away slashes and serve on the base path as well as root path
-            self.top_level.putChild(self.base.strip('/'), self.top_level)
+            self.top_level.putChild(
+                self.base.strip('/').encode('utf-8'), self.top_level
+            )
 
         setup_translation()
 


### PR DESCRIPTION
In `twisted 22.10`, a check new for passing the `path` variable as `bytes` in the `putChild` method.
We were enforcing this on every other place but the `__init__` of `DelugeWeb` itself.

Ref: https://github.com/twisted/twisted/pull/11718
Closes: https://dev.deluge-torrent.org/ticket/3566