### PR TITLE
Remove package_resources dependency

### DIFF
--- a/deluge/pluginmanagerbase.py
+++ b/deluge/pluginmanagerbase.py
@@ -10,10 +10,13 @@
 """PluginManagerBase"""
 
 import email
+import importlib.metadata
 import logging
 import os.path
+import sys
+from typing import NamedTuple
 
-import pkg_resources
+import pkginfo
 from twisted.internet import defer
 from twisted.python.failure import Failure
 
@@ -44,6 +47,18 @@ triggered this warning, please report to it's author.
 If you're the developer, please take a look at the plugins hosted on deluge's
 git repository to have an idea of what needs to be changed.
 """
+
+
+# This class exists largely to replicate
+# the metadata provided by pkg_resources
+class EggPlugin(NamedTuple):
+    name: str
+    version: str
+    location: str
+    author: str
+    author_email: str
+    homepage: str
+    description: str
 
 
 class PluginManagerBase:
@@ -85,11 +100,28 @@ class PluginManagerBase:
 
     def get_available_plugins(self):
         """Returns a list of the available plugins name"""
+        return [p.name for p in self.available_plugins]
         return self.available_plugins
 
     def get_enabled_plugins(self):
         """Returns a list of enabled plugins"""
         return list(self.plugins)
+
+    def _get_egg_metadata(self, egg_path: str) -> EggPlugin:
+        pkg_info = pkginfo.BDist(egg_path)
+        if pkg_info.name is None or pkg_info.version is None:
+            raise ValueError(
+                f'Invalid .egg plugin {egg_path}: No name or version found'
+            )
+        return EggPlugin(
+            name=pkg_info.name,
+            version=pkg_info.version,
+            location=egg_path,
+            author=pkg_info.author or '',
+            author_email=pkg_info.author_email or '',
+            homepage=pkg_info.home_page or '',
+            description=pkg_info.description or '',
+        )
 
     def scan_for_plugins(self):
         """Scans for available plugins"""
@@ -102,21 +134,24 @@ class PluginManagerBase:
         ]
         plugin_dirs = [base_dir, user_dir] + base_subdir
 
-        for dirname in plugin_dirs:
-            pkg_resources.working_set.add_entry(dirname)
-        self.pkg_env = pkg_resources.Environment(
-            plugin_dirs, platform=None, python=None
-        )
-
         self.available_plugins = []
-        for name in self.pkg_env:
-            log.debug(
-                'Found plugin: %s %s at %s',
-                self.pkg_env[name][0].project_name,
-                self.pkg_env[name][0].version,
-                self.pkg_env[name][0].location,
+        for dirname in plugin_dirs:
+            for f in os.listdir(dirname):
+                if f.endswith('.egg'):
+                    full_path = os.path.join(dirname, f)
+                    if full_path not in sys.path:
+                        try:
+                            self.available_plugins.append(
+                                self._get_egg_metadata(full_path)
+                            )
+                            sys.path.insert(0, full_path)
+                        except Exception as e:
+                            log.warning(f'Failed to load .egg plugin {full_path}: {e}')
+
+        for plugin in self.available_plugins:
+            log.info(
+                f'Found plugin: {plugin.name} {plugin.version} at {plugin.location}'
             )
-            self.available_plugins.append(self.pkg_env[name][0].project_name)
 
     def enable_plugin(self, plugin_name):
         """Enable a plugin.
@@ -129,7 +164,7 @@ class PluginManagerBase:
                 whether the plugin is enabled or not.
 
         """
-        if plugin_name not in self.available_plugins:
+        if plugin_name not in [plugin.name for plugin in self.available_plugins]:
             log.warning('Cannot enable non-existent plugin %s', plugin_name)
             return defer.succeed(False)
 
@@ -138,28 +173,32 @@ class PluginManagerBase:
             return defer.succeed(True)
 
         plugin_name = plugin_name.replace(' ', '-')
-        egg = self.pkg_env[plugin_name][0]
-        # Activate is required by non-namespace plugins.
-        egg.activate()
+        log.debug(f'Enabling plugin: {plugin_name}')
+        egg = None
+        for plugin in self.available_plugins:
+            if plugin.name == plugin_name:
+                egg = plugin
+                break
+        if egg is None:
+            raise ValueError(f'Could not find egg for plugin {plugin_name}')
         return_d = defer.succeed(True)
+        entry_points = importlib.metadata.entry_points(name=egg.name)
 
-        for name in egg.get_entry_map(self.entry_name):
+        for ep in entry_points:
             try:
-                cls = egg.load_entry_point(self.entry_name, name)
+                cls = ep.load()
                 instance = cls(plugin_name.replace('-', '_'))
             except component.ComponentAlreadyRegistered as ex:
                 log.error(ex)
                 return defer.succeed(False)
             except Exception as ex:
-                log.error(
-                    'Unable to instantiate plugin %r from %r!', name, egg.location
-                )
+                log.error('Unable to instantiate plugin from %r!', egg.location)
                 log.exception(ex)
                 continue
             try:
                 return_d = defer.maybeDeferred(instance.enable)
             except Exception as ex:
-                log.error('Unable to enable plugin: %s', name)
+                log.error('Unable to enable plugin: %s', egg.location)
                 log.exception(ex)
                 return_d = defer.fail(False)
 
@@ -167,7 +206,7 @@ class PluginManagerBase:
                 import warnings
 
                 warnings.warn_explicit(
-                    DEPRECATION_WARNING % name,
+                    DEPRECATION_WARNING % ep.name,
                     DeprecationWarning,
                     instance.__module__,
                     0,
@@ -254,20 +293,33 @@ class PluginManagerBase:
         d.addBoth(on_disabled)
         return d
 
-    def get_plugin_info(self, name):
+    def _get_plugin(self, name: str) -> EggPlugin | None:
+        for plugin in self.available_plugins:
+            if plugin.name == name:
+                return plugin
+        return None
+
+    def get_plugin_info(self, name) -> dict[str, str]:
         """Returns a dictionary of plugin info from the metadata"""
 
-        if not self.pkg_env[name]:
+        plugin = self._get_plugin(name)
+        if not plugin:
             log.warning('Failed to retrieve info for plugin: %s', name)
             info = {}.fromkeys(METADATA_KEYS, '')
             info['Name'] = info['Version'] = 'not available'
             return info
 
-        pkg_info = self.pkg_env[name][0].get_metadata('PKG-INFO')
-        return self.parse_pkg_info(pkg_info)
+        info: dict[str, str] = {
+            'Author': plugin.author,
+            'Version': plugin.version,
+            'Author-email': plugin.author_email,
+            'Home-page': plugin.homepage,
+            'Description': plugin.description,
+        }
+        return info
 
     @staticmethod
-    def parse_pkg_info(pkg_info):
+    def parse_pkg_info(pkg_info) -> dict[str, str]:
         metadata_msg = email.message_from_string(pkg_info)
         metadata_ver = metadata_msg.get('Metadata-Version')
 

--- a/deluge/plugins/AutoAdd/deluge_autoadd/common.py
+++ b/deluge/plugins/AutoAdd/deluge_autoadd/common.py
@@ -13,9 +13,9 @@
 
 import os.path
 
-from pkg_resources import resource_filename
+from deluge.plugins.backports import resource_filename
 
 
-def get_resource(filename, subdir=False):
+def get_resource(filename: str, subdir: bool = False) -> str:
     folder = os.path.join('data', 'autoadd_options') if subdir else 'data'
     return resource_filename(__package__, os.path.join(folder, filename))

--- a/deluge/plugins/AutoAdd/deluge_autoadd/core.py
+++ b/deluge/plugins/AutoAdd/deluge_autoadd/core.py
@@ -413,7 +413,7 @@ class Core(CorePluginBase):
         session_auth_level = self.rpcserver.get_session_auth_level()
         if session_auth_level == AUTH_LEVEL_ADMIN:
             log.debug(
-                'Current logged in user %s is an ADMIN, send all ' 'watchdirs',
+                'Current logged in user %s is an ADMIN, send all watchdirs',
                 session_user,
             )
             return self.watchdirs
@@ -424,8 +424,7 @@ class Core(CorePluginBase):
                 watchdirs[watchdir_id] = watchdir
 
         log.debug(
-            'Current logged in user %s is not an ADMIN, send only '
-            'their watchdirs: %s',
+            'Current logged in user %s is not an ADMIN, send only their watchdirs: %s',
             session_user,
             list(watchdirs),
         )

--- a/deluge/plugins/Blocklist/deluge_blocklist/common.py
+++ b/deluge/plugins/Blocklist/deluge_blocklist/common.py
@@ -11,14 +11,17 @@
 # See LICENSE for more details.
 #
 
+import logging
 import os.path
 from functools import wraps
 from sys import exc_info
 
-from pkg_resources import resource_filename
+from deluge.plugins.backports import resource_filename
+
+log = logging.getLogger(__name__)
 
 
-def get_resource(filename):
+def get_resource(filename: str) -> str:
     return resource_filename(__package__, os.path.join('data', filename))
 
 

--- a/deluge/plugins/Execute/deluge_execute/common.py
+++ b/deluge/plugins/Execute/deluge_execute/common.py
@@ -11,10 +11,13 @@
 # See LICENSE for more details.
 #
 
+import logging
 import os.path
 
-from pkg_resources import resource_filename
+from deluge.plugins.backports import resource_filename
+
+log = logging.getLogger(__name__)
 
 
-def get_resource(filename):
+def get_resource(filename: str) -> str:
     return resource_filename(__package__, os.path.join('data', filename))

--- a/deluge/plugins/Extractor/deluge_extractor/common.py
+++ b/deluge/plugins/Extractor/deluge_extractor/common.py
@@ -13,8 +13,8 @@
 
 import os.path
 
-from pkg_resources import resource_filename
+from deluge.plugins.backports import resource_filename
 
 
-def get_resource(filename):
+def get_resource(filename: str) -> str:
     return resource_filename(__package__, os.path.join('data', filename))

--- a/deluge/plugins/Label/deluge_label/common.py
+++ b/deluge/plugins/Label/deluge_label/common.py
@@ -13,8 +13,8 @@
 
 import os.path
 
-from pkg_resources import resource_filename
+from deluge.plugins.backports import resource_filename
 
 
-def get_resource(filename):
+def get_resource(filename: str) -> str:
     return resource_filename(__package__, os.path.join('data', filename))

--- a/deluge/plugins/Notifications/deluge_notifications/common.py
+++ b/deluge/plugins/Notifications/deluge_notifications/common.py
@@ -14,16 +14,16 @@
 import logging
 import os.path
 
-from pkg_resources import resource_filename
 from twisted.internet import defer
 
 from deluge import component
 from deluge.event import known_events
+from deluge.plugins.backports import resource_filename
 
 log = logging.getLogger(__name__)
 
 
-def get_resource(filename):
+def get_resource(filename: str) -> str:
     return resource_filename(__package__, os.path.join('data', filename))
 
 

--- a/deluge/plugins/Notifications/deluge_notifications/gtkui.py
+++ b/deluge/plugins/Notifications/deluge_notifications/gtkui.py
@@ -225,9 +225,7 @@ class GtkUiNotifications(CustomNotifications):
         log.debug('Failed to get torrent status to be able to show the popup')
 
     def _on_torrent_finished_event_got_torrent_status(self, torrent_status):
-        log.debug(
-            'Handler for TorrentFinishedEvent GTKUI called. ' 'Got Torrent Status'
-        )
+        log.debug('Handler for TorrentFinishedEvent GTKUI called. Got Torrent Status')
         title = _('Finished Torrent')
         torrent_status['num_files'] = torrent_status['file_progress'].count(1.0)
         message = (

--- a/deluge/plugins/Scheduler/deluge_scheduler/common.py
+++ b/deluge/plugins/Scheduler/deluge_scheduler/common.py
@@ -13,8 +13,8 @@
 
 import os.path
 
-from pkg_resources import resource_filename
+from deluge.plugins.backports import resource_filename
 
 
-def get_resource(filename):
+def get_resource(filename: str) -> str:
     return resource_filename(__package__, os.path.join('data', filename))

--- a/deluge/plugins/Stats/deluge_stats/common.py
+++ b/deluge/plugins/Stats/deluge_stats/common.py
@@ -13,8 +13,8 @@
 
 import os.path
 
-from pkg_resources import resource_filename
+from deluge.plugins.backports import resource_filename
 
 
-def get_resource(filename):
+def get_resource(filename: str) -> str:
     return resource_filename(__package__, os.path.join('data', filename))

--- a/deluge/plugins/Toggle/deluge_toggle/common.py
+++ b/deluge/plugins/Toggle/deluge_toggle/common.py
@@ -13,8 +13,8 @@
 
 import os.path
 
-from pkg_resources import resource_filename
+from deluge.plugins.backports import resource_filename
 
 
-def get_resource(filename):
+def get_resource(filename: str) -> str:
     return resource_filename(__package__, os.path.join('data', filename))

--- a/deluge/plugins/WebUi/deluge_webui/common.py
+++ b/deluge/plugins/WebUi/deluge_webui/common.py
@@ -13,8 +13,8 @@
 
 import os.path
 
-from pkg_resources import resource_filename
+from deluge.plugins.backports import resource_filename
 
 
-def get_resource(filename):
+def get_resource(filename: str) -> str:
     return resource_filename(__package__, os.path.join('data', filename))

--- a/deluge/plugins/backports.py
+++ b/deluge/plugins/backports.py
@@ -1,0 +1,41 @@
+import importlib.resources
+import logging
+import os
+import pathlib
+from collections.abc import Callable
+
+import platformdirs
+
+log = logging.getLogger(__name__)
+
+
+def _get_file(reader: Callable[..., bytes], target: pathlib.Path) -> pathlib.Path:
+    file_obj = open(target, 'wb')
+    fd = file_obj.fileno()
+    _ = os.write(fd, reader())
+    os.close(fd)
+    del reader
+    return pathlib.Path(target)
+
+
+def _get_target_path(archive_name: str, resource_name: str) -> pathlib.Path:
+    target_path = _get_cache_dir() / f'{archive_name}-tmp' / resource_name
+    os.makedirs(target_path.parent, exist_ok=True)
+    return target_path
+
+
+def _get_cache_dir() -> pathlib.Path:
+    if os.environ.get('PYTHON_EGG_CACHE'):
+        return pathlib.Path(os.environ['PYTHON_EGG_CACHE'])
+    return pathlib.Path(platformdirs.user_cache_dir('Python-Eggs'))
+
+
+def resource_filename(package: str, resource_name: str) -> str:
+    """Returns a file system path for the specified .egg plugin resource."""
+    log.warning(f'Getting resource for {resource_name} in package {package}')
+    target_path = _get_target_path(package, resource_name)
+
+    fp = importlib.resources.files(package)
+    reader = fp.joinpath(resource_name).read_bytes
+    usable_path = _get_file(reader, target_path)
+    return usable_path.as_posix()

--- a/deluge/ui/ui_entry.py
+++ b/deluge/ui/ui_entry.py
@@ -16,8 +16,7 @@ import argparse
 import logging
 import os
 import sys
-
-import pkg_resources
+from importlib.metadata import entry_points
 
 import deluge.common
 import deluge.configmanager
@@ -35,7 +34,7 @@ def start_ui():
 
     # Get the registered UI entry points
     ui_entrypoints = {}
-    for entrypoint in pkg_resources.iter_entry_points('deluge.ui'):
+    for entrypoint in entry_points(group='deluge.ui'):
         try:
             ui_entrypoints[entrypoint.name] = entrypoint.load()
         except ImportError:

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ zope.interface>=4.4.2
 distro; 'linux' in sys_platform or 'bsd' in sys_platform
 pygeoip
 ifaddr>=0.2.0
+pkginfo>=1.12.1

--- a/setup.py
+++ b/setup.py
@@ -293,6 +293,7 @@ class BuildPlugins(Command):
                         + path
                         + '&& '
                         + sys.executable
+                        # TODO: This is a deprecated call
                         + ' setup.py develop --install-dir=%s' % self.install_dir
                     )
                 elif self.develop:
@@ -300,6 +301,7 @@ class BuildPlugins(Command):
                         'cd ' + path + '&& ' + sys.executable + ' setup.py develop'
                     )
                 else:
+                    # TODO: This is a deprecated call
                     os.system(
                         'cd '
                         + path


### PR DESCRIPTION
Use of `pkg_resources` is deprecated in favour of
`importlib.resources` and `importlib.metadata` according to https://setuptools.pypa.io/en/latest/pkg_resources.html. Running Deluge currently triggers warnings that the `pkg_resources` library is likely to be removed as early as October 2025.

Our plugin system still relies on `.egg` files, and has relied on `pkg_resources` to expose plugin metadata and resource files. We can use the `pkg_info` to pull the metadata from the .egg files and importlib for the rest. This allows for users to continue using legacy plugins while a more modern plugin framework is developed.

This does unfortunately necessitate the inclusion of the `pkg_info` library, however this seems like a reasonable trade off given that it is (currently) well maintained. There may also be other possible solutions using the importlib.metadata library or reimplementing a minimal version of the `pkg_info` `BDist` functionality.