### PR TITLE
bugfix: double delete of pidfile

### DIFF
--- a/deluge/core/daemon_entry.py
+++ b/deluge/core/daemon_entry.py
@@ -132,8 +132,6 @@ def start_daemon(skip_start=False):
             sys.exit(1)
         finally:
             log.info('Exiting...')
-            if options.pidfile:
-                os.remove(options.pidfile)
 
     return run_profiled(
         run_daemon, options, output_file=options.profile, do_profile=options.profile


### PR DESCRIPTION
Removed redundant os.remove(options.pidfile) at daemon_entry.py:136.  cmp to daemon.py:165.