### PR TITLE
[CI] Bump Pyinstaller version for Windows packaging

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -67,9 +67,9 @@ jobs:
         run: >
           python -m pip install
           --only-binary=pillow
-          twisted[tls]==22.4.0
+          twisted[tls]==22.8.0
           libtorrent==${{ matrix.libtorrent }}
-          pyinstaller==4.10
+          pyinstaller
           pygame
           -r requirements.txt
 


### PR DESCRIPTION
Pyinstaller was pinned due to problems with v5 but these should now be resolved with latest version.

Bump Twisted to latest minor version