### PR TITLE
[3634][deps] prevent usage of twisted>=23 on Windows

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 libtorrent
-twisted[tls]>=17.1
+twisted[tls]>=17.1; sys_platform != 'win32'
+twisted[tls]<23,>=17.1; sys_platform == 'win32'
 rencode
 pyopenssl
 pyxdg

--- a/setup.py
+++ b/setup.py
@@ -538,7 +538,8 @@ _package_data['deluge.ui.gtk3'] = ['glade/*.ui']
 
 setup_requires = ['setuptools', 'wheel']
 install_requires = [
-    'twisted[tls]>=17.1',
+    "twisted[tls]>=17.1; sys_platform != 'win32'",
+    "twisted[tls]<23,>=17.1; sys_platform == 'win32'",
     # Add pyasn1 for setuptools workaround:
     #   https://github.com/pypa/setuptools/issues/1510
     'pyasn1',


### PR DESCRIPTION
with newer versions of twisted, a regression was added for the GTK reactor on Windows.
it effects all versions, including latest (currently 24.3.0).

So will prevent the upgrade on Windows only.

Closes: https://dev.deluge-torrent.org/ticket/3634

Ref: https://github.com/twisted/twisted/issues/11987 (thanks for reporting it @doadin)