### PR TITLE
Fix bug in AuthenticationDialog

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,6 +23,7 @@ Contributors (and Past Developers):
     * Pedro Algarvio ('s0undt3ch') <ufs@ufsoft.org>
     * Cristian Greco ('cgreco') <cristian@regolo.cc>
     * Chase Sterling ('gazpachoKing') <chase.sterling@gmail.com>
+    * Justin Williams ('Jaywalker')
 
 Plugin Developers:
     * Autoadd       : Chase Sterling

--- a/deluge/ui/gtk3/connectionmanager.py
+++ b/deluge/ui/gtk3/connectionmanager.py
@@ -316,7 +316,7 @@ class ConnectionManager(component.Component):
 
             def dialog_finished(response_id):
                 if response_id == Gtk.ResponseType.OK:
-                    self._connect(host_id, dialog.get_username(), dialog.get_password())
+                    self._connect(host_id, dialog.account.username, dialog.account.password)
 
             return dialog.run().addCallback(dialog_finished)
 

--- a/deluge/ui/gtk3/dialogs.py
+++ b/deluge/ui/gtk3/dialogs.py
@@ -207,6 +207,8 @@ class AuthenticationDialog(BaseDialog):
             parent,
         )
 
+        self.account = None
+
         table = Gtk.Table(2, 2, False)
         self.username_label = Gtk.Label()
         self.username_label.set_markup('<b>' + _('Username:') + '</b>')
@@ -244,6 +246,16 @@ class AuthenticationDialog(BaseDialog):
 
     def on_password_activate(self, widget):
         self.response(Gtk.ResponseType.OK)
+
+    def _on_response(self, widget, response):
+        if response == Gtk.ResponseType.OK:
+            self.account = Account(
+                self.username_entry.get_text(),
+                self.password_entry.get_text(),
+                "",
+            )
+        self.destroy()
+        self.deferred.callback(response)
 
 
 class AccountDialog(BaseDialog):


### PR DESCRIPTION
Specific bug is described here: https://dev.deluge-torrent.org/ticket/3643#ticket

The issue occured because the `AuthenticationDialog` was `destroy()`'d before the calls were made to get the text from their `GTK.Entry()`'s. It has been fixed by using the same method as `AccountDialog` and storing the information in an `Account` object prior to the `destroy()` call.

It may be worth considering giving the user an option to save/update the `hostlist.conf`  file with the working credentials as well, but that would merit discussion and a separate PR. This PR simply fixes the problem and leaves existing logic flow in place.