### PR TITLE
Correct installation instructions for FreeBSD

### DIFF
--- a/docs/source/intro/01-install.md
+++ b/docs/source/intro/01-install.md
@@ -61,7 +61,7 @@ See [Alternative Installs](#alternative-installs)
 ## <i class="icon-freebsd"></i> FreeBSD
 
 ```
-pkg add deluge
+pkg install deluge
 ```
 
 [Package details](https://www.freshports.org/net-p2p/deluge/)


### PR DESCRIPTION
Correct installation instructions for FreeBSD:
```
pkg install deluge
```

`pkg add` used if the tarball is located locally on the file system or at a specific URL.

See: https://man.freebsd.org/cgi/man.cgi?pkg(8)