### PR TITLE
Replace deprecated cgi module with email

### DIFF
--- a/deluge/httpdownloader.py
+++ b/deluge/httpdownloader.py
@@ -6,7 +6,7 @@
 # See LICENSE for more details.
 #
 
-import cgi
+import email.message
 import logging
 import os.path
 import zlib
@@ -133,7 +133,9 @@ class HTTPDownloaderAgent:
                 content_disp = headers.getRawHeaders(b'content-disposition')[0].decode(
                     'utf-8'
                 )
-                content_disp_params = cgi.parse_header(content_disp)[1]
+                message = email.message.Message()
+                message['content-type'] = content_disp
+                content_disp_params = dict(message.get_params()[1:])
                 if 'filename' in content_disp_params:
                     new_file_name = content_disp_params['filename']
                     new_file_name = sanitise_filename(new_file_name)
@@ -152,7 +154,11 @@ class HTTPDownloaderAgent:
                     self.filename = new_file_name
 
             cont_type_header = headers.getRawHeaders(b'content-type')[0].decode()
-            cont_type, params = cgi.parse_header(cont_type_header)
+            message = email.message.Message()
+            message['content-type'] = cont_type_header
+            message_params = message.get_params()
+            cont_type = message_params[0][0]
+            params = dict(message_params[1:])
             # Only re-ecode text content types.
             encoding = None
             if cont_type.startswith('text/'):

--- a/deluge/httpdownloader.py
+++ b/deluge/httpdownloader.py
@@ -133,11 +133,10 @@ class HTTPDownloaderAgent:
                 content_disp = headers.getRawHeaders(b'content-disposition')[0].decode(
                     'utf-8'
                 )
-                message = email.message.Message()
-                message['content-type'] = content_disp
-                content_disp_params = dict(message.get_params()[1:])
-                if 'filename' in content_disp_params:
-                    new_file_name = content_disp_params['filename']
+                message = email.message.EmailMessage()
+                message['content-disposition'] = content_disp
+                new_file_name = message.get_filename()
+                if new_file_name:
                     new_file_name = sanitise_filename(new_file_name)
                     new_file_name = os.path.join(
                         os.path.split(self.filename)[0], new_file_name
@@ -154,11 +153,10 @@ class HTTPDownloaderAgent:
                     self.filename = new_file_name
 
             cont_type_header = headers.getRawHeaders(b'content-type')[0].decode()
-            message = email.message.Message()
+            message = email.message.EmailMessage()
             message['content-type'] = cont_type_header
-            message_params = message.get_params()
-            cont_type = message_params[0][0]
-            params = dict(message_params[1:])
+            cont_type = message.get_content_type()
+            params = message['content-type'].params
             # Only re-ecode text content types.
             encoding = None
             if cont_type.startswith('text/'):

--- a/deluge/tests/test_httpdownloader.py
+++ b/deluge/tests/test_httpdownloader.py
@@ -206,10 +206,10 @@ class TestDownloadFile:
         self.assert_contains(filename, 'This file should be called renamed')
 
     async def test_download_with_rename_sanitised(self):
-        url = self.get_url('rename?filename=/etc/passwd')
+        url = self.get_url('rename?filename="/etc/passwd"')
         filename = await download_file(url, fname('original'))
         assert filename == fname('passwd')
-        self.assert_contains(filename, 'This file should be called /etc/passwd')
+        self.assert_contains(filename, 'This file should be called "/etc/passwd"')
 
     async def test_download_with_attachment_no_filename(self):
         url = self.get_url('attachment')

--- a/deluge/ui/web/json_api.py
+++ b/deluge/ui/web/json_api.py
@@ -6,7 +6,7 @@
 # See LICENSE for more details.
 #
 
-import cgi
+import email.message
 import json
 import logging
 import os
@@ -191,7 +191,9 @@ class JSON(resource.Resource, component.Component):
         Handler to take the json data as a string and pass it on to the
         _handle_request method for further processing.
         """
-        content_type, _ = cgi.parse_header(request.getHeader(b'content-type').decode())
+        message = email.message.Message()
+        message['content-type'] = request.getHeader(b'content-type').decode()
+        content_type = message.get_params()[0][0]
         if content_type != 'application/json':
             message = 'Invalid JSON request content-type: %s' % content_type
             raise JSONException(message)

--- a/deluge/ui/web/json_api.py
+++ b/deluge/ui/web/json_api.py
@@ -191,9 +191,9 @@ class JSON(resource.Resource, component.Component):
         Handler to take the json data as a string and pass it on to the
         _handle_request method for further processing.
         """
-        message = email.message.Message()
+        message = email.message.EmailMessage()
         message['content-type'] = request.getHeader(b'content-type').decode()
-        content_type = message.get_params()[0][0]
+        content_type = message.get_content_type()
         if content_type != 'application/json':
             message = 'Invalid JSON request content-type: %s' % content_type
             raise JSONException(message)


### PR DESCRIPTION
As PEP 594 says, cgi module is marked as deprecated in python 3.11, and will be removed in 3.13
(actually removed at least in 3.13 rc1).

As suggested on PEP 594, replace cgi.parse_header
with email.message.Message .
email module is introduced in python 3.6 .

Ref: https://peps.python.org/pep-0594/#deprecated-modules
Ref: https://peps.python.org/pep-0594/#cgi