### PR TITLE
[UI] Add flags, bytes uploaded/downloaded, RTT to Peers tab on webui

### DIFF
--- a/deluge/core/torrent.py
+++ b/deluge/core/torrent.py
@@ -115,6 +115,64 @@ def convert_lt_files(files):
     return filelist
 
 
+def peer_flags(peer):
+    """Returns a string representing flags about a peer.
+
+    Peer flags:
+        see also https://web.archive.org/web/20141111072948/http://www.utorrent.com/help/faq/misc#faq13
+        and http://libtorrent.org/reference-Core.html#peer_info
+        - S - snubbed
+        - D - we are interested and remote isn't choking us
+        - d - we are interested and remote is choking us
+        - U - peer is interested and we are not choking them
+        - u - peer is interested and we are choking them
+        - E - payload is encrypted
+        - e - only headers are encrypted
+        - O - optimistic unchoke
+        - I - incoming connection (we did not initiate connection)
+        - g - in endgame mode
+        - h - holepunched
+        - H - peer was discovered by DHT
+        - X - peer was discovered by peer exchange
+        - T - peer was discovered by tracker
+
+    Args:
+        peer: the peer from which to build the flags string.
+    """
+
+    peerflags = str()
+    if peer.flags & peer.snubbed:
+        peerflags += "S"
+    if peer.flags & peer.interesting and not peer.flags & peer.remote_choked:
+        peerflags += "D"
+    if peer.flags & peer.interesting and peer.flags & peer.remote_choked:
+        peerflags += "d"
+    if peer.flags & peer.remote_interested and not peer.flags & peer.choked:
+        peerflags += "U"
+    if peer.flags & peer.remote_interested and peer.flags & peer.choked:
+        peerflags += "u"
+    if peer.flags & peer.rc4_encrypted:
+        peerflags += "E"
+    if peer.flags & peer.plaintext_encrypted:
+        peerflags += "e"
+    if peer.flags & peer.optimistic_unchoke:
+        peerflags += "O"
+    if not peer.flags & peer.local_connection:
+        peerflags += "I"
+    if peer.flags & peer.endgame_mode:
+        peerflags += "g"
+    if peer.flags & peer.holepunched:
+        peerflags += "h"
+    if peer.source & peer.dht:
+        peerflags += "H"
+    if peer.source & peer.pex:
+        peerflags += "X"
+    if peer.source & peer.tracker:
+        peerflags += "T"
+
+    return peerflags
+
+
 class TorrentOptions(dict):
     """TorrentOptions create a dict of the torrent options.
 
@@ -860,6 +918,10 @@ class Torrent:
                     'progress': peer.progress,
                     'seed': peer.flags & peer.seed,
                     'up_speed': peer.payload_up_speed,
+                    "flags": peer_flags(peer),
+                    "total_download": peer.total_download,
+                    "total_upload": peer.total_upload,
+                    "rtt": peer.rtt,
                 }
             )
 

--- a/deluge/ui/web/js/deluge-all/data/PeerRecord.js
+++ b/deluge/ui/web/js/deluge-all/data/PeerRecord.js
@@ -47,7 +47,23 @@ Deluge.data.Peer = Ext.data.Record.create([
         type: 'int',
     },
     {
-        name: 'seed',
+        name: 'total_download',
         type: 'int',
     },
+    {
+        name: 'total_upload',
+        type: 'int',
+    },
+    {
+        name: 'flags',
+        type: 'string',
+    },
+    {
+        name: 'rtt',
+        type: 'int',
+    },
+    {
+        name: 'seed',
+        type: 'int',
+    }
 ]);

--- a/deluge/ui/web/js/deluge-all/details/PeersTab.js
+++ b/deluge/ui/web/js/deluge-all/details/PeersTab.js
@@ -35,6 +35,13 @@
         var progress = (value * 100).toFixed(0);
         return Deluge.progressBar(progress, this.width - 8, progress + '%');
     }
+    function millisecondRenderer(value) {
+        if ( value > 0 ) {
+            return String.format('{0}ms', value);
+        } else {
+            return "&nbsp;";
+        }
+    }
 
     Deluge.details.PeersTab = Ext.extend(Ext.grid.GridPanel, {
         // fast way to figure out if we have a peer already.
@@ -97,6 +104,34 @@
                             renderer: fspeed,
                             dataIndex: 'up_speed',
                         },
+                        {
+                            header: _('Downloaded'),
+                            width: 100,
+                            sortable: true,
+                            renderer: fsize,
+                            dataIndex: 'total_download',
+                        },
+                        {
+                            header: _('Uploaded'),
+                            width: 100,
+                            sortable: true,
+                            renderer: fsize,
+                            dataIndex: 'total_upload',
+                        },
+                        {
+                            header: _('Flags'),
+                            width: 70,
+                            sortable: false,
+                            renderer: fplain,
+                            dataIndex: 'flags',
+                        },
+                        {
+                            header: _('RTT'),
+                            width: 70,
+                            sortable: true,
+                            renderer: millisecondRenderer,
+                            dataIndex: 'rtt',
+                        }
                     ],
                     stripeRows: true,
                     deferredRender: false,


### PR DESCRIPTION
* add a flags string to each peer indicating the current state of the peer
* add the total bytes uploaded/downloaded by each peer
* add the estimated round-trip time to peers to which we connected