### PR TITLE
docs: man pages: order log level consistently

### DIFF
--- a/docs/man/deluge-console.1
+++ b/docs/man/deluge-console.1
@@ -71,7 +71,7 @@ Output to specified logfile instead of stdout
 .TP
 .BI \-L\  loglevel \fR,\ \fB\-\-loglevel= loglevel
 Set the log level (default is error):
-.B none, info, warning, error, debug
+.B none, error, warning, info, debug
 .TP
 .B \-q\fR,\ \fB\-\-quiet
 Sets the log level to \fBnone\fR, same as \fB\-L none

--- a/docs/man/deluge-gtk.1
+++ b/docs/man/deluge-gtk.1
@@ -26,7 +26,7 @@ Output to specified logfile instead of stdout
 .TP
 .BI \-L\  loglevel \fR,\ \fB\-\-loglevel= loglevel
 Set the log level (default is error):
-.B none, info, warning, error, debug
+.B none, error, warning, info, debug
 .TP
 .B \-q\fR,\ \fB\-\-quiet
 Sets the log level to \fBnone\fR, same as \fB\-L none

--- a/docs/man/deluge-web.1
+++ b/docs/man/deluge-web.1
@@ -43,7 +43,7 @@ Output to specified logfile instead of stdout
 .TP
 .BI \-L\  loglevel \fR,\ \fB\-\-loglevel= loglevel
 Set the log level (default is error):
-.B none, info, warning, error, debug
+.B none, error, warning, info, debug
 .TP
 .B \-q\fR,\ \fB\-\-quiet
 Sets the log level to \fBnone\fR, same as \fB\-L none

--- a/docs/man/deluge.1
+++ b/docs/man/deluge.1
@@ -34,7 +34,7 @@ Output to specified logfile instead of stdout
 .TP
 .BI \-L\  loglevel \fR,\ \fB\-\-loglevel= loglevel
 Set the log level (default is error):
-.B none, info, warning, error, debug
+.B none, error, warning, info, debug
 .TP
 .B \-q\fR,\ \fB\-\-quiet
 Sets the log level to \fBnone\fR, same as \fB\-L none

--- a/docs/man/deluged.1
+++ b/docs/man/deluged.1
@@ -35,7 +35,7 @@ Output to specified logfile instead of stdout
 .TP
 .BI \-L\  loglevel \fR,\ \fB\-\-loglevel= loglevel
 Set the log level (default is error):
-.B none, info, warning, error, debug
+.B none, error, warning, info, debug
 .TP
 .B \-q\fR,\ \fB\-\-quiet
 Sets the log level to \fBnone\fR, same as \fB\-L none


### PR DESCRIPTION
I found the order of log levels in the man pages conusing. I reordered them so they are in strict order of increasing verbosity.