### PR TITLE
Fix divide by 0 error

### DIFF
--- a/deluge/ui/web/json_api.py
+++ b/deluge/ui/web/json_api.py
@@ -600,7 +600,10 @@ class WebApi(JSONComponent):
 
                 progresses = dirinfo.setdefault('progresses', [])
                 progresses.append(torrent_file['size'] * torrent_file['progress'] / 100)
-                dirinfo['progress'] = sum(progresses) / dirinfo['size'] * 100
+                if dirinfo['size'] > 0:
+                    dirinfo['progress'] = sum(progresses) / dirinfo['size'] * 100
+                else:
+                    dirinfo['progress'] = 100
                 dirinfo['path'] = dirname
                 dirname = os.path.dirname(dirname)
 


### PR DESCRIPTION
If a dir exists with no contents then the following error occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/deluge/transfer.py", line 129, in _handle_complete_message
    self.message_received(
  File "/usr/lib/python3.10/site-packages/deluge/ui/client.py", line 133, in message_received
    d.callback(request[2])
  File "/usr/lib/python3.10/site-packages/twisted/internet/defer.py", line 662, in callback
    self._startRunCallbacks(result)
  File "/usr/lib/python3.10/site-packages/twisted/internet/defer.py", line 764, in _startRunCallbacks
    self._runCallbacks()
--- <exception caught here> ---
  File "/usr/lib/python3.10/site-packages/twisted/internet/defer.py", line 858, in _runCallbacks
    current.result = callback(  # type: ignore[misc]
  File "/usr/lib/python3.10/site-packages/deluge/ui/web/json_api.py", line 608, in _on_got_files
    dirinfo['progress'] = sum(progresses) / dirinfo['size'] * 100
builtins.ZeroDivisionError: float division by zero