### PR TITLE
Perform force recheck on torrent in error state after restart

### DIFF
--- a/deluge/core/torrentmanager.py
+++ b/deluge/core/torrentmanager.py
@@ -884,6 +884,13 @@ class TorrentManager(component.Component):
                 len(state.torrents),
                 str(datetime.datetime.now() - start),
             )
+
+            # After all torrents are loaded, perform force recheck for torrents in error state
+            for torrent in self.torrents.values():
+                if torrent.state == 'Error':
+                    log.info('Torrent %s is in error state, triggering recheck', torrent.torrent_id)
+                    torrent.force_recheck()
+
             component.get('EventManager').emit(SessionStartedEvent())
 
         deferred_list.addCallback(on_complete)


### PR DESCRIPTION
Should resolve [#3230](https://dev.deluge-torrent.org/ticket/3230)

Automatically recover torrents from error states (e.g., after crashes) without manual intervention.

#### Changes:
* Added auto-recheck for error-state torrents in `load_state()`
* Added test verifying auto-recheck after shutdown