### PR TITLE
Update deluge-win-installer.nsi

### DIFF
--- a/packaging/win/deluge-win-installer.nsi
+++ b/packaging/win/deluge-win-installer.nsi
@@ -203,8 +203,8 @@ Section Uninstall
     !insertmacro MUI_STARTMENU_GETFOLDER Application $StartMenuFolder
         SetShellVarContext all
         Delete "$SMPROGRAMS\$StartMenuFolder\Deluge.lnk"
+        Delete "$SMPROGRAMS\$StartMenuFolder\Website.lnk"
         Delete "$SMPROGRAMS\$StartMenuFolder\Uninstall Deluge.lnk"
-        Delete "$SMPROGRAMS\$StartMenuFolder\Deluge Website.lnk"
         RmDir "$SMPROGRAMS\$StartMenuFolder"
         DeleteRegKey /ifempty HKCR "Software\Deluge"
 


### PR DESCRIPTION
CreateShortCut "$SMPROGRAMS\$StartMenuFolder\Website.lnk" "$INSTDIR\homepage.url" gets made in the installer but the uninstaller was looking for "Deluge Website.lnk" theres for this file was being left behinde and since the folder was not empty $StartMenuFolder\Deluge was being left behinde as well.