### PR TITLE
[Core] Fix bug when emiting event in EventManager

### DIFF
--- a/deluge/core/rpcserver.py
+++ b/deluge/core/rpcserver.py
@@ -546,7 +546,9 @@ class RPCServer(component.Component):
         """
         log.debug('intevents: %s', self.factory.interested_events)
         # Find sessions interested in this event
-        for session_id, interest in self.factory.interested_events.items():
+        # The interested_events dict can change while iterating,
+        # therefore we need to iterate over a copy
+        for session_id, interest in self.factory.interested_events.copy().items():
             if event.name in interest:
                 log.debug('Emit Event: %s %s', event.name, event.args)
                 # This session is interested so send a RPC_EVENT


### PR DESCRIPTION
In some cases, when emiting events with EventManager.emit_event(), the underlying dictionary of interested sessions can change during iteration, causing: RuntimeError: dictionary changed size during iteration

Fix by iterating over a copy of the dictionary.

Closes: https://dev.deluge-torrent.org/ticket/3351