### PR TITLE
authmanager mtime_ns fix

### DIFF
--- a/deluge/core/authmanager.py
+++ b/deluge/core/authmanager.py
@@ -87,7 +87,7 @@ class AuthManager(component.Component):
             self.__load_auth_file()
             return
 
-        auth_file_modification_time = os.stat(auth_file).st_mtime
+        auth_file_modification_time = os.stat(auth_file).st_mtime_ns
         if self.__auth_modification_time != auth_file_modification_time:
             log.info('Auth file changed, reloading it!')
             self.__load_auth_file()


### PR DESCRIPTION
the log is flooded with
```
22:11:01 [INFO    ][deluge.core.authmanager       :1655] Auth file changed, reloading it!
```

the commit 0d9efb0b51fd7723f006899fab2e8ef546bbdd52 is incomplete