### PR TITLE
[Packaging] deluge-console Windows workaround

### DIFF
--- a/packaging/win/delugewin.spec
+++ b/packaging/win/delugewin.spec
@@ -107,6 +107,8 @@ datas += copy_metadata('twisted', recursive=True)
 # Copy UI/Plugin and translation files to where pyinstaller expects
 package_data = collect_data_files('deluge')
 datas += package_data
+# Workaround for Console UI files not being included in package data
+datas += [('../../deluge/ui/console', 'deluge/ui/console')]
 
 icon = [src for src, dest in package_data if src.endswith('deluge.ico')][0]
 


### PR DESCRIPTION
Deluge-console broke on Windows after commit d559f67, which before that was working because it's source files getting included with rest UI/plugin data copied into place. This workaround here, copies back it's source files into place. 

The underlying workarounded issues here is two-fold. It's not that anything is missing from the freezing, but rather that there at runtime is generated subparsers for the commands, using path_[0] (UI_PATH var in init.py, joined in console.py with rest path), so looking for files/paths not there anymore, as freezed now, and second, the use of 'overrides' decorator which breaks in freezed env since in decorators.py trying use inspect.stack()[2][4][0], and in freezed env inspect.stack()[2][4] is None, and hence any mention of former breaks with 'NoneType object is not subscriptable'. In non-freezed, it returns the call-context correctly, as source code readily available here.