### PR TITLE
fix: close file handles in gen_web_gettext.py to prevent resource leak

### DIFF
--- a/gen_web_gettext.py
+++ b/gen_web_gettext.py
@@ -54,21 +54,23 @@ def check_missing_markup(js_dir):
         for filename in files:
             if os.path.splitext(filename)[1] != '.js':
                 continue
-            for lineno, line in enumerate(open(os.path.join(root, filename))):
-                for match in string_re.finditer(line):
-                    for string in match.groups():
-                        # Ignore string that contains only digits or specificied strings in skip.
-                        if (
-                            not string
-                            or string.split("'")[1].isdigit()
-                            or any(x in string for x in skip)
-                        ):
-                            continue
-                        locations = strings.get(string, [])
-                        locations.append(
-                            (os.path.join(root, filename), str(lineno + 1))
-                        )
-                        strings[string] = locations
+            filepath = os.path.join(root, filename)
+            with open(filepath) as f:
+                for lineno, line in enumerate(f):
+                    for match in string_re.finditer(line):
+                        for string in match.groups():
+                            # Ignore string that contains only digits or specificied strings in skip.
+                            if (
+                                not string
+                                or string.split("'")[1].isdigit()
+                                or any(x in string for x in skip)
+                            ):
+                                continue
+                            locations = strings.get(string, [])
+                            locations.append(
+                                (filepath, str(lineno + 1))
+                            )
+                            strings[string] = locations
     return strings
 
 


### PR DESCRIPTION
## Summary

Fixes a resource leak in gen_web_gettext.py where JavaScript files are opened but never explicitly closed.

## Changes

- Wrapped file opening in a context manager (with statement)
- Extracted filepath to a variable for clarity and reuse
- Ensures proper file handle cleanup for all opened JavaScript files

## Issue

The current code on line 57:

```python
for lineno, line in enumerate(open(os.path.join(root, filename))):
```

Opens file handles but never explicitly closes them. When processing many JavaScript files, this can lead to:

1. File descriptor exhaustion
2. Potential file locking issues on Windows
3. Non-deterministic resource cleanup
4. Possible issues in long-running processes

## Solution

Using a context manager (`with` statement) ensures file handles are properly closed immediately after use:

```python
filepath = os.path.join(root, filename)
with open(filepath) as f:
    for lineno, line in enumerate(f):
```

This is the recommended Python pattern for file I/O and guarantees cleanup even if exceptions occur.

## Testing

- Verified gen_web_gettext.py still works correctly
- No functional changes to the gettext extraction process
- Better resource management for processing directories with many JS files