### PR TITLE
[Label Plugin] Fix label display name in submenu

### DIFF
--- a/deluge/plugins/Label/deluge_label/gtkui/submenu.py
+++ b/deluge/plugins/Label/deluge_label/gtkui/submenu.py
@@ -51,7 +51,7 @@ class LabelMenu(MenuItem):
             if label == NO_LABEL:
                 item = MenuItem(_(NO_LABEL))  # noqa: F821
             else:
-                item = MenuItem(label.replace('_', '__'))
+                item = MenuItem(label)
             item.connect('activate', self.on_select_label, label)
             self.sub_menu.append(item)
         self.show_all()


### PR DESCRIPTION
Previously every '_' in label's name was incorrectly replaced by '__'