### PR TITLE
Fix slow startup caused by inspect.stack() in overrides()

### DIFF
--- a/deluge/decorators.py
+++ b/deluge/decorators.py
@@ -7,7 +7,9 @@
 #
 
 import inspect
+import linecache
 import re
+import sys
 import warnings
 from functools import wraps
 from typing import Any, Callable, Coroutine, TypeVar
@@ -34,6 +36,19 @@ def proxy(proxy_func):
     return decorator
 
 
+def _frameinfo(frame):
+    """Build a lightweight inspect.FrameInfo-compatible tuple for a single frame.
+
+    Mirrors the (frame, filename, lineno, function, code_context, index) shape
+    that inspect.stack() returns with the default context=1, but without walking
+    the whole stack or resolving modules.
+    """
+    filename = frame.f_code.co_filename
+    lineno = frame.f_lineno
+    line = linecache.getline(filename, lineno)
+    return (frame, filename, lineno, frame.f_code.co_name, [line], 0)
+
+
 def overrides(*args):
     """
     Decorater function to specify when class methods override
@@ -52,7 +67,15 @@ def overrides(*args):
     the argument will be the BaseClass
 
     """
-    stack = inspect.stack()
+    # NOTE: inspect.stack() walks the *entire* call stack and resolves a module
+    # for every frame (inspect.getmodule scans all of sys.modules), which makes
+    # it pathologically slow at import time. We only ever index stack[1] and
+    # stack[2], so build just those two FrameInfo-like entries directly.
+    stack = (
+        None,
+        _frameinfo(sys._getframe(1)),
+        _frameinfo(sys._getframe(2)),
+    )
     if inspect.isfunction(args[0]):
         return _overrides(stack, args[0])
     else:

--- a/deluge/tests/test_decorators.py
+++ b/deluge/tests/test_decorators.py
@@ -5,7 +5,9 @@
 #
 
 
-from deluge.decorators import proxy
+import pytest
+
+from deluge.decorators import overrides, proxy
 
 
 class TestDecorators:
@@ -46,3 +48,64 @@ class TestDecorators:
         t = Test(5)
         assert t.diff(1) == -4
         assert t.no_diff(1) == 4
+
+
+class TestOverrides:
+    def test_basic(self):
+        class Base:
+            def method(self):
+                pass
+
+        class Child(Base):
+            @overrides
+            def method(self):
+                pass
+
+    def test_explicit_base_class(self):
+        class Base:
+            def method(self):
+                pass
+
+        class Child(Base):
+            @overrides(Base)
+            def method(self):
+                pass
+
+    def test_multiple_inheritance(self):
+        class A:
+            def method(self):
+                pass
+
+        class B(A):
+            pass
+
+        class C(B):
+            @overrides(A)
+            def method(self):
+                pass
+
+    def test_missing_method_raises(self):
+        class Base:
+            def method(self):
+                pass
+
+        with pytest.raises(Exception, match='not found'):
+            class Child(Base):
+                @overrides
+                def nonexistent(self):
+                    pass
+
+    def test_explicit_base_not_superclass_raises(self):
+        class Base:
+            def method(self):
+                pass
+
+        class Unrelated:
+            def method(self):
+                pass
+
+        with pytest.raises(Exception):
+            class Child(Base):
+                @overrides(Unrelated)
+                def method(self):
+                    pass


### PR DESCRIPTION
On a small DigitalOcean VPS, `deluge-console` startup was taking ~3.5 s. Profiling with Claude AI pointed to `overrides()` as the culprit, leading to a ~3× speedup with no behaviour change.

`overrides()` calls `inspect.stack()` at import time for every decorated method. `inspect.stack()` builds a record for every frame on the call stack; for each frame it calls `inspect.getmodule()`, which scans all of `sys.modules`. Cost is O(decorated_methods × stack_depth × loaded_modules).

This was introduced in 891209d (2016) and was fine then. It became painful as the import graph grew, the console UI has ~102 `@overrides` calls, deep import stacks, and `sys.modules` at ~1000+ entries by the time it finishes loading. Root cause is [CPython #92041](https://github.com/python/cpython/issues/92041).

Measured on `deluge-console quit` (2.1.2~dev0, Python 3.12, Ubuntu 24.04):

| | real | user CPU |
|---|---|---|
| before | 3.1–3.7 s | 2.3 s |
| after | 0.9–1.1 s | 0.5 s |

`overrides()`/`_overrides()` only ever use `stack[1]` and `stack[2]`, and only need each frame's single source line and its locals. Replace the full walk with `sys._getframe(1/2)` + `linecache.getline()` — same two frames, same one line of context, no module resolution. The original used `inspect.stack()` with default `context=1`, so the line is identical. Behaviour unchanged.

Changes:
- `deluge/decorators.py` — replace `inspect.stack()` with `_frameinfo()` using `sys._getframe()` + `linecache`
- `deluge/tests/test_decorators.py` — add `TestOverrides` (basic, explicit base, multiple inheritance, missing method, non-superclass); the file previously only covered `proxy`

Reproduce:

```bash
python3 -c "
import cProfile, pstats
pr = cProfile.Profile(); pr.enable()
try: import deluge.ui.console.main
except Exception: pass
pr.disable()
pstats.Stats(pr).sort_stats('tottime').print_stats(10)
"
# inspect.getmodule / hasattr / ismodule near the top

for i in 1 2 3; do /usr/bin/time -f "%e s real, %U s user" deluge-console quit >/dev/null; done
```