### PR TITLE
[Core] Replace deprecated pkg_resources with importlib.metadata

### DIFF
--- a/deluge/common.py
+++ b/deluge/common.py
@@ -34,9 +34,13 @@ from deluge.decorators import deprecated
 from deluge.error import InvalidPathError
 
 try:
-    from importlib.metadata import distribution
+    from importlib import metadata
 except ImportError:
-    from pkg_resources import get_distribution as distribution
+    import importlib_metadata as metadata  # type: ignore
+
+
+def distribution(package_name):
+    return metadata.distribution(package_name)
 
 
 try:

--- a/deluge/pluginmanagerbase.py
+++ b/deluge/pluginmanagerbase.py
@@ -12,8 +12,13 @@
 import email
 import logging
 import os.path
+import sys
 
-import pkg_resources
+try:
+    from importlib import metadata
+except ImportError:
+    import importlib_metadata as metadata  # type: ignore
+
 from twisted.internet import defer
 from twisted.python.failure import Failure
 
@@ -103,20 +108,41 @@ class PluginManagerBase:
         plugin_dirs = [base_dir, user_dir] + base_subdir
 
         for dirname in plugin_dirs:
-            pkg_resources.working_set.add_entry(dirname)
-        self.pkg_env = pkg_resources.Environment(
-            plugin_dirs, platform=None, python=None
-        )
+            if dirname not in sys.path:
+                sys.path.insert(0, dirname)
+
+        self.pkg_env = {}
+        for dirname in plugin_dirs:
+            # metadata.distributions() path= is only available in Python 3.10+
+            try:
+                dists = metadata.distributions(path=[dirname])
+            except TypeError:
+                # Python 3.9 workaround
+                dists = metadata.MetadataPathFinder.find_distributions(
+                    context=type('Context', (object,), {'path': [dirname]})
+                )
+
+            for dist in dists:
+                # Use project name from metadata
+                name = dist.metadata.get('Name')
+                if not name:
+                    continue
+                # pkg_resources uses normalized names for keys
+                key = name.replace(' ', '-').replace('_', '-').lower()
+                if key not in self.pkg_env:
+                    self.pkg_env[key] = []
+                self.pkg_env[key].append(dist)
 
         self.available_plugins = []
         for name in self.pkg_env:
+            dist = self.pkg_env[name][0]
             log.debug(
                 'Found plugin: %s %s at %s',
-                self.pkg_env[name][0].project_name,
-                self.pkg_env[name][0].version,
-                self.pkg_env[name][0].location,
+                dist.metadata.get('Name'),
+                dist.version,
+                getattr(dist, 'path', 'unknown'),
             )
-            self.available_plugins.append(self.pkg_env[name][0].project_name)
+            self.available_plugins.append(dist.metadata.get('Name'))
 
     def enable_plugin(self, plugin_name):
         """Enable a plugin.
@@ -137,22 +163,35 @@ class PluginManagerBase:
             log.warning('Cannot enable already enabled plugin %s', plugin_name)
             return defer.succeed(True)
 
-        plugin_name = plugin_name.replace(' ', '-')
-        egg = self.pkg_env[plugin_name][0]
-        # Activate is required by non-namespace plugins.
-        egg.activate()
+        plugin_name_normalized = plugin_name.replace(' ', '-')
+        key = plugin_name_normalized.replace('_', '-').lower()
+        dist = self.pkg_env[key][0]
+        # Activation not directly supported by importlib.metadata,
+        # but adding to sys.path in scan_for_plugins should be enough.
         return_d = defer.succeed(True)
 
-        for name in egg.get_entry_map(self.entry_name):
+        entry_points = dist.entry_points
+        # Filter entry points by group
+        if hasattr(entry_points, 'select'):  # 3.10+
+            selected_entry_points = entry_points.select(group=self.entry_name)
+        else:  # 3.9
+            selected_entry_points = [
+                ep for ep in entry_points if ep.group == self.entry_name
+            ]
+
+        for entry_point in selected_entry_points:
+            name = entry_point.name
             try:
-                cls = egg.load_entry_point(self.entry_name, name)
-                instance = cls(plugin_name.replace('-', '_'))
+                cls = entry_point.load()
+                instance = cls(plugin_name_normalized.replace('-', '_'))
             except component.ComponentAlreadyRegistered as ex:
                 log.error(ex)
                 return defer.succeed(False)
             except Exception as ex:
                 log.error(
-                    'Unable to instantiate plugin %r from %r!', name, egg.location
+                    'Unable to instantiate plugin %r from %r!',
+                    name,
+                    getattr(dist, 'path', 'unknown'),
                 )
                 log.exception(ex)
                 continue
@@ -257,18 +296,20 @@ class PluginManagerBase:
     def get_plugin_info(self, name):
         """Returns a dictionary of plugin info from the metadata"""
 
-        if not self.pkg_env[name]:
+        if name not in self.pkg_env or not self.pkg_env[name]:
             log.warning('Failed to retrieve info for plugin: %s', name)
             info = {}.fromkeys(METADATA_KEYS, '')
             info['Name'] = info['Version'] = 'not available'
             return info
 
-        pkg_info = self.pkg_env[name][0].get_metadata('PKG-INFO')
-        return self.parse_pkg_info(pkg_info)
+        dist = self.pkg_env[name][0]
+        return self.parse_pkg_info(dist.metadata)
 
     @staticmethod
-    def parse_pkg_info(pkg_info):
-        metadata_msg = email.message_from_string(pkg_info)
+    def parse_pkg_info(metadata_msg):
+        if isinstance(metadata_msg, str):
+            metadata_msg = email.message_from_string(metadata_msg)
+
         metadata_ver = metadata_msg.get('Metadata-Version')
 
         info = {key: metadata_msg.get(key, '') for key in METADATA_KEYS}

--- a/deluge/plugins/AutoAdd/deluge_autoadd/common.py
+++ b/deluge/plugins/AutoAdd/deluge_autoadd/common.py
@@ -13,9 +13,9 @@
 
 import os.path
 
-from pkg_resources import resource_filename
+import deluge.common
 
 
 def get_resource(filename, subdir=False):
     folder = os.path.join('data', 'autoadd_options') if subdir else 'data'
-    return resource_filename(__package__, os.path.join(folder, filename))
+    return deluge.common.resource_filename(__package__, os.path.join(folder, filename))

--- a/deluge/plugins/Blocklist/deluge_blocklist/common.py
+++ b/deluge/plugins/Blocklist/deluge_blocklist/common.py
@@ -15,11 +15,11 @@ import os.path
 from functools import wraps
 from sys import exc_info
 
-from pkg_resources import resource_filename
+import deluge.common
 
 
 def get_resource(filename):
-    return resource_filename(__package__, os.path.join('data', filename))
+    return deluge.common.resource_filename(__package__, os.path.join('data', filename))
 
 
 def raises_errors_as(error):

--- a/deluge/plugins/Execute/deluge_execute/common.py
+++ b/deluge/plugins/Execute/deluge_execute/common.py
@@ -13,8 +13,8 @@
 
 import os.path
 
-from pkg_resources import resource_filename
+import deluge.common
 
 
 def get_resource(filename):
-    return resource_filename(__package__, os.path.join('data', filename))
+    return deluge.common.resource_filename(__package__, os.path.join('data', filename))

--- a/deluge/plugins/Extractor/deluge_extractor/common.py
+++ b/deluge/plugins/Extractor/deluge_extractor/common.py
@@ -13,8 +13,8 @@
 
 import os.path
 
-from pkg_resources import resource_filename
+import deluge.common
 
 
 def get_resource(filename):
-    return resource_filename(__package__, os.path.join('data', filename))
+    return deluge.common.resource_filename(__package__, os.path.join('data', filename))

--- a/deluge/plugins/Label/deluge_label/common.py
+++ b/deluge/plugins/Label/deluge_label/common.py
@@ -13,8 +13,8 @@
 
 import os.path
 
-from pkg_resources import resource_filename
+import deluge.common
 
 
 def get_resource(filename):
-    return resource_filename(__package__, os.path.join('data', filename))
+    return deluge.common.resource_filename(__package__, os.path.join('data', filename))

--- a/deluge/plugins/Notifications/deluge_notifications/common.py
+++ b/deluge/plugins/Notifications/deluge_notifications/common.py
@@ -14,7 +14,7 @@
 import logging
 import os.path
 
-from pkg_resources import resource_filename
+import deluge.common
 from twisted.internet import defer
 
 from deluge import component
@@ -24,7 +24,7 @@ log = logging.getLogger(__name__)
 
 
 def get_resource(filename):
-    return resource_filename(__package__, os.path.join('data', filename))
+    return deluge.common.resource_filename(__package__, os.path.join('data', filename))
 
 
 class CustomNotifications:

--- a/deluge/plugins/Scheduler/deluge_scheduler/common.py
+++ b/deluge/plugins/Scheduler/deluge_scheduler/common.py
@@ -13,8 +13,8 @@
 
 import os.path
 
-from pkg_resources import resource_filename
+import deluge.common
 
 
 def get_resource(filename):
-    return resource_filename(__package__, os.path.join('data', filename))
+    return deluge.common.resource_filename(__package__, os.path.join('data', filename))

--- a/deluge/plugins/Stats/deluge_stats/common.py
+++ b/deluge/plugins/Stats/deluge_stats/common.py
@@ -13,8 +13,8 @@
 
 import os.path
 
-from pkg_resources import resource_filename
+import deluge.common
 
 
 def get_resource(filename):
-    return resource_filename(__package__, os.path.join('data', filename))
+    return deluge.common.resource_filename(__package__, os.path.join('data', filename))

--- a/deluge/plugins/Toggle/deluge_toggle/common.py
+++ b/deluge/plugins/Toggle/deluge_toggle/common.py
@@ -13,8 +13,8 @@
 
 import os.path
 
-from pkg_resources import resource_filename
+import deluge.common
 
 
 def get_resource(filename):
-    return resource_filename(__package__, os.path.join('data', filename))
+    return deluge.common.resource_filename(__package__, os.path.join('data', filename))

--- a/deluge/plugins/WebUi/deluge_webui/common.py
+++ b/deluge/plugins/WebUi/deluge_webui/common.py
@@ -13,8 +13,8 @@
 
 import os.path
 
-from pkg_resources import resource_filename
+import deluge.common
 
 
 def get_resource(filename):
-    return resource_filename(__package__, os.path.join('data', filename))
+    return deluge.common.resource_filename(__package__, os.path.join('data', filename))

--- a/deluge/scripts/create_plugin.py
+++ b/deluge/scripts/create_plugin.py
@@ -226,11 +226,11 @@ COMMON = """from __future__ import unicode_literals
 
 import os.path
 
-from pkg_resources import resource_filename
+import deluge.common
 
 
 def get_resource(filename):
-    return resource_filename(__package__, os.path.join('data', filename))
+    return deluge.common.resource_filename(__package__, os.path.join('data', filename))
 """
 
 GTK3UI = """from __future__ import unicode_literals

--- a/deluge/ui/ui_entry.py
+++ b/deluge/ui/ui_entry.py
@@ -17,7 +17,10 @@ import logging
 import os
 import sys
 
-import pkg_resources
+try:
+    from importlib import metadata
+except ImportError:
+    import importlib_metadata as metadata  # type: ignore
 
 import deluge.common
 import deluge.configmanager
@@ -35,7 +38,13 @@ def start_ui():
 
     # Get the registered UI entry points
     ui_entrypoints = {}
-    for entrypoint in pkg_resources.iter_entry_points('deluge.ui'):
+    eps = metadata.entry_points()
+    if hasattr(eps, 'select'):  # 3.10+
+        ui_eps = eps.select(group='deluge.ui')
+    else:  # 3.9
+        ui_eps = eps.get('deluge.ui', [])
+
+    for entrypoint in ui_eps:
         try:
             ui_entrypoints[entrypoint.name] = entrypoint.load()
         except ImportError:


### PR DESCRIPTION
This fixes the ModuleNotFoundError: No module named 'pkg_resources' errors encountered in Python 3.13 environments, as setuptools has removed this module.

- Refactored plugin discovery in pluginmanagerbase.py
- Updated UI entry point loading in ui_entry.py
- Modernized resource handling in common.py and plugins
- Maintained compatibility with Python 3.9