### PR TITLE
[WebUI]Fix Connection Manager stop daemon, return 5 elem from get_host_info()

### DIFF
--- a/deluge/ui/hostlist.py
+++ b/deluge/ui/hostlist.py
@@ -163,12 +163,12 @@ class HostList:
             host_id (str): The host id to get info on.
 
         Returns:
-            list: A list of (host_id, hostname, port, username).
+            list: A list of (host_id, hostname, port, username, password).
 
         """
         for host_entry in self.config['hosts']:
             if host_entry[0] == host_id:
-                return host_entry[0:4]
+                return host_entry[0:5]
         else:
             return []
 
@@ -212,7 +212,7 @@ class HostList:
             return status_offline
 
         try:
-            host_id, host, port, user = self.get_host_info(host_id)
+            host_id, host, port, user = self.get_host_info(host_id)[0:4]
         except ValueError:
             log.warning('Problem getting host_id info from hostlist')
             return defer.succeed(status_offline)


### PR DESCRIPTION
Attempting to stop the daemon from Connection Manager in the WebUI would throw an error "An error occurred". On deeper inspection this was because this line threw a ValueError expecting 4 items but only getting 3:

```python
host, port, user, password = host[1:5]
```

This fix updates the `get_host_info()` function to also return password.