### PR TITLE
[3635][WebUI] fix language change to system default

### DIFF
--- a/deluge/i18n/util.py
+++ b/deluge/i18n/util.py
@@ -66,6 +66,9 @@ def set_language(lang):
     :type lang: str
     """
     if not lang:
+        for lang_env_var in ['LANGUAGE', 'LANG']:
+            if lang_env_var in os.environ:
+                del os.environ[lang_env_var]
         return
 
     # Necessary to set these environment variables for GtkBuilder


### PR DESCRIPTION
When setting a language, we set 2 environment variables at run time. Setting the language back to `System Default`, we don't clean those env variables.
In the WebUI, the page only reloads, and we still use the env variables to set the language back to the previous one.
This does not affect GTK.

Closes: https://dev.deluge-torrent.org/ticket/3635