### PR TITLE
[3350][GTK] Fix a regression with quick search

### DIFF
--- a/deluge/ui/gtk3/listview.py
+++ b/deluge/ui/gtk3/listview.py
@@ -782,7 +782,7 @@ class ListView:
 
         return True
 
-    def on_keypress_search_by_name(self, model, column, key, _iter):
+    def on_keypress_search_by_name(self, model, column, key, _iter, *search_data):
         torrent_name_col = self.columns[_('Name')].column_indices[1]
         return not model[_iter][torrent_name_col].lower().startswith(key.lower())
 


### PR DESCRIPTION
When one tries to search in the TorrentView, then a little search window appears but does nothing.

Closes: https://dev.deluge-torrent.org/ticket/3350