### PR TITLE
GHA CI: enable WebTorrent support

### DIFF
--- a/.github/workflows/ci_webtorrent.yaml
+++ b/.github/workflows/ci_webtorrent.yaml
@@ -1,0 +1,72 @@
+name: CI: WebTorrent
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test-linux-webtorrent:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        libtorrent:
+          - version: "RC_2_1"
+            libt_build_flags: "-Dwebtorrent=ON"
+          - version: "RC_2_0"
+            libt_build_flags: ""
+        python-version: ["3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            cmake \
+            libboost-python-dev \
+            libboost-system-dev \
+            libssl-dev \
+            python3-dev
+
+      - name: Clone libtorrent ${{ matrix.libtorrent.version }}
+        run: |
+          git clone --branch ${{ matrix.libtorrent.version }} --depth 1 \
+            https://github.com/arvidn/libtorrent.git
+
+      - name: Build libtorrent with Python bindings
+        run: |
+          cmake -B libtorrent/build -S libtorrent \
+            -DCMAKE_BUILD_TYPE=Release \
+            -Dpython-bindings=ON \
+            -Ddeprecated-functions=OFF \
+            ${{ matrix.libtorrent.libt_build_flags }}
+          cmake --build libtorrent/build -j$(nproc)
+          sudo cmake --install libtorrent/build
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Install Deluge dependencies
+        env:
+          UV_SYSTEM_PYTHON: 1
+        run: |
+          uv pip install -r requirements-ci.txt
+          uv pip install -e . --no-build-isolation
+
+      - name: Test with pytest
+        run: |
+          python -c 'from deluge._libtorrent import lt; print(lt.__version__)'
+          pytest -v -m "not (todo or gtkui or internet)" deluge


### PR DESCRIPTION
## Summary

- Adds a new `ci_webtorrent.yaml` workflow that builds **libtorrent-rasterbar from source** and passes `-Dwebtorrent=ON` for the `RC_2_1` branch
- Uses a version matrix so `RC_2_0` still builds without the flag (matching its release capabilities)
- Mirrors the approach taken in [qbittorrent/qBittorrent#24564](https://github.com/qbittorrent/qBittorrent/pull/24564)

This paves the way for future WebTorrent related development in Deluge.

> **Note:** Unlike qBittorrent's CI which already compiled libtorrent from source, Deluge's existing CI uses pre-built pip wheels. This new workflow adds a dedicated source-build path so WebTorrent-enabled libtorrent bindings can be tested end-to-end.

## Test plan

- [ ] Workflow triggers on push/PR
- [ ] `RC_2_1` matrix entry builds with `-Dwebtorrent=ON` and passes pytest suite
- [ ] `RC_2_0` matrix entry builds without flag and passes pytest suite
