### PR TITLE
[Core] Refactor new features support check

### DIFF
--- a/deluge/_features.py
+++ b/deluge/_features.py
@@ -1,0 +1,19 @@
+from enum import IntFlag
+from functools import reduce
+from operator import or_ as _or_
+
+
+def _with_limits(enumeration):
+    """add NONE and ALL psuedo-members to enumeration"""
+    none_member = enumeration(0)
+    all_member = enumeration(reduce(_or_, enumeration))
+    enumeration.NONE = none_member
+    enumeration.ALL = all_member
+    enumeration._member_map_['NONE'] = none_member
+    enumeration._member_map_['ALL'] = all_member
+    return enumeration
+
+
+@_with_limits
+class DelugeFeatures(IntFlag):
+    BASE = 1  # marks all features up to 2.2.0

--- a/deluge/core/core.py
+++ b/deluge/core/core.py
@@ -22,6 +22,7 @@ from twisted.web.client import Agent, readBody
 import deluge.common
 import deluge.component as component
 from deluge import metafile, path_chooser_common
+from deluge._features import DelugeFeatures
 from deluge._libtorrent import LT_VERSION, lt
 from deluge.configmanager import ConfigManager, get_config_dir
 from deluge.core.alertmanager import AlertManager
@@ -1301,3 +1302,8 @@ class Core(component.Component):
     @export(AUTH_LEVEL_ADMIN)
     def remove_account(self, username: str) -> bool:
         return self.authmanager.remove_account(username)
+
+    @export
+    def get_supported_features(self) -> int:
+        """Returns the supported features."""
+        return DelugeFeatures.ALL.value

--- a/deluge/plugins/Blocklist/deluge_blocklist/gtkui.py
+++ b/deluge/plugins/Blocklist/deluge_blocklist/gtkui.py
@@ -60,7 +60,7 @@ class GtkUI(Gtk3PluginBase):
         self.plugin.deregister_hook('on_apply_prefs', self._on_apply_prefs)
         self.plugin.deregister_hook('on_show_prefs', self._on_show_prefs)
 
-        del self.glade
+        del self.builder
 
     def update(self):
         def _on_get_status(status):

--- a/deluge/tests/test_core.py
+++ b/deluge/tests/test_core.py
@@ -20,6 +20,7 @@ from twisted.web.static import File
 import deluge.common
 import deluge.component as component
 import deluge.core.torrent
+from deluge._features import DelugeFeatures
 from deluge._libtorrent import lt
 from deluge.conftest import BaseTestCase
 from deluge.core.core import Core
@@ -509,3 +510,7 @@ class TestCore(BaseTestCase):
             assert f.read() == filecontent
 
         lt.torrent_info(filecontent)
+
+    def test_get_supported_features(self):
+        features = self.core.get_supported_features()
+        assert features == DelugeFeatures.ALL


### PR DESCRIPTION
In 1989d0de a check for a daemon version was added. As this depends on knowing the version in which the feature will be merged, this approach is not suitable for this.
Therefore, a features enum will help us list all features, without knowing in which version each was added.