### PR TITLE
[Core] Work around libtorrent size limit

### DIFF
--- a/deluge/core/torrentmanager.py
+++ b/deluge/core/torrentmanager.py
@@ -15,6 +15,7 @@ import os
 import pickle
 import time
 from base64 import b64encode
+from pathlib import Path
 from tempfile import gettempdir
 from typing import Dict, List, NamedTuple, Tuple
 
@@ -338,8 +339,8 @@ class TorrentManager(component.Component):
         if log.isEnabledFor(logging.DEBUG):
             log.debug('Attempting to extract torrent_info from %s', filepath)
         try:
-            torrent_info = lt.torrent_info(filepath)
-        except RuntimeError as ex:
+            torrent_info = lt.torrent_info(Path(filepath).read_bytes())
+        except (RuntimeError, OSError) as ex:
             log.warning('Unable to open torrent file %s: %s', filepath, ex)
         else:
             return torrent_info


### PR DESCRIPTION
When loading a torrent_info by file path, libtorrent has a hardcoded size limit that some torrents exceed. This means that the torrent can be added normally to deluge, but on restart it fails to load the file from the state directory and the torrent is lost.

Work around the hardcoded buffer size limit by reading in the file directly and passing the buffer.

See: https://libtorrent-discuss.narkive.com/wYACQDb7/libtorrent-loading-a-big-torrent-fails
Fixes: https://forum.deluge-torrent.org/viewtopic.php?t=56856