### PR TITLE
Make mako optional in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -526,7 +526,6 @@ install_requires = [
     'rencode',
     'pyopenssl',
     'pyxdg',
-    'mako',
     'setuptools',
     "pywin32; sys_platform == 'win32'",
     "certifi; sys_platform == 'win32'",
@@ -534,10 +533,11 @@ install_requires = [
 ]
 extras_require = {
     'all': [
-        'setproctitle',
-        'pillow',
         'chardet',
         'ifaddr',
+        'mako',
+        'pillow',
+        'setproctitle',
     ]
 }
 


### PR DESCRIPTION
This attempts to fix https://dev.deluge-torrent.org/ticket/3542. I'm not very familiar with the build system, but it seems like this is straightforward.