### PR TITLE
fix(label): move already finished torrents to label move completed path

### DIFF
--- a/deluge/plugins/Label/deluge_label/core.py
+++ b/deluge/plugins/Label/deluge_label/core.py
@@ -222,6 +222,16 @@ class Core(CorePluginBase):
                     'move_completed_path': options['move_completed_path'],
                 }
             )
+            # The torrent_finished alert only fires once, so move an already
+            # finished torrent to the label's move completed path now.
+            if (
+                options['move_completed']
+                and options['move_completed_path']
+                and torrent.is_finished
+                and torrent.options['download_location']
+                != options['move_completed_path']
+            ):
+                torrent.move_storage(options['move_completed_path'])
 
     def _unset_torrent_options(self, torrent_id, label_id):
         options = self.labels[label_id]

--- a/deluge/tests/plugins/test_label.py
+++ b/deluge/tests/plugins/test_label.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: GPL-3.0-or-later WITH GPL-3.0-linking-exception
+
+"""Tests for the Label plugin core."""
+
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+import deluge.common
+
+
+@pytest.fixture
+def label_core_module():
+    """Import the Label plugin core module from the plugin source tree."""
+    label_dir = Path(deluge.common.resource_filename('deluge', 'plugins')) / 'Label'
+    sys.path.insert(0, str(label_dir))
+    try:
+        from deluge_label import core
+
+        yield core
+    finally:
+        sys.path.remove(str(label_dir))
+
+
+@pytest.fixture
+def label_core(label_core_module):
+    """A Label plugin Core with mocked config and no component framework."""
+    plugin_core = label_core_module.Core.__new__(label_core_module.Core)
+    plugin_core.labels = {}
+    plugin_core.torrent_labels = {}
+    plugin_core.torrents = {}
+    plugin_core.config = mock.MagicMock()
+    plugin_core.core_cfg = mock.MagicMock()
+    return plugin_core
+
+
+def make_label(label_core_module, **options):
+    label_options = dict(label_core_module.OPTIONS_DEFAULTS)
+    label_options.update(options)
+    return label_options
+
+
+def make_torrent(is_finished, download_location='/downloads'):
+    torrent = mock.MagicMock()
+    torrent.is_finished = is_finished
+    torrent.options = {'download_location': download_location}
+    return torrent
+
+
+MOVE_OPTIONS = {
+    'apply_move_completed': True,
+    'move_completed': True,
+    'move_completed_path': '/downloads/movies',
+}
+
+
+def test_set_torrent_moves_already_finished_torrent(label_core_module, label_core):
+    """Applying a label after completion moves the data to the label path."""
+    label_core.labels['movies'] = make_label(label_core_module, **MOVE_OPTIONS)
+    torrent = make_torrent(is_finished=True)
+    label_core.torrents['t1'] = torrent
+
+    label_core.set_torrent('t1', 'movies')
+
+    torrent.move_storage.assert_called_once_with('/downloads/movies')
+
+
+def test_set_torrent_does_not_move_unfinished_torrent(label_core_module, label_core):
+    """An unfinished torrent is moved at completion by core, not by the plugin."""
+    label_core.labels['movies'] = make_label(label_core_module, **MOVE_OPTIONS)
+    torrent = make_torrent(is_finished=False)
+    label_core.torrents['t1'] = torrent
+
+    label_core.set_torrent('t1', 'movies')
+
+    torrent.move_storage.assert_not_called()
+
+
+def test_set_torrent_does_not_move_torrent_already_at_path(
+    label_core_module, label_core
+):
+    """No move when the torrent already lives at the label's move path."""
+    label_core.labels['movies'] = make_label(label_core_module, **MOVE_OPTIONS)
+    torrent = make_torrent(is_finished=True, download_location='/downloads/movies')
+    label_core.torrents['t1'] = torrent
+
+    label_core.set_torrent('t1', 'movies')
+
+    torrent.move_storage.assert_not_called()
+
+
+def test_set_torrent_does_not_move_without_move_completed(
+    label_core_module, label_core
+):
+    """No move when the label does not enable move_completed."""
+    label_core.labels['movies'] = make_label(
+        label_core_module,
+        apply_move_completed=True,
+        move_completed=False,
+        move_completed_path='/downloads/movies',
+    )
+    torrent = make_torrent(is_finished=True)
+    label_core.torrents['t1'] = torrent
+
+    label_core.set_torrent('t1', 'movies')
+
+    torrent.move_storage.assert_not_called()
+
+
+def test_set_torrent_does_not_move_with_empty_path(label_core_module, label_core):
+    """No move when the label's move path is empty."""
+    label_core.labels['movies'] = make_label(
+        label_core_module,
+        apply_move_completed=True,
+        move_completed=True,
+        move_completed_path='',
+    )
+    torrent = make_torrent(is_finished=True)
+    label_core.torrents['t1'] = torrent
+
+    label_core.set_torrent('t1', 'movies')
+
+    torrent.move_storage.assert_not_called()
+
+
+def test_set_options_moves_already_finished_labeled_torrents(
+    label_core_module, label_core
+):
+    """Updating label options re-applies them, moving finished labeled torrents."""
+    label_core.labels['movies'] = make_label(label_core_module)
+    torrent = make_torrent(is_finished=True)
+    label_core.torrents['t1'] = torrent
+    label_core.torrent_labels['t1'] = 'movies'
+
+    label_core.set_options('movies', dict(MOVE_OPTIONS))
+
+    torrent.move_storage.assert_called_once_with('/downloads/movies')


### PR DESCRIPTION
## Problem

The Label plugin's `move_completed` routing only works if the label is applied **before** the download finishes. Applying a label to an already-finished torrent has no effect on its location.

Root cause: the move-on-completed logic only runs in `TorrentManager.on_alert_torrent_finished`, triggered once by libtorrent's `torrent_finished_alert`. When a label is applied later, `_set_torrent_options` only updates the torrent's options dict — nothing ever re-reads `move_completed`/`move_completed_path` after the alert has fired (the handler is also guarded by `if not torrent.is_finished`, so it can never re-run).

## Fix

In `_set_torrent_options`, after applying the label's move-completed options: if the torrent is already finished, the label enables `move_completed` with a non-empty path, and the torrent's `download_location` differs from that path, call `torrent.move_storage()`.

This mirrors the guard logic already used by `on_alert_torrent_finished` and makes labelling after completion behave the same as labelling before completion. It also covers updating a label's options (`label.set_options`), which re-applies options to all torrents carrying the label.

No move is triggered when:
- the torrent is still downloading (core moves it at completion, as before)
- the label doesn't enable `move_completed` / `apply_move_completed`
- the move path is empty
- the torrent already lives at the target path

## Tests

Added `deluge/tests/plugins/test_label.py` with 6 unit tests for the Label plugin core covering the cases above (the plugin previously had no pytest coverage). Verified the two behaviour tests fail without the fix and pass with it; full test suite passes locally (3 pre-existing GTK env failures unrelated).