### PR TITLE
fix(gtk): prevent PathChooser Enter key hang inside dialogs

### DIFF
--- a/deluge/ui/gtk3/path_combo_chooser.py
+++ b/deluge/ui/gtk3/path_combo_chooser.py
@@ -1438,8 +1438,12 @@ class PathChooserComboBox(Gtk.Box, StoredValuesPopup, GObject.GObject):
             if self.auto_completer.auto_complete_enabled:
                 self.auto_completer.do_completion()
                 return True
-        # Show popup when Enter is pressed
+        # Show popup when Enter is pressed, unless inside a dialog where
+        # Enter should confirm the dialog instead of opening the popup.
         elif key_is_enter(keyval):
+            if isinstance(self.get_toplevel(), Gtk.Dialog):
+                self.get_toplevel().activate_default()
+                return True
             # This sets the toggle active which results in
             # on_button_toggle_dropdown_toggled being called which initiates the popup
             self.button_toggle.set_active(True)


### PR DESCRIPTION
## Problem

Pressing Enter in a PathChooser text entry inside a modal dialog (e.g. Add Torrent, Move Storage, Preferences) opens the stored-values popup, which calls `seat.grab()`. The nested grab deadlocks GTK's event loop, requiring a force quit.

## Fix

When the widget's toplevel is a `Gtk.Dialog`, skip the popup and call `activate_default()` to confirm the dialog. Simply propagating the event is not enough because `entry_text` doesn't have `activates-default` set.

Affects all five PathChooser uses in dialogs. The standalone use in OptionsTab (parented to the main window) is unaffected.

## Steps to reproduce

1. Open Add Torrent dialog (or Move Storage, or Preferences)
2. Focus the path entry
3. Press Enter
4. **Before fix:** UI freezes, must force quit
5. **After fix:** Dialog confirms normally