### PR TITLE
replace deprecated calls in certificate generation

### DIFF
--- a/deluge/crypto_utils.py
+++ b/deluge/crypto_utils.py
@@ -8,8 +8,12 @@
 
 import os
 import stat
+from datetime import datetime, timedelta, timezone
 
-from OpenSSL import crypto
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
 from OpenSSL.crypto import FILETYPE_PEM
 from twisted.internet.ssl import (
     AcceptableCiphers,
@@ -102,35 +106,35 @@ def generate_ssl_keys():
     """
     This method generates a new SSL key/cert.
     """
-    digest = 'sha256'
-
     # Generate key pair
-    pkey = crypto.PKey()
-    pkey.generate_key(crypto.TYPE_RSA, 2048)
-
-    # Generate cert request
-    req = crypto.X509Req()
-    subj = req.get_subject()
-    setattr(subj, 'CN', 'Deluge Daemon')
-    req.set_pubkey(pkey)
-    req.sign(pkey, digest)
+    pkey = rsa.generate_private_key(public_exponent=65537, key_size=2048)
 
     # Generate certificate
-    cert = crypto.X509()
-    cert.set_serial_number(0)
-    cert.gmtime_adj_notBefore(0)
-    cert.gmtime_adj_notAfter(60 * 60 * 24 * 365 * 3)  # Three Years
-    cert.set_issuer(req.get_subject())
-    cert.set_subject(req.get_subject())
-    cert.set_pubkey(req.get_pubkey())
-    cert.sign(pkey, digest)
+    subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, 'Deluge Daemon')])
+    now = datetime.now(timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(pkey.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + timedelta(days=365 * 3))  # Three Years
+        .sign(pkey, hashes.SHA256())
+    )
 
-    # Write out files
     ssl_dir = deluge.configmanager.get_config_dir('ssl')
-    with open(os.path.join(ssl_dir, 'daemon.pkey'), 'wb') as _file:
-        _file.write(crypto.dump_privatekey(crypto.FILETYPE_PEM, pkey))
-    with open(os.path.join(ssl_dir, 'daemon.cert'), 'wb') as _file:
-        _file.write(crypto.dump_certificate(crypto.FILETYPE_PEM, cert))
-    # Make the files only readable by this user
-    for f in ('daemon.pkey', 'daemon.cert'):
-        os.chmod(os.path.join(ssl_dir, f), stat.S_IREAD | stat.S_IWRITE)
+    files = {
+        'daemon.pkey': pkey.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        ),
+        'daemon.cert': cert.public_bytes(serialization.Encoding.PEM),
+    }
+    for name, data in files.items():
+        path = os.path.join(ssl_dir, name)
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, stat.S_IRUSR | stat.S_IWUSR)
+        with os.fdopen(fd, 'wb') as _file:
+            _file.write(data)
+        os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)


### PR DESCRIPTION
Minimal patch to fix a crash on launch on systems without deprecated pyopenssl versions. Instead rely on the cryptography equivalents.