### PR TITLE
Cleanup type annotations and linting for Authmanager

### DIFF
--- a/deluge/common.py
+++ b/deluge/common.py
@@ -27,7 +27,7 @@ from datetime import datetime
 from importlib import resources
 from io import BytesIO
 from pathlib import Path
-from typing import Literal
+from typing import Literal, Optional
 from urllib.parse import unquote_plus, urljoin
 from urllib.request import pathname2url
 
@@ -101,7 +101,7 @@ def get_version():
     return distribution('Deluge').version
 
 
-def get_default_config_dir(filename: str | None = None) -> str:
+def get_default_config_dir(filename: Optional[str] = None) -> str:
     """
     :param filename: if None, only the config path is returned, if provided,
                      a path including the filename will be returned
@@ -1246,7 +1246,7 @@ def create_auth_file(auth_file):
 
 
 def create_localclient_account(
-    append: bool = False, auth_file: str | None = None
+    append: bool = False, auth_file: Optional[str] = None
 ) -> tuple[Literal['localclient'], str]:
     import random
     from hashlib import sha1 as sha

--- a/deluge/common.py
+++ b/deluge/common.py
@@ -27,6 +27,7 @@ from datetime import datetime
 from importlib import resources
 from io import BytesIO
 from pathlib import Path
+from typing import Literal
 from urllib.parse import unquote_plus, urljoin
 from urllib.request import pathname2url
 
@@ -100,7 +101,7 @@ def get_version():
     return distribution('Deluge').version
 
 
-def get_default_config_dir(filename=None):
+def get_default_config_dir(filename: str | None = None) -> str:
     """
     :param filename: if None, only the config path is returned, if provided,
                      a path including the filename will be returned
@@ -1244,7 +1245,9 @@ def create_auth_file(auth_file):
         os.chmod(auth_file, stat.S_IREAD | stat.S_IWRITE)
 
 
-def create_localclient_account(append=False, auth_file=None):
+def create_localclient_account(
+    append: bool = False, auth_file: str | None = None
+) -> tuple[Literal['localclient'], str]:
     import random
     from hashlib import sha1 as sha
 

--- a/deluge/configmanager.py
+++ b/deluge/configmanager.py
@@ -20,7 +20,7 @@ class _ConfigManager:
     def __init__(self):
         log.debug('ConfigManager started..')
         self.config_files = {}
-        self.__config_directory = None
+        self.__config_directory: str | None = None
 
     @property
     def config_directory(self):
@@ -116,7 +116,7 @@ def set_config_dir(directory):
     return _configmanager.set_config_dir(deluge.common.decode_bytes(directory))
 
 
-def get_config_dir(filename=None):
+def get_config_dir(filename: str | None = None) -> str:
     if filename is not None:
         return os.path.join(_configmanager.get_config_dir(), filename)
     else:

--- a/deluge/configmanager.py
+++ b/deluge/configmanager.py
@@ -8,6 +8,7 @@
 
 import logging
 import os
+from typing import Optional
 
 import deluge.common
 import deluge.log
@@ -116,7 +117,7 @@ def set_config_dir(directory):
     return _configmanager.set_config_dir(deluge.common.decode_bytes(directory))
 
 
-def get_config_dir(filename: str | None = None) -> str:
+def get_config_dir(filename: Optional[str] = None) -> str:
     if filename is not None:
         return os.path.join(_configmanager.get_config_dir(), filename)
     else:

--- a/deluge/core/authmanager.py
+++ b/deluge/core/authmanager.py
@@ -69,18 +69,22 @@ class Account:
 class AuthManager(component.Component):
     def __init__(self) -> None:
         component.Component.__init__(self, 'AuthManager', interval=10)
-        self.__auth = {}
+        self.__auth: dict[str, Account] = {}
         self.__auth_modification_time = None
 
+    @override
     def start(self) -> None:
         self.__load_auth_file()
 
+    @override
     def stop(self) -> None:
         self.__auth = {}
 
+    @override
     def shutdown(self) -> None:
         pass
 
+    @override
     def update(self) -> None:
         auth_file = configmanager.get_config_dir('auth')
         # Check for auth file and create if necessary
@@ -140,8 +144,7 @@ class AuthManager(component.Component):
             return check_password_hash(stored_password, password)
         except InvalidHashError as ex:
             log.warning(
-                'Invalid hash method in password for user %s: %s'
-                ' Falling back to plaintext validation.',
+                'Invalid hash method in password for user %s: %s Falling back to plaintext validation.',
                 username,
                 ex.method,
             )
@@ -213,7 +216,7 @@ class AuthManager(component.Component):
         try:
             if os.path.isfile(filepath):
                 log.debug('Creating backup of %s at: %s', filename, filepath_bak)
-                shutil.copy2(filepath, filepath_bak)
+                _ = shutil.copy2(filepath, filepath_bak)
         except OSError as ex:
             log.error('Unable to backup %s to %s: %s', filepath, filepath_bak, ex)
         else:
@@ -221,22 +224,22 @@ class AuthManager(component.Component):
             try:
                 with open(filepath_tmp, 'w', encoding='utf8') as _file:
                     for account in self.__auth.values():
-                        _file.write(
+                        _ = _file.write(
                             '%(username)s:%(password)s:%(authlevel_int)s\n'
                             % account.data()
                         )
                     _file.flush()
                     os.fsync(_file.fileno())
-                shutil.move(filepath_tmp, filepath)
+                _ = shutil.move(filepath_tmp, filepath)
             except OSError as ex:
                 log.error('Unable to save %s: %s', filename, ex)
                 if os.path.isfile(filepath_bak):
                     log.info('Restoring backup of %s from: %s', filename, filepath_bak)
-                    shutil.move(filepath_bak, filepath)
+                    _ = shutil.move(filepath_bak, filepath)
 
         self.__load_auth_file()
 
-    def __load_auth_file(self):
+    def __load_auth_file(self) -> None:
         save_and_reload = False
         filename = 'auth'
         auth_file = configmanager.get_config_dir(filename)
@@ -244,7 +247,7 @@ class AuthManager(component.Component):
 
         # Check for auth file and create if necessary
         if not os.path.isfile(auth_file):
-            create_localclient_account()
+            _ = create_localclient_account()
             return self.__load_auth_file()
 
         auth_file_modification_time = os.stat(auth_file).st_mtime_ns
@@ -276,8 +279,7 @@ class AuthManager(component.Component):
             if len(lsplit) == 2:
                 username, password = lsplit
                 log.warning(
-                    'Your auth entry for %s contains no auth level, '
-                    'using AUTH_LEVEL_DEFAULT(%s)..',
+                    'Your auth entry for %s contains no auth level, using AUTH_LEVEL_DEFAULT(%s)..',
                     username,
                     AUTH_LEVEL_DEFAULT,
                 )
@@ -310,7 +312,7 @@ class AuthManager(component.Component):
             self.__auth[username] = Account(username, password, authlevel)
 
         if 'localclient' not in self.__auth:
-            create_localclient_account(True)
+            _ = create_localclient_account(True)
             return self.__load_auth_file()
 
         if save_and_reload:

--- a/deluge/core/authmanager.py
+++ b/deluge/core/authmanager.py
@@ -10,7 +10,7 @@
 import logging
 import os
 import shutil
-from typing import Literal, override
+from typing import Literal, Union
 
 import deluge.component as component
 import deluge.configmanager as configmanager
@@ -50,7 +50,7 @@ class Account:
         self.password: str = password
         self.authlevel: int = authlevel
 
-    def data(self) -> dict[str, str | int]:
+    def data(self) -> dict[str, Union[str, int]]:
         return {
             'username': self.username,
             'password': self.password,
@@ -58,7 +58,6 @@ class Account:
             'authlevel_int': self.authlevel,
         }
 
-    @override
     def __repr__(self) -> str:
         return '<Account username="{username}" authlevel={authlevel}>'.format(
             username=self.username,
@@ -72,19 +71,15 @@ class AuthManager(component.Component):
         self.__auth: dict[str, Account] = {}
         self.__auth_modification_time = None
 
-    @override
     def start(self) -> None:
         self.__load_auth_file()
 
-    @override
     def stop(self) -> None:
         self.__auth = {}
 
-    @override
     def shutdown(self) -> None:
         pass
 
-    @override
     def update(self) -> None:
         auth_file = configmanager.get_config_dir('auth')
         # Check for auth file and create if necessary

--- a/deluge/core/authmanager.py
+++ b/deluge/core/authmanager.py
@@ -10,6 +10,7 @@
 import logging
 import os
 import shutil
+from typing import Literal, override
 
 import deluge.component as component
 import deluge.configmanager as configmanager
@@ -44,12 +45,12 @@ AUTH_LEVELS_MAPPING_REVERSE = {v: k for k, v in AUTH_LEVELS_MAPPING.items()}
 class Account:
     __slots__ = ('username', 'password', 'authlevel')
 
-    def __init__(self, username, password, authlevel):
-        self.username = username
-        self.password = password
-        self.authlevel = authlevel
+    def __init__(self, username: str, password: str, authlevel: int) -> None:
+        self.username: str = username
+        self.password: str = password
+        self.authlevel: int = authlevel
 
-    def data(self):
+    def data(self) -> dict[str, str | int]:
         return {
             'username': self.username,
             'password': self.password,
@@ -57,7 +58,8 @@ class Account:
             'authlevel_int': self.authlevel,
         }
 
-    def __repr__(self):
+    @override
+    def __repr__(self) -> str:
         return '<Account username="{username}" authlevel={authlevel}>'.format(
             username=self.username,
             authlevel=self.authlevel,
@@ -65,21 +67,21 @@ class Account:
 
 
 class AuthManager(component.Component):
-    def __init__(self):
+    def __init__(self) -> None:
         component.Component.__init__(self, 'AuthManager', interval=10)
         self.__auth = {}
         self.__auth_modification_time = None
 
-    def start(self):
+    def start(self) -> None:
         self.__load_auth_file()
 
-    def stop(self):
+    def stop(self) -> None:
         self.__auth = {}
 
-    def shutdown(self):
+    def shutdown(self) -> None:
         pass
 
-    def update(self):
+    def update(self) -> None:
         auth_file = configmanager.get_config_dir('auth')
         # Check for auth file and create if necessary
         if not os.path.isfile(auth_file):
@@ -145,7 +147,7 @@ class AuthManager(component.Component):
             )
             return stored_password == password
 
-    def has_account(self, username):
+    def has_account(self, username: str) -> bool:
         return username in self.__auth
 
     def get_known_accounts(self):
@@ -153,7 +155,7 @@ class AuthManager(component.Component):
         self.__load_auth_file()
         return [account.data() for account in self.__auth.values()]
 
-    def create_account(self, username, password, authlevel):
+    def create_account(self, username: str, password: str, authlevel: str) -> bool:
         password_hash = generate_password_hash(password)
 
         if username in self.__auth:
@@ -170,7 +172,7 @@ class AuthManager(component.Component):
             log.exception(ex)
             raise ex
 
-    def update_account(self, username, password, authlevel):
+    def update_account(self, username: str, password: str, authlevel: str) -> bool:
         # If the username is 'localclient', we don't hash the password
         # to keep compatability with the current localclient autologin.
         password_hash = None
@@ -190,7 +192,7 @@ class AuthManager(component.Component):
             log.exception(ex)
             raise ex
 
-    def remove_account(self, username):
+    def remove_account(self, username: str) -> Literal[True]:
         if username not in self.__auth:
             raise AuthManagerError('Username not known', username)
         elif username == component.get('RPCServer').get_session_user():
@@ -202,7 +204,7 @@ class AuthManager(component.Component):
         self.write_auth_file()
         return True
 
-    def write_auth_file(self):
+    def write_auth_file(self) -> None:
         filename = 'auth'
         filepath = os.path.join(configmanager.get_config_dir(), filename)
         filepath_bak = filepath + '.bak'


### PR DESCRIPTION
Adds better type annotations to authmanager for easier extension/development/maintenance. Also cleaned up a few implicit string concatenations used in logging and added override flags where appropriate.

Hoping to use this as a basis for integrating an automated upgrade path for plaintext passwords-->hashes as disccussed in #484.

No functional changes, all tests still passing.