### PR TITLE
Fix the icon to fit within the row in the main window tracker column.

### DIFF
--- a/deluge/ui/web/js/deluge-all/TorrentGrid.js
+++ b/deluge/ui/web/js/deluge-all/TorrentGrid.js
@@ -61,7 +61,7 @@
         return String.format(
             '<div style="background: url(' +
                 deluge.config.base +
-                'tracker/{0}) no-repeat; padding-left: 20px;">{0}</div>',
+                'tracker/{0}) no-repeat; background-size: contain; padding-left: 20px;">{0}</div>',
             Ext.util.Format.htmlEncode(value)
         );
     }


### PR DESCRIPTION
For me at least, Safari on Mac OS X, the tracker icon significantly overflows in the Tracker column of the torrent list.  (It does show the correct size in the Trackers filter, though.  Different CSS.)

This change causes it to constrain down to the height of the column and display correctly.