### PR TITLE
[3581][Core] Stop using libtorrent.add_torrent_params_flags_t

### DIFF
--- a/deluge/core/torrentmanager.py
+++ b/deluge/core/torrentmanager.py
@@ -50,10 +50,10 @@ from deluge.event import (
 log = logging.getLogger(__name__)
 
 LT_DEFAULT_ADD_TORRENT_FLAGS = (
-    lt.add_torrent_params_flags_t.flag_paused
-    | lt.add_torrent_params_flags_t.flag_auto_managed
-    | lt.add_torrent_params_flags_t.flag_update_subscribe
-    | lt.add_torrent_params_flags_t.flag_apply_ip_filter
+    lt.torrent_flags.paused
+    | lt.torrent_flags.auto_managed
+    | lt.torrent_flags.update_subscribe
+    | lt.torrent_flags.apply_ip_filter
 )
 
 
@@ -369,11 +369,11 @@ class TorrentManager(component.Component):
         add_torrent_params.flags = (
             (
                 LT_DEFAULT_ADD_TORRENT_FLAGS
-                | lt.add_torrent_params_flags_t.flag_duplicate_is_error
-                | lt.add_torrent_params_flags_t.flag_upload_mode
+                | lt.torrent_flags.duplicate_is_error
+                | lt.torrent_flags.upload_mode
             )
-            ^ lt.add_torrent_params_flags_t.flag_auto_managed
-            ^ lt.add_torrent_params_flags_t.flag_paused
+            ^ lt.torrent_flags.auto_managed
+            ^ lt.torrent_flags.paused
         )
 
         torrent_handle = self.session.add_torrent(add_torrent_params)
@@ -481,16 +481,12 @@ class TorrentManager(component.Component):
 
         # Set flags: enable duplicate_is_error & override_resume_data, disable auto_managed.
         add_torrent_params['flags'] = (
-            LT_DEFAULT_ADD_TORRENT_FLAGS
-            | lt.add_torrent_params_flags_t.flag_duplicate_is_error
-            | lt.add_torrent_params_flags_t.flag_override_resume_data
-        ) ^ lt.add_torrent_params_flags_t.flag_auto_managed
+            LT_DEFAULT_ADD_TORRENT_FLAGS | lt.torrent_flags.duplicate_is_error
+        ) ^ lt.torrent_flags.auto_managed
         if options['seed_mode']:
-            add_torrent_params['flags'] |= lt.add_torrent_params_flags_t.flag_seed_mode
+            add_torrent_params['flags'] |= lt.torrent_flags.seed_mode
         if options['super_seeding']:
-            add_torrent_params[
-                'flags'
-            ] |= lt.add_torrent_params_flags_t.flag_super_seeding
+            add_torrent_params['flags'] |= lt.torrent_flags.super_seeding
 
         return torrent_id, add_torrent_params
 

--- a/deluge/tests/test_core.py
+++ b/deluge/tests/test_core.py
@@ -116,9 +116,9 @@ class TestCore(BaseTestCase):
             self.patch(
                 deluge.core.torrentmanager,
                 'LT_DEFAULT_ADD_TORRENT_FLAGS',
-                lt.add_torrent_params_flags_t.flag_auto_managed
-                | lt.add_torrent_params_flags_t.flag_update_subscribe
-                | lt.add_torrent_params_flags_t.flag_apply_ip_filter,
+                lt.torrent_flags.auto_managed
+                | lt.torrent_flags.update_subscribe
+                | lt.torrent_flags.apply_ip_filter,
             )
         options = {'add_paused': paused, 'auto_managed': False}
         filepath = common.get_test_data_file(filename)

--- a/deluge/tests/test_torrent.py
+++ b/deluge/tests/test_torrent.py
@@ -74,9 +74,8 @@ class TestTorrent(BaseTestCase):
             'save_path': os.getcwd(),
             'storage_mode': lt.storage_mode_t.storage_mode_sparse,
             'flags': (
-                lt.add_torrent_params_flags_t.flag_auto_managed
-                | lt.add_torrent_params_flags_t.flag_duplicate_is_error
-                & ~lt.add_torrent_params_flags_t.flag_paused
+                lt.torrent_flags.auto_managed
+                | lt.torrent_flags.duplicate_is_error & ~lt.torrent_flags.paused
             ),
         }
         return atp


### PR DESCRIPTION
The `libtorrent.add_torrent_params_flags_t` is deprecated and when
`libtorrent` is being compiled without deprecated functionality, we will
fail on `AttributeError`.

Closes: https://dev.deluge-torrent.org/ticket/3581