### PR TITLE
Store Hashes of Daemon User Passwords

### DIFF
--- a/deluge/core/authmanager.py
+++ b/deluge/core/authmanager.py
@@ -21,7 +21,12 @@ from deluge.common import (
     AUTH_LEVEL_READONLY,
     create_localclient_account,
 )
-from deluge.error import AuthenticationRequired, AuthManagerError, BadLoginError
+from deluge.error import (
+    AuthenticationRequired,
+    AuthManagerError,
+    BadLoginError,
+    InvalidHashError,
+)
 from deluge.security import check_password_hash, generate_password_hash
 
 log = logging.getLogger(__name__)
@@ -113,8 +118,18 @@ class AuthManager(component.Component):
             if username not in self.__auth:
                 raise BadLoginError('Username does not exist', username)
 
-        # if self._validate_hash(password, self.__auth[username].password):
-        if check_password_hash(self.__auth[username].password, password):
+        try:
+            verified = check_password_hash(self.__auth[username].password, password)
+        except InvalidHashError as ex:
+            log.warning(
+                'Invalid hash method in password for user %s: %s'
+                ' Falling back to plaintext validation.',
+                username,
+                ex.method,
+            )
+            verified = password == self.__auth[username].password
+
+        if verified:
             # Return the users auth level
             return self.__auth[username].authlevel
         #  Fall back to plaintext password for localclient account so that autologin doesn't break.

--- a/deluge/core/authmanager.py
+++ b/deluge/core/authmanager.py
@@ -150,7 +150,6 @@ class AuthManager(component.Component):
         return [account.data() for account in self.__auth.values()]
 
     def create_account(self, username, password, authlevel):
-        # password_hash = self._get_hash(password)
         password_hash = generate_password_hash(password)
 
         if username in self.__auth:

--- a/deluge/core/authmanager.py
+++ b/deluge/core/authmanager.py
@@ -10,6 +10,7 @@
 import logging
 import os
 import shutil
+from hashlib import scrypt
 
 import deluge.component as component
 import deluge.configmanager as configmanager
@@ -63,6 +64,13 @@ class AuthManager(component.Component):
         component.Component.__init__(self, 'AuthManager', interval=10)
         self.__auth = {}
         self.__auth_modification_time = None
+        self.__hash_parameters = {
+            'n': 16384,
+            'r': 8,
+            'p': 1,
+            'maxmem': 0,
+            'dklen': 64,
+        }
 
     def start(self):
         self.__load_auth_file()
@@ -72,6 +80,46 @@ class AuthManager(component.Component):
 
     def shutdown(self):
         pass
+
+    def _get_hash(self, password, salt=None):
+        """Hashes the password using scrypt.
+
+        Args:
+            password (str): The password to hash.
+            salt (bytes, optional): The salt to use for hashing. If not provided, a new salt will be generated.
+
+        Returns:
+            str: The hashed password in the format 'salt$hash'.
+        """
+        if not salt:
+            salt = os.urandom(16)
+
+        password = scrypt(
+            password.encode('utf-8'),
+            salt=salt,
+            **self.__hash_parameters,
+        )
+        hashed_password = f'{salt.hex()}${password.hex()}'
+        return hashed_password
+
+    def _validate_hash(self, password, hashed_password):
+        """Validates a password against a hashed password.
+
+        Args:
+            password (str): The password to validate.
+            hashed_password (str): The hashed password in the format 'salt$hash'.
+
+        Returns:
+            bool: True if the password matches the hashed password, False otherwise.
+        """
+        try:
+            salt, hashed = hashed_password.split('$')
+        except ValueError:
+            return False
+        salt = bytes.fromhex(salt)
+        hashed = bytes.fromhex(hashed)
+        password_hash = self._get_hash(password, salt=salt)
+        return password_hash == hashed_password
 
     def update(self):
         auth_file = configmanager.get_config_dir('auth')
@@ -112,8 +160,12 @@ class AuthManager(component.Component):
             if username not in self.__auth:
                 raise BadLoginError('Username does not exist', username)
 
-        if self.__auth[username].password == password:
+        if self._validate_hash(password, self.__auth[username].password):
             # Return the users auth level
+            return self.__auth[username].authlevel
+        #  Fall back to plaintext password for localclient account so that autologin doesn't break.
+        elif username == 'localclient' and self.__auth[username].password == password:
+            log.debug('Localclient account authenticated')
             return self.__auth[username].authlevel
         elif not password and self.__auth[username].password:
             raise AuthenticationRequired('Password is required', username)
@@ -129,13 +181,15 @@ class AuthManager(component.Component):
         return [account.data() for account in self.__auth.values()]
 
     def create_account(self, username, password, authlevel):
+        password_hash = self._get_hash(password)
+
         if username in self.__auth:
             raise AuthManagerError('Username in use.', username)
         if authlevel not in AUTH_LEVELS_MAPPING:
             raise AuthManagerError('Invalid auth level: %s' % authlevel)
         try:
             self.__auth[username] = Account(
-                username, password, AUTH_LEVELS_MAPPING[authlevel]
+                username, password_hash, AUTH_LEVELS_MAPPING[authlevel]
             )
             self.write_auth_file()
             return True
@@ -144,13 +198,18 @@ class AuthManager(component.Component):
             raise ex
 
     def update_account(self, username, password, authlevel):
+        # If the username is 'localclient', we don't hash the password
+        # to keep compatability with the current localclient autologin.
+        password_hash = None
+        if username != 'localclient':
+            password_hash = self._get_hash(password)
         if username not in self.__auth:
             raise AuthManagerError('Username not known', username)
         if authlevel not in AUTH_LEVELS_MAPPING:
             raise AuthManagerError('Invalid auth level: %s' % authlevel)
         try:
             self.__auth[username].username = username
-            self.__auth[username].password = password
+            self.__auth[username].password = password_hash or password
             self.__auth[username].authlevel = AUTH_LEVELS_MAPPING[authlevel]
             self.write_auth_file()
             return True

--- a/deluge/core/authmanager.py
+++ b/deluge/core/authmanager.py
@@ -10,7 +10,6 @@
 import logging
 import os
 import shutil
-from hashlib import scrypt
 
 import deluge.component as component
 import deluge.configmanager as configmanager
@@ -23,6 +22,7 @@ from deluge.common import (
     create_localclient_account,
 )
 from deluge.error import AuthenticationRequired, AuthManagerError, BadLoginError
+from deluge.security import check_password_hash, generate_password_hash
 
 log = logging.getLogger(__name__)
 
@@ -64,13 +64,6 @@ class AuthManager(component.Component):
         component.Component.__init__(self, 'AuthManager', interval=10)
         self.__auth = {}
         self.__auth_modification_time = None
-        self.__hash_parameters = {
-            'n': 16384,
-            'r': 8,
-            'p': 1,
-            'maxmem': 0,
-            'dklen': 64,
-        }
 
     def start(self):
         self.__load_auth_file()
@@ -80,46 +73,6 @@ class AuthManager(component.Component):
 
     def shutdown(self):
         pass
-
-    def _get_hash(self, password, salt=None):
-        """Hashes the password using scrypt.
-
-        Args:
-            password (str): The password to hash.
-            salt (bytes, optional): The salt to use for hashing. If not provided, a new salt will be generated.
-
-        Returns:
-            str: The hashed password in the format 'salt$hash'.
-        """
-        if not salt:
-            salt = os.urandom(16)
-
-        password = scrypt(
-            password.encode('utf-8'),
-            salt=salt,
-            **self.__hash_parameters,
-        )
-        hashed_password = f'{salt.hex()}${password.hex()}'
-        return hashed_password
-
-    def _validate_hash(self, password, hashed_password):
-        """Validates a password against a hashed password.
-
-        Args:
-            password (str): The password to validate.
-            hashed_password (str): The hashed password in the format 'salt$hash'.
-
-        Returns:
-            bool: True if the password matches the hashed password, False otherwise.
-        """
-        try:
-            salt, hashed = hashed_password.split('$')
-        except ValueError:
-            return False
-        salt = bytes.fromhex(salt)
-        hashed = bytes.fromhex(hashed)
-        password_hash = self._get_hash(password, salt=salt)
-        return password_hash == hashed_password
 
     def update(self):
         auth_file = configmanager.get_config_dir('auth')
@@ -160,7 +113,8 @@ class AuthManager(component.Component):
             if username not in self.__auth:
                 raise BadLoginError('Username does not exist', username)
 
-        if self._validate_hash(password, self.__auth[username].password):
+        # if self._validate_hash(password, self.__auth[username].password):
+        if check_password_hash(self.__auth[username].password, password):
             # Return the users auth level
             return self.__auth[username].authlevel
         #  Fall back to plaintext password for localclient account so that autologin doesn't break.
@@ -181,7 +135,8 @@ class AuthManager(component.Component):
         return [account.data() for account in self.__auth.values()]
 
     def create_account(self, username, password, authlevel):
-        password_hash = self._get_hash(password)
+        # password_hash = self._get_hash(password)
+        password_hash = generate_password_hash(password)
 
         if username in self.__auth:
             raise AuthManagerError('Username in use.', username)
@@ -202,7 +157,7 @@ class AuthManager(component.Component):
         # to keep compatability with the current localclient autologin.
         password_hash = None
         if username != 'localclient':
-            password_hash = self._get_hash(password)
+            password_hash = generate_password_hash(password)
         if username not in self.__auth:
             raise AuthManagerError('Username not known', username)
         if authlevel not in AUTH_LEVELS_MAPPING:

--- a/deluge/error.py
+++ b/deluge/error.py
@@ -94,3 +94,10 @@ class AuthManagerError(_UsernameBasedPasstroughError):
 
 class LibtorrentImportError(ImportError):
     pass
+
+
+class InvalidHashError(_ClientSideRecreateError):
+    def __init__(self, message, method):
+        super().__init__(message)
+        self.method = method
+        self.message = message

--- a/deluge/security.py
+++ b/deluge/security.py
@@ -1,0 +1,120 @@
+# This file is adapted from Werkzeug (https://github.com/pallets/werkzeug)
+# and is licensed under the BSD 3-Clause License:
+
+# Copyright 2007 Pallets
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+
+# 3.  Neither the name of the copyright holder nor the names of its
+#     contributors may be used to endorse or promote products derived from
+#     this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+# TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import secrets
+
+SALT_CHARS = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
+
+
+def gen_salt(length: int) -> str:
+    """Generate a random string of SALT_CHARS with specified ``length``."""
+    if length <= 0:
+        raise ValueError('Salt length must be at least 1.')
+
+    return ''.join(secrets.choice(SALT_CHARS) for _ in range(length))
+
+
+def _hash_internal(method: str, salt: str, password: str) -> tuple[str, str]:
+    method, *args = method.split('$')
+    salt_bytes = salt.encode()
+    password_bytes = password.encode()
+
+    if method == 'scrypt':
+        if not args:
+            n = 2**15
+            r = 8
+            p = 1
+        else:
+            try:
+                n, r, p = map(int, args)
+            except ValueError:
+                raise ValueError("'scrypt' takes 3 arguments.") from None
+
+        maxmem = 132 * n * r * p  # ideally 128, but some extra seems needed
+        return (
+            hashlib.scrypt(
+                password_bytes, salt=salt_bytes, n=n, r=r, p=p, maxmem=maxmem
+            ).hex(),
+            f'scrypt${n}${r}${p}',
+        )
+
+    else:
+        raise ValueError(f"Invalid hash method '{method}'.")
+
+
+def generate_password_hash(
+    password: str, method: str = 'scrypt', salt_length: int = 16
+) -> str:
+    """Securely hash a password for storage. A password can be compared to a stored hash using check_password_hash.
+
+    Args:
+        password (str): The plaintext password to hash.
+        method (str): The key derivation function and parameters. Defaults to 'scrypt'.
+        salt_length (int): The length of the salt to generate. Defaults to 16.
+
+        Returns:
+            str: The hashed password in the format 'method$salt$hash'.
+
+    """
+    salt = gen_salt(salt_length)
+    h, actual_method = _hash_internal(method, salt, password)
+    return f'{salt}${h}${actual_method}'
+
+
+def check_password_hash(pwhash: str, password: str) -> bool:
+    """Securely check that the given stored password hash, previously generated using
+    generate_password_hash, matches the given password.
+
+    Methods may be deprecated and removed if they are no longer considered secure. To
+    migrate old hashes, you may generate a new hash when checking an old hash, or you
+    may contact users with a link to reset their password.
+
+    Args:
+        pwhash (str): The hashed password in the format 'method$salt$hash
+        password (str): The plaintext password to check against the hash.
+
+    Raises:
+        ValueError: If the hash format is invalid or the method is not recognized.
+
+    Returns:
+        bool: True if the password matches the hash, False otherwise.
+    """
+    try:
+        salt, hashval, method = pwhash.split('$', 2)
+    except ValueError:
+        return False
+
+    return hmac.compare_digest(_hash_internal(method, salt, password)[0], hashval)

--- a/deluge/security.py
+++ b/deluge/security.py
@@ -36,6 +36,8 @@ import hashlib
 import hmac
 import secrets
 
+from deluge.error import InvalidHashError
+
 SALT_CHARS = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
 
 
@@ -86,7 +88,7 @@ def generate_password_hash(
         salt_length (int): The length of the salt to generate. Defaults to 16.
 
         Returns:
-            str: The hashed password in the format 'method$salt$hash'.
+            str: The hashed password in the format 'salt$hash$method'.
 
     """
     salt = gen_salt(salt_length)
@@ -114,7 +116,10 @@ def check_password_hash(pwhash: str, password: str) -> bool:
     """
     try:
         salt, hashval, method = pwhash.split('$', 2)
-    except ValueError:
-        return False
+    except ValueError as ve:
+        raise InvalidHashError(
+            'Invalid password hash format. Expected format: "salt$hash$method".',
+            method=None,
+        ) from ve
 
     return hmac.compare_digest(_hash_internal(method, salt, password)[0], hashval)


### PR DESCRIPTION
Fixes [#2442 - Plaintext auth passwords](https://dev.deluge-torrent.org/ticket/2442) by hashing passwords daemon-side instead of storing all credentials as plaintext, primarily with the aim of reducing issues that may arise from reused passwords being stored in plaintext.

The localclient user is 'whitelisted' and still uses plaintext authentication to avoid breaking autologins.