### PR TITLE
fix: close file handle in setup.py to prevent resource leak

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ import sys
 from distutils.command.build import build as _build
 from distutils.command.clean import clean as _clean
 from distutils.command.install_data import install_data as _install_data
+from pathlib import Path
 from shutil import rmtree, which
 
 from setuptools import Command, find_packages, setup
@@ -570,7 +571,7 @@ setup(
     maintainer='Calum Lind',
     maintainer_email='calumlind+deluge@gmail.com',
     keywords='torrent bittorrent p2p fileshare filesharing',
-    long_description=open('README.md').read(),
+    long_description=Path('README.md').read_text(encoding='utf-8'),
     long_description_content_type='text/markdown',
     url='https://deluge-torrent.org',
     project_urls={


### PR DESCRIPTION
## Summary

Fixes a resource leak in setup.py where a file handle is opened but never closed.

## Changes

- Changed `open('README.md').read()` to `Path('README.md').read_text(encoding='utf-8')`
- Added `from pathlib import Path` import
- Ensures proper file handle cleanup

## Issue

The current code on line 573:

```python
long_description=open('README.md').read(),
```

Opens a file handle but never closes it. While Python's garbage collector will eventually close it, this is not guaranteed to happen immediately and can lead to:

1. File descriptor exhaustion in environments with many setup.py invocations
2. Potential file locking issues on Windows systems
3. Non-deterministic resource cleanup

## Solution

Using `Path.read_text()` provides the same functionality while ensuring the file handle is properly closed immediately after reading.

## Testing

- Verified setup.py still works correctly
- No functional changes to the package installation process