### PR TITLE
[AutoAdd] Fixes #3515 - check for more torrent decode errors

### DIFF
--- a/deluge/plugins/AutoAdd/deluge_autoadd/core.py
+++ b/deluge/plugins/AutoAdd/deluge_autoadd/core.py
@@ -271,7 +271,7 @@ class Core(CorePluginBase):
 
             try:
                 filedump = self.load_torrent(filepath, magnet)
-            except (OSError, EOFError, InvalidTorrentError) as ex:
+            except (OSError, EOFError, RuntimeError, InvalidTorrentError) as ex:
                 # If torrent is invalid, keep track of it so can try again on the next pass.
                 # This catches torrent files that may not be fully saved to disk at load time.
                 log.debug('Torrent is invalid: %s', ex)


### PR DESCRIPTION
https://github.com/deluge-torrent/deluge/pull/381 improved the situation with possible errors during torrent decoding. However, the log message in https://dev.deluge-torrent.org/ticket/3515 indicates a RuntimeError:

```
Traceback: <class 'RuntimeError'>: unexpected end of file in bencoded string
```

This commit adds RuntimeError to those caught while loading the torrent to add.