### PR TITLE
[CI] Update actions to latest version (node 16 deprecation)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,20 +29,20 @@ jobs:
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       # Checkout Deluge source to subdir to enable packaging any tag/commit
       - name: Checkout Deluge source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.ref }}
           fetch-depth: 0
           path: deluge_src
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python}}
           architecture: ${{ matrix.arch }}
@@ -98,7 +98,7 @@ jobs:
           python setup_nsis.py
           makensis /Darch=${{ matrix.arch }} deluge-win-installer.nsi
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: deluge-py${{ matrix.python }}-lt${{ matrix.libtorrent }}-${{ matrix.arch }}
           path: packaging/win/*.exe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,12 @@ jobs:
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
@@ -63,7 +63,7 @@ jobs:
           python -c 'from deluge._libtorrent import lt; print(lt.__version__)';
           $DEBUG_PREFIX pytest -v -m "not (todo or gtkui)" deluge
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         # capture all crashes as build artifacts
         if: failure()
         with:
@@ -78,12 +78,12 @@ jobs:
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,11 +15,11 @@ jobs:
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
           cache: "pip"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
       - name: Run pre-commit linting
-        uses: pre-commit/action@v3.0.0
+        uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
node 16 versions are deprecated, so to solve this issue that would otherwise potentially cause future failures i have updated all of the actions to the latest

there seem to be no issues during the runs on my fork

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

you can see the deprecation warnings [here](https://github.com/deluge-torrent/deluge/actions/runs/7963495728)