### PR TITLE
[UI][Common] Add daemon version check

### DIFF
--- a/deluge/tests/test_client.py
+++ b/deluge/tests/test_client.py
@@ -8,7 +8,7 @@ import pytest_twisted
 from twisted.internet import defer
 
 from deluge import error
-from deluge.common import AUTH_LEVEL_NORMAL, get_localhost_auth
+from deluge.common import AUTH_LEVEL_NORMAL, get_localhost_auth, get_version
 from deluge.core.authmanager import AUTH_LEVEL_ADMIN
 from deluge.ui.client import Client, DaemonSSLProxy, client
 
@@ -170,3 +170,23 @@ class TestClient:
 
         d.addCallbacks(self.fail, on_failure)
         return d
+
+    @pytest_twisted.inlineCallbacks
+    def test_daemon_version(self):
+        username, password = get_localhost_auth()
+        yield client.connect(
+            'localhost', self.listen_port, username=username, password=password
+        )
+
+        assert client.daemon_version == get_version()
+
+    @pytest_twisted.inlineCallbacks
+    def test_is_daemon_compatible(self):
+        username, password = get_localhost_auth()
+        yield client.connect(
+            'localhost', self.listen_port, username=username, password=password
+        )
+
+        assert client.is_daemon_compatible(get_version())
+        assert not client.is_daemon_compatible(f'{get_version()}1')
+        assert client.is_daemon_compatible('0.1.0')


### PR DESCRIPTION
For new UI features to be added, one should make sure the backend daemon is supported and add fallback in case it doesn't.
Here we add the ability to get the daemon version from the `Client` class and also check the version against a desired version.