### PR TITLE
console: fix pause * and resume * hanging when done

### DIFF
--- a/deluge/ui/console/cmdline/commands/pause.py
+++ b/deluge/ui/console/cmdline/commands/pause.py
@@ -7,6 +7,8 @@
 # See LICENSE for more details.
 #
 
+from twisted.internet import defer
+
 import deluge.component as component
 from deluge.ui.client import client
 
@@ -31,7 +33,7 @@ class Command(BaseCommand):
 
         if options.torrent_ids[0] == '*':
             client.core.pause_session()
-            return
+            return defer.succeed(True)
 
         torrent_ids = []
         for arg in options.torrent_ids:

--- a/deluge/ui/console/cmdline/commands/resume.py
+++ b/deluge/ui/console/cmdline/commands/resume.py
@@ -7,6 +7,8 @@
 # See LICENSE for more details.
 #
 
+from twisted.internet import defer
+
 import deluge.component as component
 from deluge.ui.client import client
 
@@ -31,7 +33,7 @@ class Command(BaseCommand):
 
         if options.torrent_ids[0] == '*':
             client.core.resume_session()
-            return
+            return defer.succeed(True)
 
         torrent_ids = []
         for t_id in options.torrent_ids:


### PR DESCRIPTION
Since 253eb2240bd33cdedac53eb19eecc9de53f57d8a the `pause *` and `resume *` commands hang without returning when finished. Changes based on 0e197ee07e7ab8ea93aff96e906dd582cd5fd202.