### PR TITLE
Import setuptools before distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,13 +12,13 @@ import glob
 import os
 import platform
 import sys
-from distutils.command.build import build as _build
-from distutils.command.clean import clean as _clean
-from distutils.command.install_data import install_data as _install_data
 from shutil import rmtree, which
 
 from setuptools import Command, find_packages, setup
 from setuptools.command.test import test as _test
+from distutils.command.build import build as _build
+from distutils.command.clean import clean as _clean
+from distutils.command.install_data import install_data as _install_data
 
 import msgfmt
 from version import get_version


### PR DESCRIPTION
setuptools 60 uses its own bundled version of distutils, by default. It injects this into sys.modules, at import time. So we need to make sure that it is imported, before anything else imports distutils, to ensure everything is using the same distutils version.

This change in setuptools is to prepare for Python 3.12, which will drop distutils.

Fixes: https://bugs.debian.org/1022491