### PR TITLE
[Core] implement synchronous and v2 metafile creation

### DIFF
--- a/deluge/core/core.py
+++ b/deluge/core/core.py
@@ -21,7 +21,7 @@ from twisted.web.client import Agent, readBody
 
 import deluge.common
 import deluge.component as component
-from deluge import path_chooser_common
+from deluge import metafile, path_chooser_common
 from deluge._libtorrent import LT_VERSION, lt
 from deluge.configmanager import ConfigManager, get_config_dir
 from deluge.core.alertmanager import AlertManager
@@ -998,7 +998,11 @@ class Core(component.Component):
         created_by=None,
         trackers=None,
         add_to_session=False,
+        torrent_format=metafile.TorrentFormat.V1,
     ):
+        if isinstance(torrent_format, str):
+            torrent_format = metafile.TorrentFormat(torrent_format)
+
         log.debug('creating torrent..')
         return threads.deferToThread(
             self._create_torrent_thread,
@@ -1012,6 +1016,7 @@ class Core(component.Component):
             created_by=created_by,
             trackers=trackers,
             add_to_session=add_to_session,
+            torrent_format=torrent_format,
         )
 
     def _create_torrent_thread(
@@ -1026,6 +1031,7 @@ class Core(component.Component):
         created_by,
         trackers,
         add_to_session,
+        torrent_format,
     ):
         from deluge import metafile
 
@@ -1038,6 +1044,7 @@ class Core(component.Component):
             private=private,
             created_by=created_by,
             trackers=trackers,
+            torrent_format=torrent_format,
         )
 
         write_file = False

--- a/deluge/metafile.py
+++ b/deluge/metafile.py
@@ -51,7 +51,7 @@ class RemoteFileProgress:
         )
 
 
-def make_meta_file(
+def make_meta_file_content(
     path,
     url,
     piece_length,
@@ -60,7 +60,6 @@ def make_meta_file(
     comment=None,
     safe=None,
     content_type=None,
-    target=None,
     webseeds=None,
     name=None,
     private=False,
@@ -70,14 +69,6 @@ def make_meta_file(
     data = {'creation date': int(gmtime())}
     if url:
         data['announce'] = url.strip()
-    a, b = os.path.split(path)
-    if not target:
-        if b == '':
-            f = a + '.torrent'
-        else:
-            f = os.path.join(a, b + '.torrent')
-    else:
-        f = target
 
     if progress is None:
         progress = dummy
@@ -121,8 +112,55 @@ def make_meta_file(
         data['announce-list'] = trackers
 
     data['encoding'] = 'UTF-8'
-    with open(f, 'wb') as file_:
-        file_.write(bencode(utf8_encode_structure(data)))
+    return bencode(utf8_encode_structure(data))
+
+
+def default_meta_file_path(content_path):
+    a, b = os.path.split(content_path)
+    if b == '':
+        f = a + '.torrent'
+    else:
+        f = os.path.join(a, b + '.torrent')
+    return f
+
+
+def make_meta_file(
+    path,
+    url,
+    piece_length,
+    progress=None,
+    title=None,
+    comment=None,
+    safe=None,
+    content_type=None,
+    target=None,
+    webseeds=None,
+    name=None,
+    private=False,
+    created_by=None,
+    trackers=None,
+):
+    if not target:
+        target = default_meta_file_path(path)
+
+    file_content = make_meta_file_content(
+        path,
+        url,
+        piece_length,
+        progress=progress,
+        title=title,
+        comment=comment,
+        safe=safe,
+        content_type=content_type,
+        webseeds=webseeds,
+        name=name,
+        private=private,
+        created_by=created_by,
+        trackers=trackers,
+    )
+
+    with open(target, 'wb') as file_:
+        file_.write(file_content)
 
 
 def calcsize(path):


### PR DESCRIPTION
Assuming an entity which has access to deluge daemons on multiple storage servers, 
this will allow to generate a torrent file on a source server, followed by triggering
the transfer from multiple source locations towards the destination storage server.

In particular, I'm interested to add support for deluge/bittorent as a wire transfer protocol in [rucio](https://github.com/rucio/rucio)

The individual commit messages contain additional information about the changes.
