### PR TITLE
[UI][Common] Wrap torrent comment and tracker status URLs in HTML (clickable)

### DIFF
--- a/deluge/common.py
+++ b/deluge/common.py
@@ -720,6 +720,16 @@ def parse_human_size(size):
     raise InvalidSize(msg % (size, tokens))
 
 
+def anchorify_urls(text: str) -> str:
+    """
+    Wrap all occurrences of text URLs with HTML
+    """
+    url_pattern = r'((htt)|(ft)|(ud))ps?://\S+'
+    html_href_pattern = r'<a href="\g<0>">\g<0></a>'
+
+    return re.sub(url_pattern, html_href_pattern, text)
+
+
 def is_url(url):
     """
     A simple test to check if the URL is valid

--- a/deluge/ui/gtk3/details_tab.py
+++ b/deluge/ui/gtk3/details_tab.py
@@ -10,7 +10,7 @@ import logging
 from xml.sax.saxutils import escape as xml_escape
 
 import deluge.component as component
-from deluge.common import decode_bytes, fdate, fsize, is_url
+from deluge.common import anchorify_urls, decode_bytes, fdate, fsize
 
 from .tab_data_funcs import fdate_or_dash, fpieces_num_size
 from .torrentdetails import Tab
@@ -61,8 +61,8 @@ class DetailsTab(Tab):
         for widget in self.tab_widgets.values():
             txt = xml_escape(self.widget_status_as_fstr(widget, status))
             if decode_bytes(widget.obj.get_text()) != txt:
-                if 'comment' in widget.status_keys and is_url(txt):
-                    widget.obj.set_markup(f'<a href="{txt}">{txt}</a>')
+                if 'comment' in widget.status_keys:
+                    widget.obj.set_markup(anchorify_urls(txt))
                 else:
                     widget.obj.set_markup(txt)
 

--- a/deluge/ui/gtk3/trackers_tab.py
+++ b/deluge/ui/gtk3/trackers_tab.py
@@ -9,7 +9,7 @@
 import logging
 
 import deluge.component as component
-from deluge.common import ftime
+from deluge.common import anchorify_urls, ftime
 
 from .tab_data_funcs import fcount, ftranslate, fyes_no
 from .torrentdetails import Tab
@@ -54,7 +54,10 @@ class TrackersTab(Tab):
         for widget in self.tab_widgets.values():
             txt = self.widget_status_as_fstr(widget, status)
             if widget.obj.get_text() != txt:
-                widget.obj.set_text(txt)
+                if 'tracker_status' in widget.status_keys:
+                    widget.obj.set_markup(anchorify_urls(txt))
+                else:
+                    widget.obj.set_text(txt)
 
     def clear(self):
         for widget in self.tab_widgets.values():


### PR DESCRIPTION
This PR adds a function to common.py that uses a `re.sub` function to wrap supported URLs (taken from the is_url function) with HTML.

With this function, the torrent comments in `details_tab` and tracker status in `trackers_tab` will now display these URLs as clickable hyperlinks. 

This was previously only supported where the comment itself was only a URL. It will now support links within the comment. Also for tracker errors that give a link, in the case of removal and replacement for a new torrent on a tracker, the link reported in the status is now clickable too. 