### PR TITLE
Use system default locale for date formatting in web UI

### DIFF
--- a/deluge/ui/web/js/deluge-all/Formatters.js
+++ b/deluge/ui/web/js/deluge-all/Formatters.js
@@ -32,34 +32,33 @@ Deluge.Formatters = (function () {
         return charToEntity[capture];
     };
 
-    /**
-     * Formats a date string in the date representation of the current locale,
-     * based on the systems timezone.
-     *
-     * @param {Number} timestamp time in seconds since the Epoch.
-     * @return {String} a string in the date representation of the current locale
-     * or "" if seconds < 0.
-     */
+    // undefined locale will use the system default
+    var dateFormatter = new Intl.DateTimeFormat(undefined, {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        hour12: false,
+    });
+
     return (Formatters = {
+        /**
+         * Formats a date string in the date representation of the current locale,
+         * based on the systems timezone.
+         *
+         * @param {Number} timestamp time in seconds since the Epoch.
+         * @return {String} a string in the date representation of the current locale
+         * or "" if seconds < 0.
+         */
         date: function (timestamp) {
-            function zeroPad(num, count) {
-                var numZeropad = num + '';
-                while (numZeropad.length < count) {
-                    numZeropad = '0' + numZeropad;
-                }
-                return numZeropad;
-            }
             timestamp = timestamp * 1000;
-            var date = new Date(timestamp);
-            return String.format(
-                '{0}/{1}/{2} {3}:{4}:{5}',
-                zeroPad(date.getDate(), 2),
-                zeroPad(date.getMonth() + 1, 2),
-                date.getFullYear(),
-                zeroPad(date.getHours(), 2),
-                zeroPad(date.getMinutes(), 2),
-                zeroPad(date.getSeconds(), 2)
-            );
+            if (timestamp < 0) {
+                return '';
+            } else {
+                return dateFormatter.format(new Date(timestamp));
+            }
         },
 
         /**


### PR DESCRIPTION
should resolve [#3639](https://dev.deluge-torrent.org/ticket/3639)

I used [Intl.DateTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat) for the localized formatting, which has been widely on all major browsers since at least 2016.

**Changes**
- removed hard-coded date formatting
- added date formatting that uses the default system locale
- moved the docstring to be immediately before the date formatter function

**Examples**
| locale | display |
| --- | --- |
| en-US | ![en-US](https://github.com/user-attachments/assets/db709fac-4f14-4ecf-a2ae-b21b3253f166) |
| en-GB | ![en-GB](https://github.com/user-attachments/assets/fc1f3872-55fd-4fe0-81c6-63717c3eafa5) |
| de-DE | ![de-DE](https://github.com/user-attachments/assets/b9cdd9ab-0010-45c1-94d1-aedb84d15758) |
| ja-JP-u-ca-japanese | ![ja-JP-u-ca-japanese](https://github.com/user-attachments/assets/b3e44e57-3562-402f-aaa2-25eb64222970) |