### PR TITLE
Fix multipart form data parsing for file upload in Web UI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ zope.interface>=4.4.2
 distro; 'linux' in sys_platform or 'bsd' in sys_platform
 pygeoip
 ifaddr>=0.2.0
+python-multipart


### PR DESCRIPTION
Per the [forum thread](https://forum.deluge-torrent.org/viewtopic.php?t=56916), adding multiple files via the Web UI was broken by the removal of `parse_multipart` in Twisted v24.

I've pulled in [python-multipart](https://github.com/kludex/python-multipart) to re-enable that functionality.