### PR TITLE
[Console] Improve interactive-mode preferences saving

### DIFF
--- a/deluge/ui/console/modes/preferences/preferences.py
+++ b/deluge/ui/console/modes/preferences/preferences.py
@@ -139,7 +139,13 @@ class Preferences(BaseMode, PopupsHandler):
         ]
 
         self.action_input = SelectInput(
-            self, None, None, [_('Cancel'), _('Apply'), _('OK')], [0, 1, 2], 0
+            self,
+            None,
+            None,
+            [_('Cancel'), _('Apply'), _('OK')],
+            [0, 1, 2],
+            0,
+            require_select_action=False,
         )
 
     def load_config(self):
@@ -308,16 +314,21 @@ class Preferences(BaseMode, PopupsHandler):
         if didupdate:
             self.parent_mode.on_config_changed()
 
-    def _update_preferences(self, core_config):
+    def _update_preferences(self, core_config, console_config=None):
         self.core_config = core_config
         for pane in self.panes:
-            pane.update_values(core_config)
+            if isinstance(pane, InterfacePane) and console_config:
+                pane.update_values(console_config)
+            else:
+                pane.update_values(core_config)
 
     def _actions_read(self, c):
         self.action_input.handle_read(c)
         if c in [curses.KEY_ENTER, util.KEY_ENTER2]:
             # take action
             if self.action_input.selected_index == 0:  # Cancel
+                # Reload stored config for panes
+                self._update_preferences(self.core_config, self.console_config)
                 self.back_to_parent()
             elif self.action_input.selected_index == 1:  # Apply
                 self._apply_prefs()


### PR DESCRIPTION
The bottom options for cancel/apply/ok where confusing for end-users as being checkboxes needing spacebar prepended to activate firstly, before return/enter to activate said previous selection, but changed now to omit. Also fixed not showing canceled options as sticking.