### PR TITLE
[UI][Web] Respect the x-deulge-base header, to permit reverse proxy

### DIFF
--- a/deluge/ui/web/server.py
+++ b/deluge/ui/web/server.py
@@ -632,7 +632,8 @@ class TopLevel(resource.Resource):
         request.setHeader(b'content-type', b'text/html; charset=utf-8')
 
         web_config = component.get('Web').get_config()
-        web_config['base'] = request.base.decode()
+        header = request.getHeader('x-deluge-base')
+        web_config['base'] = header if header else request.base.decode()
         config = {key: web_config[key] for key in UI_CONFIG_KEYS}
         js_config = json.dumps(config)
         # Insert the values into 'index.html' and return.


### PR DESCRIPTION
This in enabled in nginx using similar to the following:
 location /deluge {
   proxy_set_header x-deluge-base deluge/;
   proxy_pass http://{deluge-host}:{deluge-port}/;
   proxy_ssl_session_reuse off;
   proxy_set_header Host ;
   proxy_cache_bypass ;
   proxy_redirect off;
 }
This is related to bug [#3105](https://dev.deluge-torrent.org/ticket/3105) and [#2677](https://dev.deluge-torrent.org/ticket/2677), but using a different solution to solve the reverse proxy problem.