### PR TITLE
Add instructions for getting the latest release tag

### DIFF
--- a/docs/source/contributing/code.md
+++ b/docs/source/contributing/code.md
@@ -14,9 +14,9 @@
 - Fork us on [GitHub](https://github.com/deluge-torrent/deluge).
 - Clone your repository.
 - Ensure you have the latest version tag from the main repository (required for versioning):
-  - `LATEST_TAG=$(git ls-remote --tags --refs upstream 'deluge-[0-9]*' | cut -f2 | sed 's|^refs/tags/||' | sort -V | tail -n1)`
-  - `git fetch upstream tag "${LATEST_TAG?}"`
-  - `git push origin tag "${LATEST_TAG?}"`
+  - `git remote add upstream https://github.com/deluge-torrent/deluge.git`
+  - `git fetch upstream --tags`
+  - `git push origin --tags`
 - Create a feature branch for your issue.
 - Apply your changes:
   - Add them, and then commit them to your branch.

--- a/docs/source/contributing/code.md
+++ b/docs/source/contributing/code.md
@@ -13,6 +13,10 @@
 
 - Fork us on [GitHub](https://github.com/deluge-torrent/deluge).
 - Clone your repository.
+- Ensure you have the latest version tag from the main repository (required for versioning):
+  - `LATEST_TAG=$(git ls-remote --tags --refs upstream 'deluge-[0-9]*' | cut -f2 | sed 's|^refs/tags/||' | sort -V | tail -n1)`
+  - `git fetch upstream tag "${LATEST_TAG?}"`
+  - `git push origin tag "${LATEST_TAG?}"`
 - Create a feature branch for your issue.
 - Apply your changes:
   - Add them, and then commit them to your branch.

--- a/version.py
+++ b/version.py
@@ -65,7 +65,10 @@ def get_version(prefix='deluge-', suffix='.dev0'):
     if not version:
         version = release_version
     if not version:
-        raise ValueError('Cannot find the version number!')
+        raise ValueError(
+            'Cannot find the version number! If you are using a git clone, '
+            'please ensure you have tags fetched (e.g., git fetch --tags).'
+        )
 
     if version != release_version:
         with open(VERSION_FILE, 'w') as f:


### PR DESCRIPTION
Forks of the main repo may not include tags, and so the CI fails since the CI environment also doesn't have the RELEASE-VERSION file. This adds instructions to the pull request documentation to fix this issue. It also updates the error in `version.py` to mention this issue.