### PR TITLE
Fix tweaking logging levels

### DIFF
--- a/deluge/log.py
+++ b/deluge/log.py
@@ -156,8 +156,6 @@ def setup_logger(
     else:
         handler = logging.StreamHandler(stream=output_stream)
 
-    handler.setLevel(level)
-
     formatter = logging.Formatter(
         DEFAULT_LOGGING_FORMAT % MAX_LOGGER_NAME_LENGTH, datefmt='%H:%M:%S'
     )


### PR DESCRIPTION
When you set a config directory path (-c) on the command line, and only when, a file named logging.conf is read to set fine grained log levels. This allows to have per module/plugin log levels.

A simple logging.conf could be:
```
deluge:info
deluge.plugin.foo:debug
```

The file is parsed and the log levels are set in the deluge.log.tweak_logging_levels. This function set the appropriate logger to the desired level. Despite the log level is changed, log levels less than ERROR are still not logged.

The reason is that the log level check is done twice, in the logging.Logger class and in the logging.Handler class.

The fix is to not set the logging level in the Handler in deluge.log.setup_logger and let only the logging.Logger check the level.