### PR TITLE
Fix name of Ubuntu prerequisite

### DIFF
--- a/DEPENDS.md
+++ b/DEPENDS.md
@@ -95,6 +95,6 @@ All modules will require the [common](#common) section dependencies.
 [mako]: https://www.makotemplates.org/
 [pygame]: https://www.pygame.org/
 [libnotify]: https://developer.gnome.org/libnotify/
-[ayatanaappindicator3]: https://packages.ubuntu.com/jammy/gir1.2-ayatanaappindicator3-0.1
+[ayatanaappindicator3]: https://lazka.github.io/pgi-docs/AyatanaAppIndicator3-0.1/index.html
 [librsvg]: https://wiki.gnome.org/action/show/Projects/LibRsvg
 [ifaddr]: https://pypi.org/project/ifaddr/

--- a/DEPENDS.md
+++ b/DEPENDS.md
@@ -50,7 +50,7 @@ All modules will require the [common](#common) section dependencies.
 - [PyGObject]
 - [Pycairo]
 - [librsvg] _>= 2_
-- [libappindicator3] w/GIR - Optional: Ubuntu system tray icon.
+- [ayatanaappindicator3] w/GIR - Optional: Ubuntu system tray icon.
 
 ### MacOS
 
@@ -95,6 +95,6 @@ All modules will require the [common](#common) section dependencies.
 [mako]: https://www.makotemplates.org/
 [pygame]: https://www.pygame.org/
 [libnotify]: https://developer.gnome.org/libnotify/
-[python-appindicator]: https://packages.ubuntu.com/xenial/python-appindicator
+[ayatanaappindicator3]: https://packages.ubuntu.com/jammy/gir1.2-ayatanaappindicator3-0.1
 [librsvg]: https://wiki.gnome.org/action/show/Projects/LibRsvg
 [ifaddr]: https://pypi.org/project/ifaddr/

--- a/docs/source/devguide/tutorials/01-setup.md
+++ b/docs/source/devguide/tutorials/01-setup.md
@@ -24,7 +24,7 @@ You might need to add `~/.local/bin` to your PATH.
 #### Runtime libraries and tools
 
     sudo apt install python3-libtorrent python3-geoip python3-dbus  python3-gi \
-    python3-gi-cairo gir1.2-gtk-3.0 gir1.2-appindicator3-0.1 python3-pygame libnotify4 \
+    python3-gi-cairo gir1.2-gtk-3.0 gir1.2-ayatanaappindicator3-0.1 python3-pygame libnotify4 \
     librsvg2-common xdg-utils
 
 ## Setup development environment

--- a/docs/source/devguide/tutorials/01-setup.md
+++ b/docs/source/devguide/tutorials/01-setup.md
@@ -24,7 +24,7 @@ You might need to add `~/.local/bin` to your PATH.
 #### Runtime libraries and tools
 
     sudo apt install python3-libtorrent python3-geoip python3-dbus  python3-gi \
-    python3-gi-cairo gir1.2-gtk-3.0 gir1.2-appindicator3 python3-pygame libnotify4 \
+    python3-gi-cairo gir1.2-gtk-3.0 gir1.2-appindicator3-0.1 python3-pygame libnotify4 \
     librsvg2-common xdg-utils
 
 ## Setup development environment

--- a/docs/source/intro/01-install.md
+++ b/docs/source/intro/01-install.md
@@ -80,7 +80,7 @@ Will require system installed packages such as libtorent and GTK3. See [DEPENDS]
 
 e.g. on Ubuntu/Debian install these packages:
 
-    sudo apt install python3-pip python3-libtorrent python3-gi python3-gi-cairo gir1.2-gtk-3.0 gir1.2-appindicator3
+    sudo apt install python3-pip python3-libtorrent python3-gi python3-gi-cairo gir1.2-gtk-3.0 gir1.2-ayatanaappindicator3-0.1
 
 ## Alternative Installs
 


### PR DESCRIPTION
Change name to gir1.2-appindicator3-0.1.  Tested on Ubuntu 22.04.4 LTS and Ubuntu 20.04.6 LTS.