### PR TITLE
[WebUI] request always in utf8

### DIFF
--- a/deluge/ui/web/json_api.py
+++ b/deluge/ui/web/json_api.py
@@ -134,7 +134,7 @@ class JSON(resource.Resource, component.Component):
         procedure calls and the request id.
         """
         try:
-            request_data = json.loads(request.json.decode())
+            request_data = json.loads(request.json.decode("UTF-8"))
         except (ValueError, TypeError):
             raise JSONException('JSON not decodable')
 


### PR DESCRIPTION
assume request from browser is in UTF-8 regardless of whatever encoding env set for running server python