### PR TITLE
[ConsoleUI] remove `deferred` being returned after command

### DIFF
--- a/deluge/ui/console/__init__.py
+++ b/deluge/ui/console/__init__.py
@@ -12,5 +12,4 @@ UI_PATH = __path__[0]
 
 
 def start():
-
-    return Console().start()
+    Console().start()


### PR DESCRIPTION
A `return` statement was added in ece31cf, so it is now being removed.

Closes: https://dev.deluge-torrent.org/ticket/3582