### PR TITLE
[GTKUI] Add torrent dialog incorrectly removes dir

### DIFF
--- a/deluge/tests/data/dir_with_single_file.torrent
+++ b/deluge/tests/data/dir_with_single_file.torrent
@@ -1,0 +1,1 @@
+d10:created by13:mktorrent 1.113:creation datei1684991433e4:infod5:filesld6:lengthi9e4:pathl15:single_file.txteee4:name20:dir_with_single_file12:piece lengthi262144e6:pieces20:üÿWÑi,=35ŒYñÂhÌee

--- a/deluge/tests/test_ui_common.py
+++ b/deluge/tests/test_ui_common.py
@@ -157,3 +157,19 @@ class TestUICommon:
         ]
 
         assert len(ti.files) == len(result_files)
+
+    def test_directory_with_single_file(self):
+        filename = common.get_test_data_file('dir_with_single_file.torrent')
+
+        ti = TorrentInfo(filename)
+        expected_file_tree = {'dir_with_single_file': {'single_file.txt': (0, 9, True)}}
+        assert ti.files_tree == expected_file_tree
+
+        result_files = [
+            {
+                'path': 'dir_with_single_file/single_file.txt',
+                'size': 9,
+                'download': True,
+            }
+        ]
+        assert ti.files == result_files

--- a/deluge/ui/common.py
+++ b/deluge/ui/common.py
@@ -216,7 +216,7 @@ class TorrentInfo:
         if 'files' in info_dict:
             paths = {}
             dirs = {}
-            prefix = self._name if len(info_dict['files']) > 1 else ''
+            prefix = self._name
 
             for index, f in enumerate(info_dict['files']):
                 f = {k.decode(): v for k, v in f.items()}


### PR DESCRIPTION
When adding a torrent in the add torrents dialog, containing only a single directory with a single file inside, the directory is not included as a prefix to the filename.
The prefix is added only if there are multiple files inside the directory.

Fix by adding the prefix also when there is only one file inside a dir.

Closes: https://dev.deluge-torrent.org/ticket/3602