### PR TITLE
Update GTK stack for use in CI/CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,6 +16,9 @@ on:
       ref:
         description: "Enter a tag or commit to package"
         default: ""
+      gvsbuild-tag:
+        description: "Use an alternative gvsbuild release for the windows build. Defaults to latest."
+        default: "latest"
 
 jobs:
   windows_package:
@@ -23,8 +26,8 @@ jobs:
     if: (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'package'))
     strategy:
       matrix:
-        arch: [x64, x86]
-        python: ["3.9"]
+        arch: [x64]
+        python: ["3.10"]
         libtorrent: [2.0.7, 1.2.19]
 
     steps:
@@ -49,12 +52,20 @@ jobs:
           cache: pip
 
       - name: Prepare pip
-        run: python -m pip install wheel setuptools==68.*
+        run: python -m pip install wheel setuptools==70.*
+
+      - name: Determine gvsbuild release URL
+        id: gvsbuild-url
+        shell: bash
+        run: |
+          test -z "${{ github.event.inputs.gvsbuild-tag }}" && tag=latest || tag="${{ github.event.inputs.gvsbuild-tag }}"
+          if [[ "$tag" == "latest" ]]; then URL="https://github.com/${{ github.repository_owner }}/gvsbuild-release/releases/$tag/download"; else URL="https://github.com/${{ github.repository_owner }}/gvsbuild-release/releases/download/$tag" ; fi
+          echo "gvsbuild-release-url=$URL" >> $GITHUB_OUTPUT
 
       - name: Install GTK
         run: |
           $WebClient = New-Object System.Net.WebClient
-          $WebClient.DownloadFile("https://github.com/deluge-torrent/gvsbuild-release/releases/download/latest/gvsbuild-py${{ matrix.python }}-vs16-${{ matrix.arch }}.zip","C:\GTK.zip")
+          $WebClient.DownloadFile("${{ steps.gvsbuild-url.outputs.gvsbuild-release-url }}/gvsbuild-py${{ matrix.python }}-vs17-${{ matrix.arch }}.zip","C:\GTK.zip")
           7z x C:\GTK.zip -oc:\GTK
           echo "C:\GTK\release\lib" | Out-File -FilePath $env:GITHUB_PATH -Append
           echo "C:\GTK\release\bin" | Out-File -FilePath $env:GITHUB_PATH -Append

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,19 @@ on:
       core-dump:
         description: "Set to 1 to enable retrieving core dump from crashes"
         default: "0"
+      gvsbuild-tag:
+        description: "Use an alternative gvsbuild release for the windows build. Defaults to latest."
+        default: "latest"
 jobs:
   test-linux:
-    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.7", "3.10"]
-
+        python-version: ["3.9", "3.10"]
+        os: ["ubuntu-24.04"]
+        include:
+          - os: ubuntu-22.04
+            python-version: 3.7
+    runs-on: ${{ matrix.os }}
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
@@ -74,7 +80,8 @@ jobs:
     runs-on: windows-2022
     strategy:
       matrix:
-        python-version: ["3.7", "3.10"]
+        python-version: ["3.7", "3.9", "3.10"]
+        arch: ["x64"]
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -88,6 +95,24 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
           cache-dependency-path: "requirements*.txt"
+
+      - name: Determine gvsbuild release URL
+        id: gvsbuild-url
+        shell: bash
+        run: |
+          test -z "${{ github.event.inputs.gvsbuild-tag }}" && tag=latest || tag="${{ github.event.inputs.gvsbuild-tag }}"
+          if [[ "$tag" == "latest" ]]; then URL="https://github.com/${{ github.repository_owner }}/gvsbuild-release/releases/$tag/download"; else URL="https://github.com/${{ github.repository_owner }}/gvsbuild-release/releases/download/$tag" ; fi
+          echo "gvsbuild-release-url=$URL" >> $GITHUB_OUTPUT
+
+      - name: Install GTK
+        run: |
+          $WebClient = New-Object System.Net.WebClient
+          $WebClient.DownloadFile("${{ steps.gvsbuild-url.outputs.gvsbuild-release-url }}/gvsbuild-py${{ matrix.python-version }}-vs17-${{matrix.arch}}.zip","C:\GTK.zip")
+          7z x C:\GTK.zip -oc:\GTK
+          echo "C:\GTK\release\lib" | Out-File -FilePath $env:GITHUB_PATH -Append
+          echo "C:\GTK\release\bin" | Out-File -FilePath $env:GITHUB_PATH -Append
+          echo "C:\GTK\release" | Out-File -FilePath $env:GITHUB_PATH -Append
+          python -m pip install --no-index --find-links="C:\GTK\release\python" pycairo PyGObject
 
       - name: Install dependencies
         run: |

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,4 +1,4 @@
-libtorrent
+libtorrent==2.0.7
 pytest
 pytest-twisted
 pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 libtorrent
-twisted[tls]>=17.1
+twisted[tls]>=17.1,<=24.7
 twisted[tls]<23,>=17.1; sys_platform == 'win32'
 rencode
 pyopenssl


### PR DESCRIPTION
Ok @cas--, you win; I'll split it.

I also opted to make a new PR  that will supersede #454, to make it easier to keep track of the discussion, were there to be any.

After this, I will make another PR for unpinning pytest (I _might_ include the change from `gtkreactor` to `gireactor` in this latter one because I genuinely think it would make everybody's lives easier, but you tell me)

This is just the bit updating the GTK stack. As you can see, I've reverted the changes to libtorrent and such (although I maintain it should be somewhat of a priority to address this sooner rather than later)