### PR TITLE
Fixing alignment issues with the FilesTab progress bar

### DIFF
--- a/deluge/ui/web/css/deluge.css
+++ b/deluge/ui/web/css/deluge.css
@@ -283,7 +283,7 @@ dl.singleline dd {
 }
 
 .x-progress-renderered .x-progress-bar .x-progress-text {
-    margin-top: -1px;
+    margin-top: -2px;
     height: 18px;
 }
 

--- a/deluge/ui/web/js/deluge-all/details/FilesTab.js
+++ b/deluge/ui/web/js/deluge-all/details/FilesTab.js
@@ -41,7 +41,7 @@ Deluge.details.FilesTab = Ext.extend(Ext.ux.tree.TreeGrid, {
                     progress,
                     this.col.width,
                     progress.toFixed(2) + '%',
-                    0
+                    10
                 );
             },
         },


### PR DESCRIPTION
# What
Two issues:
- Height offset for the white overlayed text was slightly off, causing the background darker text to be slightly visible when replaced with the foreground white text: <img width="781" src="https://user-images.githubusercontent.com/12701930/204930785-c7a52d0d-d64d-4237-a3ef-a7b45c8c2a16.png">

- Progress offset caused the white foreground text to be 10 pixels ahead in progress, meaning the replacement text wasn't aligned with the background progress bar: <img width="781" src="https://user-images.githubusercontent.com/12701930/204930790-9b09951b-91eb-4eb7-af64-7439463a7034.png">

## Now
<img width="781" src="https://user-images.githubusercontent.com/12701930/204930129-105d69f8-4fc4-43c8-b09e-f8313be4b417.png">
<img width="781" src="https://user-images.githubusercontent.com/12701930/204930128-828054fe-5e4c-4005-84d6-3283fbddf1a3.png">
<img width="781" src="https://user-images.githubusercontent.com/12701930/204930124-029ba40a-e326-4f9b-9d82-438565aaece7.png">
<img width="781" src="https://user-images.githubusercontent.com/12701930/204930121-d3ba0257-a28d-4677-882f-4b21e7e9ece0.png">
<img width="781" src="https://user-images.githubusercontent.com/12701930/204930118-61977f0d-07eb-40fc-b596-a2daaad36271.png">
<img width="781" src="https://user-images.githubusercontent.com/12701930/204930115-d3aea5b5-6048-4128-b982-05a8ae04fe8d.png">
<img width="781" src="https://user-images.githubusercontent.com/12701930/204930110-ff2d3fa7-56fb-4391-9169-0af7e18aeced.png">