### PR TITLE
[GTKUI] Fix cairo crashes by not storing current context

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -62,8 +62,11 @@ jobs:
           python -m pip install --no-index --find-links="C:\GTK\release\python" pycairo PyGObject
 
       - name: Install Python dependencies
+        # Pillow no longer provides 32-bit wheels for Windows
+        # so specify only-binary to install old version.
         run: >
           python -m pip install
+          --only-binary=pillow
           twisted[tls]==22.4.0
           libtorrent==${{ matrix.libtorrent }}
           pyinstaller==4.10


### PR DESCRIPTION
Windows users have reported Deluge crashes when resizing the window with Piecesbar or Stats plugins enabled:

    Expression: CAIRO_REFERENCE_COUNT_HAS_REFERENCE(&surface->ref_count)

This is similar to issues fixed in GNU Radio which is a problem due to storing the current cairo context which is then being destroyed and recreated within GTK causing a reference count error

Fixes: https://dev.deluge-torrent.org/ticket/3339
Refs: https://github.com/gnuradio/gnuradio/pull/6352