### PR TITLE
console-ui: endwin() not needed when using wrapper

### DIFF
--- a/deluge/ui/console/modes/basemode.py
+++ b/deluge/ui/console/modes/basemode.py
@@ -236,7 +236,6 @@ class BaseMode(CursesStdIO, component.Component):
         curses.nocbreak()
         self.stdscr.keypad(0)
         curses.echo()
-        curses.endwin()
 
 
 def add_string(


### PR DESCRIPTION
Using it anyway produces a crash because it returns an error if called two times without any intervening updates.