### PR TITLE
[UI] Split trackers by newline, not by "/n"

### DIFF
--- a/deluge/ui/gtk3/createtorrentdialog.py
+++ b/deluge/ui/gtk3/createtorrentdialog.py
@@ -493,7 +493,7 @@ class CreateTorrentDialog:
                 *textview_buf.get_bounds(), include_hidden_chars=False
             )
             log.debug('Create torrent tracker lines: %s', trackers_text)
-            self.config['createtorrent.trackers'] = trackers_text.split('/n')
+            self.config['createtorrent.trackers'] = trackers_text.split('\n')
 
             # Append trackers liststore with unique trackers and tiers starting from last tier number.
             last_tier, orig_trackers = last_tier_trackers_from_liststore(

--- a/deluge/ui/gtk3/createtorrentdialog.py
+++ b/deluge/ui/gtk3/createtorrentdialog.py
@@ -493,7 +493,7 @@ class CreateTorrentDialog:
                 *textview_buf.get_bounds(), include_hidden_chars=False
             )
             log.debug('Create torrent tracker lines: %s', trackers_text)
-            self.config['createtorrent.trackers'] = trackers_text.split('\n')
+            self.config['createtorrent.trackers'] = trackers_text.splitlines()
 
             # Append trackers liststore with unique trackers and tiers starting from last tier number.
             last_tier, orig_trackers = last_tier_trackers_from_liststore(


### PR DESCRIPTION
Fixes a bug where e.g. http://not-a-real-tracker.com was split into 
```
http:/
ot-a-real-tracker.com
```
when the add trackers dialogue was next shown

First adding the tracker (typing/pasting it in):
![Screenshot from 2024-11-02 17-25-20](https://github.com/user-attachments/assets/eb1cf393-ae1f-4230-a129-91fc7f7339bb)
Next time adding trackers (autofilled):
![Screenshot from 2024-11-02 17-25-27](https://github.com/user-attachments/assets/d0909ca7-3967-4d15-9f35-f2893e1b6ce4)
