### PR TITLE
Accept network interface name in addition to IP address in "Incoming Address" in web UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Python 3.6 support removed (Python >= 3.7)
 
+### Web UI
+- Accept network interface name in addition to IP adress in "Incoming Address"
+
 ## 2.1.1 (2022-07-10)
 
 ### Core

--- a/deluge/ui/web/js/deluge-all/preferences/NetworkPage.js
+++ b/deluge/ui/web/js/deluge-all/preferences/NetworkPage.js
@@ -9,15 +9,6 @@
  */
 Ext.namespace('Deluge.preferences');
 
-// custom Vtype for vtype:'IPAddress'
-Ext.apply(Ext.form.VTypes, {
-    IPAddress: function (v) {
-        return /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(v);
-    },
-    IPAddressText: 'Must be a numeric IP address',
-    IPAddressMask: /[\d\.]/i,
-});
-
 /**
  * @class Deluge.preferences.Network
  * @extends Ext.form.FormPanel
@@ -35,7 +26,7 @@ Deluge.preferences.Network = Ext.extend(Ext.form.FormPanel, {
         fieldset = this.add({
             xtype: 'fieldset',
             border: false,
-            title: _('Incoming Address'),
+            title: _('Incoming Interface'),
             style: 'margin-bottom: 5px; padding-bottom: 0px;',
             autoHeight: true,
             labelWidth: 1,
@@ -48,7 +39,6 @@ Deluge.preferences.Network = Ext.extend(Ext.form.FormPanel, {
                 fieldLabel: '',
                 labelSeparator: '',
                 width: 200,
-                vtype: 'IPAddress',
             })
         );
 
@@ -110,7 +100,7 @@ Deluge.preferences.Network = Ext.extend(Ext.form.FormPanel, {
                 name: 'outgoing_interface',
                 fieldLabel: '',
                 labelSeparator: '',
-                width: 40,
+                width: 200,
             })
         );
 


### PR DESCRIPTION
Deluge & libtorrent actually accept both IP address and device/interface names as listen_interface:
https://github.com/deluge-torrent/deluge/commit/540d557cb2163c41af894ee252cc677d01887376
it patched ui/ console & gkt3, but not web, this fixes it.

(Inspired by https://github.com/deluge-torrent/deluge/pull/300)

(Translation should be ok: this string already exists)

Also, resync listen & outgoing widths: they hold the same data types.