### PR TITLE
[tox] update tox.ini for support for `tox` 4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -56,7 +56,7 @@ deps =
 
 [testenv]
 install_command = python -m pip install --ignore-installed {opts} {packages}
-passenv = DISPLAY PYTHONPATH APPDATA
+passenv = DISPLAY,PYTHONPATH,APPDATA
 setenv =
     PYTHONPATH = {toxinidir}
     PYTEST_ADDOPTS = --verbose --capture=no
@@ -101,7 +101,7 @@ commands =
 
 [testenv:lint]
 sitepackages = False
-passenv = HOMEPATH SSH_AUTH_SOCK
+passenv = HOMEPATH,SSH_AUTH_SOCK
 deps = {[baselint]deps}
 commands = pre-commit run --all-files
 


### PR DESCRIPTION
`tox` 4 now demands that `passenv` parameter will be comma-separated and not space-seperated.

