### PR TITLE
[WebUI] Sidebar: fix error for lazy init

### DIFF
--- a/deluge/ui/web/js/deluge-all/Sidebar.js
+++ b/deluge/ui/web/js/deluge-all/Sidebar.js
@@ -60,14 +60,16 @@ Deluge.Sidebar = Ext.extend(Ext.Panel, {
         this.doLayout();
         this.panels[filter] = panel;
 
-        panel.header.on('click', function (header) {
-            if (!deluge.config.sidebar_multiple_filters) {
-                deluge.ui.update();
-            }
-            if (!panel.list.getSelectionCount()) {
-                panel.list.select(0);
-            }
-        });
+        if (panel.header) {
+            panel.header.on('click', function (header) {
+                if (!deluge.config.sidebar_multiple_filters) {
+                    deluge.ui.update();
+                }
+                if (!panel.list.getSelectionCount()) {
+                    panel.list.select(0);
+                }
+            });
+        }
         this.fireEvent('filtercreate', this, panel);
 
         panel.updateStates(states);


### PR DESCRIPTION
When sidebar is hidden at WebUI startup, header isn't created yet.