### PR TITLE
[Build] Prevent usage of twisted>=24

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 libtorrent
-twisted[tls]>=17.1
+twisted[tls]<24,>=17.1
 twisted[tls]<23,>=17.1; sys_platform == 'win32'
 rencode
 pyopenssl


### PR DESCRIPTION
Breaking ability of adding multiple torrents at once in WebUI, with following error in web-console after pressing 'Add':
```
deluge-all.js:7 Uncaught TypeError: Cannot read properties of undefined (reading 'filename')
    at S.getFilename (deluge-all.js:7:1946)
    at S.<anonymous> (deluge-all.js:3:2013)
    at Ext.util.MixedCollection.each (ext-all.js:21:111850)
    at constructor.each (ext-all.js:21:321534)
    at S.onAddClick (deluge-all.js:3:1932)
    at S.onClick (ext-all.js:21:426947)
    at HTMLTableElement.I (ext-all.js:21:57750)
```
The issue stems from only one of the torrents getting uploaded to server, after cgi.parse_multipart was removed from twisted.web.http and replaced with email.message_from_bytes, in there commit [4579398](https://github.com/twisted/twisted/commit/4579398f6b089f93181ba2f912e2524bd1f43c5e). 

Note, there's currently a twisted draft [PR](https://github.com/twisted/twisted/pull/12352) replacing email.message* with 'multipart' lib, as seemingly better fitted/faster, and which coincidentally also is fixing our issue.