### PR TITLE
[UI] Convert all favicon to png format for tracker icons

### DIFF
--- a/deluge/ui/tracker_icons.py
+++ b/deluge/ui/tracker_icons.py
@@ -461,15 +461,12 @@ class TrackerIcons(Component):
         # Requires Pillow(PIL) to resize.
         if icon and Image:
             filename = icon.get_filename()
-            remove_old = False
             with Image.open(filename) as img:
+                new_filename = os.path.splitext(filename)[0] + '.png'
                 if img.size > (16, 16):
-                    new_filename = filename.rpartition('.')[0] + '.png'
                     img = img.resize((16, 16), Image.Resampling.LANCZOS)
-                    img.save(new_filename)
-                    if new_filename != filename:
-                        remove_old = True
-            if remove_old:
+                img.save(new_filename)
+            if new_filename != filename:
                 os.remove(filename)
                 icon = TrackerIcon(new_filename)
         return icon


### PR DESCRIPTION
Due to the potential for favicon's on-site to be in either png OR ico format, I've opted to convert and resize favicon to .png of at max 16x16.

Previously, any sites that did not use .png and met the 16x16 threshold for their favicon would actually fail to load in the GTK tracker list. Only favicons that were resized/converted to png or were natively in png would load.

With this change, all fav icons end up as .png and within the max size, displaying 100% of the trackers with favicon's on the domain in the GTK tracker list properly.