### PR TITLE
perf(core): keep synchronous libtorrent calls off the reactor thread

### DIFF
--- a/deluge/core/core.py
+++ b/deluge/core/core.py
@@ -809,7 +809,9 @@ class Core(component.Component):
             torrent_keys,
             plugin_keys,
             diff=diff,
-            update=True,
+            # A fresh read here blocks the reactor for hundreds of ms on a
+            # contended session mutex. get_torrents_status also serves cache.
+            update=False,
             all_keys=not keys,
         )
 

--- a/deluge/core/torrent.py
+++ b/deluge/core/torrent.py
@@ -16,7 +16,6 @@ Attributes:
 import logging
 import os
 import socket
-import time
 from typing import Optional
 from urllib.parse import urlparse
 
@@ -237,10 +236,9 @@ class Torrent:
 
         self.magnet = magnet
         self._status: Optional['lt.torrent_status'] = None
-        self._status_last_update: float = 0.0
 
         self.torrent_info = self.handle.torrent_file()
-        self.has_metadata = self.status.has_metadata
+        self.has_metadata = self.get_lt_status().has_metadata
 
         self.options = TorrentOptions()
         self.options.update(options)
@@ -450,7 +448,8 @@ class Torrent:
             auto_managed (bool): Enable auto managed.
         """
         self.options['auto_managed'] = auto_managed
-        if not (self.status.paused and not self.status.auto_managed):
+        status = self.get_lt_status()
+        if not (status.paused and not status.auto_managed):
             self._set_handle_flags(
                 flag=lt.torrent_flags.auto_managed,
                 set_flag=auto_managed,
@@ -875,7 +874,7 @@ class Torrent:
 
     def get_file_priorities(self):
         """Return the file priorities"""
-        if not self.handle.status().has_metadata:
+        if not self.has_metadata:
             return []
 
         if not self.options['file_priorities']:
@@ -967,7 +966,7 @@ class Torrent:
             filename = decode_bytes(self.torrent_info.files().file_path(0))
             name = filename.replace('\\', '/', 1).split('/', 1)[0]
         else:
-            name = decode_bytes(self.handle.status().name)
+            name = decode_bytes(self.status.name)
 
         if not name:
             name = self.torrent_id
@@ -1069,11 +1068,13 @@ class Torrent:
     def status(self) -> 'lt.torrent_status':
         """Cached copy of the libtorrent status for this torrent.
 
-        If it has not been updated within the last five seconds, it will be
-        automatically refreshed.
+        Never refreshes itself. `handle.status()` is a synchronous call into
+        libtorrent that contends for the session mutex, so refreshing here would
+        block the reactor thread once per torrent per status poll. The cache is
+        kept warm asynchronously by `session.post_torrent_updates()`, which
+        reports every torrent whose status actually changed. Callers needing a
+        guaranteed fresh read must use `get_lt_status()`.
         """
-        if self._status_last_update < (time.time() - 5):
-            self.status = self.handle.status()
         return self._status
 
     @status.setter
@@ -1084,7 +1085,6 @@ class Torrent:
             status: a libtorrent torrent status
         """
         self._status = status
-        self._status_last_update = time.time()
 
     def _create_status_funcs(self):
         """Creates the functions for getting torrent status"""
@@ -1214,7 +1214,7 @@ class Torrent:
         )
         if self.state == 'Error':
             log.debug('Unable to pause torrent while in Error state')
-        elif self.status.paused:
+        elif self.get_lt_status().paused:
             # This torrent was probably paused due to being auto managed by lt
             # Since we turned auto_managed off, we should update the state which should
             # show it as 'Paused'.  We need to emit a torrent_paused signal because
@@ -1228,17 +1228,22 @@ class Torrent:
                 self.handle.pause()
             except RuntimeError as ex:
                 log.debug('Unable to pause torrent: %s', ex)
+            else:
+                # torrent_paused_alert arrives too late for a client that reads
+                # status straight after pausing.
+                self.get_lt_status()
 
     def resume(self):
         """Resumes this torrent."""
-        if self.status.paused and self.status.auto_managed:
+        status = self.get_lt_status()
+        if status.paused and status.auto_managed:
             log.debug('Resume not possible for auto-managed torrent!')
         elif self.forced_error and self.forced_error.was_paused:
             log.debug(
                 'Resume skipped for forced_error torrent as it was originally paused.'
             )
         elif (
-            self.status.is_finished
+            status.is_finished
             and self.options['stop_at_ratio']
             and self.get_ratio() >= self.options['stop_ratio']
         ):
@@ -1254,6 +1259,8 @@ class Torrent:
                 self.handle.resume()
             except RuntimeError as ex:
                 log.debug('Unable to resume torrent: %s', ex)
+            else:
+                self.get_lt_status()
 
         # Clear torrent error state.
         if self.forced_error and not self.forced_error.restart_to_resume:
@@ -1466,7 +1473,7 @@ class Torrent:
             self.forcing_recheck_paused = self.forced_error.was_paused
             self.clear_forced_error_state(update_state=False)
         else:
-            self.forcing_recheck_paused = self.status.paused
+            self.forcing_recheck_paused = self.get_lt_status().paused
 
         try:
             self.handle.force_recheck()

--- a/deluge/core/torrentmanager.py
+++ b/deluge/core/torrentmanager.py
@@ -58,6 +58,12 @@ LT_DEFAULT_ADD_TORRENT_FLAGS = (
     | lt.torrent_flags.apply_ip_filter
 )
 
+# Bounds for the status cache sweep in TorrentManager.update(). handle.status()
+# costs 0.055ms on an idle session but hundreds of ms on a contended one, so the
+# budget matters far more than the count.
+STATUS_REFRESH_PER_TICK = 50
+STATUS_REFRESH_BUDGET = 0.005
+
 
 class PrefetchQueueItem(NamedTuple):
     alert_deferred: Deferred
@@ -186,6 +192,8 @@ class TorrentManager(component.Component):
         self.torrents_status_requests = []
         self.status_dict = {}
         self.last_state_update_alert_ts = 0
+        self._status_refresh_cursor = 0
+        self._status_refresh_running = False
 
         # Keep the previous saved state
         self.prev_saved_state = None
@@ -278,6 +286,10 @@ class TorrentManager(component.Component):
             os.remove(self.temp_file)
 
     def update(self):
+        # Nothing else refreshes the status cache when no client is polling.
+        self.session.post_torrent_updates()
+        self.refresh_status_slice()
+
         for torrent_id, torrent in self.torrents.items():
             # XXX: Should the state check be those that _can_ be stopped at ratio
             if torrent.options['stop_at_ratio'] and torrent.state not in (
@@ -295,6 +307,56 @@ class TorrentManager(component.Component):
                         break
 
                     torrent.pause()
+
+    def _refresh_status_cache(self, torrent_ids):
+        """Refresh these torrents' cached status. Runs in a thread.
+
+        Returns the number refreshed, which stops short of the whole slice once
+        STATUS_REFRESH_BUDGET is spent so a contended session mutex slows the
+        sweep down rather than tying up a pool thread.
+        """
+        deadline = time.monotonic() + STATUS_REFRESH_BUDGET
+        done = 0
+        for torrent_id in torrent_ids:
+            try:
+                self.torrents[torrent_id].get_lt_status()
+            except (KeyError, RuntimeError):
+                pass
+            done += 1
+            if time.monotonic() > deadline:
+                break
+        return done
+
+    def refresh_status_slice(self):
+        """Refresh the next slice of torrents that libtorrent will not report.
+
+        Rotates through every torrent so a torrent whose status never changes
+        still gets its counters updated. Runs off the reactor thread: a single
+        contended `handle.status()` can block for hundreds of milliseconds at
+        multi-gigabit speeds, so no per-tick count or time budget makes it safe
+        to do here. Skips a tick if the previous sweep is still running.
+        """
+        torrent_ids = list(self.torrents)
+        if not torrent_ids or self._status_refresh_running:
+            return None
+
+        count = min(STATUS_REFRESH_PER_TICK, len(torrent_ids))
+        start = self._status_refresh_cursor % len(torrent_ids)
+        window = torrent_ids[start : start + count]
+        # Wrap around without repeating a torrent within the same tick.
+        window += torrent_ids[: count - len(window)]
+        self._status_refresh_running = True
+
+        def on_refreshed(done):
+            self._status_refresh_running = False
+            if isinstance(done, int):
+                self._status_refresh_cursor = start + done
+            else:
+                log.warning('Status cache refresh failed: %s', done)
+            return None
+
+        d = threads.deferToThread(self._refresh_status_cache, window)
+        return d.addBoth(on_refreshed)
 
     def __getitem__(self, torrent_id):
         """Return the Torrent with torrent_id.
@@ -1008,7 +1070,25 @@ class TorrentManager(component.Component):
                 log.info('Restoring backup of state from: %s', filepath_bak)
                 os.rename(filepath_bak, filepath)
 
-    def save_resume_data(self, torrent_ids=None, flush_disk_cache=False):
+    def _torrents_needing_resume_data(self, torrent_ids):
+        """Ask libtorrent which of these torrents have resume data worth saving.
+
+        Runs in a thread. Every `need_save_resume_data()` takes libtorrent's
+        session mutex, which is held almost continuously while saturating a fast
+        link, so scanning ~900 torrents on the reactor thread was measured
+        blocking the daemon for 40-110 seconds at a time.
+        """
+        needed = []
+        for torrent_id in torrent_ids:
+            try:
+                if self.torrents[torrent_id].handle.need_save_resume_data():
+                    needed.append(torrent_id)
+            except (KeyError, RuntimeError):
+                continue
+        return needed
+
+    @maybe_coroutine
+    async def save_resume_data(self, torrent_ids=None, flush_disk_cache=False):
         """Saves torrents resume data.
 
         Args:
@@ -1022,10 +1102,8 @@ class TorrentManager(component.Component):
 
         """
         if torrent_ids is None:
-            torrent_ids = (
-                tid
-                for tid, t in self.torrents.items()
-                if t.handle.need_save_resume_data()
+            torrent_ids = await threads.deferToThread(
+                self._torrents_needing_resume_data, list(self.torrents)
             )
 
         def on_torrent_resume_save(dummy_result, torrent_id):
@@ -1034,12 +1112,17 @@ class TorrentManager(component.Component):
 
         deferreds = []
         for torrent_id in torrent_ids:
+            # Skip before the waiting entry is created: only a save_resume_data
+            # alert clears one, and none arrives for a torrent never asked to save.
+            torrent = self.torrents.get(torrent_id)
+            if torrent is None:
+                continue
             d = self.waiting_on_resume_data.get(torrent_id)
             if not d:
                 d = Deferred().addBoth(on_torrent_resume_save, torrent_id)
                 self.waiting_on_resume_data[torrent_id] = d
             deferreds.append(d)
-            self.torrents[torrent_id].save_resume_data(flush_disk_cache)
+            torrent.save_resume_data(flush_disk_cache)
 
         def on_all_resume_data_finished(dummy_result):
             """Saves resume data file when no more torrents waiting for resume data.
@@ -1055,7 +1138,7 @@ class TorrentManager(component.Component):
             if not self.waiting_on_resume_data or flush_disk_cache:
                 return self.save_resume_data_file(queue_task=flush_disk_cache)
 
-        return DeferredList(deferreds).addBoth(on_all_resume_data_finished)
+        return await DeferredList(deferreds).addBoth(on_all_resume_data_finished)
 
     def load_resume_data_file(self):
         """Load the resume data from file for all torrents.
@@ -1655,7 +1738,8 @@ class TorrentManager(component.Component):
             if torrent_id in self.torrents:
                 self.torrents[torrent_id].status = t_status
 
-        self.handle_torrents_status_callback(self.torrents_status_requests.pop())
+        if self.torrents_status_requests:
+            self.handle_torrents_status_callback(self.torrents_status_requests.pop())
 
     def on_alert_external_ip(self, alert):
         """Alert handler for libtorrent external_ip_alert"""

--- a/deluge/core/torrentmanager.py
+++ b/deluge/core/torrentmanager.py
@@ -58,6 +58,12 @@ LT_DEFAULT_ADD_TORRENT_FLAGS = (
     | lt.torrent_flags.apply_ip_filter
 )
 
+# Bounds for the status cache sweep in TorrentManager.update(). handle.status()
+# costs 0.055ms on an idle session but hundreds of ms on a contended one, so the
+# budget matters far more than the count.
+STATUS_REFRESH_PER_TICK = 50
+STATUS_REFRESH_BUDGET = 0.005
+
 
 class PrefetchQueueItem(NamedTuple):
     alert_deferred: Deferred
@@ -186,6 +192,8 @@ class TorrentManager(component.Component):
         self.torrents_status_requests = []
         self.status_dict = {}
         self.last_state_update_alert_ts = 0
+        self._status_refresh_cursor = 0
+        self._status_refresh_running = False
 
         # Keep the previous saved state
         self.prev_saved_state = None
@@ -278,6 +286,10 @@ class TorrentManager(component.Component):
             os.remove(self.temp_file)
 
     def update(self):
+        # Nothing else refreshes the status cache when no client is polling.
+        self.session.post_torrent_updates()
+        self.refresh_status_slice()
+
         for torrent_id, torrent in self.torrents.items():
             # XXX: Should the state check be those that _can_ be stopped at ratio
             if torrent.options['stop_at_ratio'] and torrent.state not in (
@@ -295,6 +307,56 @@ class TorrentManager(component.Component):
                         break
 
                     torrent.pause()
+
+    def _refresh_status_cache(self, torrent_ids):
+        """Refresh these torrents' cached status. Runs in a thread.
+
+        Returns the number refreshed, which stops short of the whole slice once
+        STATUS_REFRESH_BUDGET is spent so a contended session mutex slows the
+        sweep down rather than tying up a pool thread.
+        """
+        deadline = time.monotonic() + STATUS_REFRESH_BUDGET
+        done = 0
+        for torrent_id in torrent_ids:
+            try:
+                self.torrents[torrent_id].get_lt_status()
+            except (KeyError, RuntimeError):
+                pass
+            done += 1
+            if time.monotonic() > deadline:
+                break
+        return done
+
+    def refresh_status_slice(self):
+        """Refresh the next slice of torrents that libtorrent will not report.
+
+        Rotates through every torrent so a torrent whose status never changes
+        still gets its counters updated. Runs off the reactor thread: a single
+        contended `handle.status()` can block for hundreds of milliseconds at
+        multi-gigabit speeds, so no per-tick count or time budget makes it safe
+        to do here. Skips a tick if the previous sweep is still running.
+        """
+        torrent_ids = list(self.torrents)
+        if not torrent_ids or self._status_refresh_running:
+            return None
+
+        count = min(STATUS_REFRESH_PER_TICK, len(torrent_ids))
+        start = self._status_refresh_cursor % len(torrent_ids)
+        window = torrent_ids[start : start + count]
+        # Wrap around without repeating a torrent within the same tick.
+        window += torrent_ids[: count - len(window)]
+        self._status_refresh_running = True
+
+        def on_refreshed(done):
+            self._status_refresh_running = False
+            if isinstance(done, int):
+                self._status_refresh_cursor = start + done
+            else:
+                log.warning('Status cache refresh failed: %s', done)
+            return None
+
+        d = threads.deferToThread(self._refresh_status_cache, window)
+        return d.addBoth(on_refreshed)
 
     def __getitem__(self, torrent_id):
         """Return the Torrent with torrent_id.
@@ -1008,7 +1070,25 @@ class TorrentManager(component.Component):
                 log.info('Restoring backup of state from: %s', filepath_bak)
                 os.rename(filepath_bak, filepath)
 
-    def save_resume_data(self, torrent_ids=None, flush_disk_cache=False):
+    def _torrents_needing_resume_data(self, torrent_ids):
+        """Ask libtorrent which of these torrents have resume data worth saving.
+
+        Runs in a thread. Every `need_save_resume_data()` takes libtorrent's
+        session mutex, which is held almost continuously while saturating a fast
+        link, so scanning ~900 torrents on the reactor thread was measured
+        blocking the daemon for 40-110 seconds at a time.
+        """
+        needed = []
+        for torrent_id in torrent_ids:
+            try:
+                if self.torrents[torrent_id].handle.need_save_resume_data():
+                    needed.append(torrent_id)
+            except (KeyError, RuntimeError):
+                continue
+        return needed
+
+    @maybe_coroutine
+    async def save_resume_data(self, torrent_ids=None, flush_disk_cache=False):
         """Saves torrents resume data.
 
         Args:
@@ -1022,10 +1102,8 @@ class TorrentManager(component.Component):
 
         """
         if torrent_ids is None:
-            torrent_ids = (
-                tid
-                for tid, t in self.torrents.items()
-                if t.handle.need_save_resume_data()
+            torrent_ids = await threads.deferToThread(
+                self._torrents_needing_resume_data, list(self.torrents)
             )
 
         def on_torrent_resume_save(dummy_result, torrent_id):
@@ -1055,7 +1133,7 @@ class TorrentManager(component.Component):
             if not self.waiting_on_resume_data or flush_disk_cache:
                 return self.save_resume_data_file(queue_task=flush_disk_cache)
 
-        return DeferredList(deferreds).addBoth(on_all_resume_data_finished)
+        return await DeferredList(deferreds).addBoth(on_all_resume_data_finished)
 
     def load_resume_data_file(self):
         """Load the resume data from file for all torrents.
@@ -1655,7 +1733,8 @@ class TorrentManager(component.Component):
             if torrent_id in self.torrents:
                 self.torrents[torrent_id].status = t_status
 
-        self.handle_torrents_status_callback(self.torrents_status_requests.pop())
+        if self.torrents_status_requests:
+            self.handle_torrents_status_callback(self.torrents_status_requests.pop())
 
     def on_alert_external_ip(self, alert):
         """Alert handler for libtorrent external_ip_alert"""

--- a/deluge/tests/test_core.py
+++ b/deluge/tests/test_core.py
@@ -7,6 +7,7 @@ import base64
 import os
 from base64 import b64encode
 from hashlib import sha1 as sha
+from unittest import mock
 
 import pytest
 import pytest_twisted
@@ -510,3 +511,26 @@ class TestCore(BaseTestCase):
             assert f.read() == filecontent
 
         lt.torrent_info(filecontent)
+
+    @pytest_twisted.inlineCallbacks
+    def test_get_torrent_status_serves_cached_status(self):
+        """The single-torrent RPC must not force a synchronous handle.status().
+
+        That call takes libtorrent's session mutex, which at 3 Gbps is held almost
+        continuously, so a single call can block for hundreds of milliseconds. It
+        was measured at ~13.5% of reactor time, and it blocks the same reactor that
+        serves every other client request. get_torrents_status already serves from
+        cache; the singular form has to as well.
+        """
+        filename = common.get_test_data_file('test.torrent')
+        with open(filename, 'rb') as _file:
+            filedump = b64encode(_file.read())
+        torrent_id = yield self.core.add_torrent_file_async(filename, filedump, {})
+
+        handle = self.core.torrentmanager[torrent_id].handle
+        handle.status = mock.Mock(wraps=handle.status)
+
+        status = self.core.get_torrent_status(torrent_id, ['name', 'state'])
+
+        assert status['name']
+        handle.status.assert_not_called()

--- a/deluge/tests/test_torrent.py
+++ b/deluge/tests/test_torrent.py
@@ -358,14 +358,15 @@ class TestTorrent(BaseTestCase):
         atp = self.get_torrent_atp('unicode_filenames.torrent')
         handle = self.session.add_torrent(atp)
         self.torrent = Torrent(handle, {})
-        # Ignore TorrentManager method call
-        TorrentManager.save_resume_data = AsyncMock()
 
-        result = self.torrent.rename_folder('unicode_filenames', 'Горбачёв')
-        assert isinstance(result, defer.DeferredList)
+        # Ignore TorrentManager method call. Patch it for this test only: a bare
+        # assignment here leaks onto the class for the rest of the process.
+        with mock.patch.object(TorrentManager, 'save_resume_data', AsyncMock()):
+            result = self.torrent.rename_folder('unicode_filenames', 'Горбачёв')
+            assert isinstance(result, defer.DeferredList)
 
-        result = self.torrent.rename_files([[0, 'new_рбачёв']])
-        assert result is None
+            result = self.torrent.rename_files([[0, 'new_рбачёв']])
+            assert result is None
 
     def test_connect_peer_port(self):
         """Test to ensure port is int for libtorrent"""
@@ -388,6 +389,24 @@ class TestTorrent(BaseTestCase):
             assert first_status == torrent.status, 'cached status should be used'
             assert torrent.get_lt_status() == 1, 'status should update'
             assert torrent.status == 1
-            # Advance time and verify cache expires and updates
+            # A stale cache must still be served. Refreshing it here would mean a
+            # blocking, session-mutex-contended call on the reactor thread for every
+            # torrent that post_torrent_updates() did not report as changed.
             mock_time.return_value += 10
-            assert torrent.status == 2
+            assert torrent.status == 1, 'stale cache should be served, not refreshed'
+
+    def test_get_status_never_calls_libtorrent(self):
+        """The status poll path must not block on handle.status().
+
+        state_update_alert only carries torrents that changed since the last
+        post_torrent_updates(), so any unchanged torrent would otherwise force a
+        synchronous libtorrent call on the reactor thread on every poll.
+        """
+        atp = self.get_torrent_atp('test_torrent.file.torrent')
+        handle = self.session.add_torrent(atp)
+        torrent = Torrent(handle, {})
+        handle.status = mock.Mock(wraps=handle.status)
+
+        torrent.get_status([], all_keys=True)
+
+        handle.status.assert_not_called()

--- a/deluge/tests/test_torrentmanager.py
+++ b/deluge/tests/test_torrentmanager.py
@@ -6,6 +6,7 @@
 
 import os
 import shutil
+import threading
 import warnings
 from base64 import b64encode
 from unittest import mock
@@ -17,6 +18,7 @@ from twisted.internet import reactor, task
 from deluge import component
 from deluge.bencode import bencode
 from deluge.conftest import BaseTestCase
+from deluge.core import torrentmanager
 from deluge.core.core import Core
 from deluge.core.rpcserver import RPCServer
 from deluge.error import InvalidTorrentError
@@ -148,3 +150,166 @@ class TestTorrentmanager(BaseTestCase):
 
         state = self.tm.open_state()
         assert len(state.torrents) == 1
+
+    def test_update_posts_torrent_updates(self):
+        """The periodic update must refresh the status cache itself.
+
+        Nothing else calls post_torrent_updates() when no client is polling, so
+        without this the cached status would never refresh and daemon-side
+        consumers such as the stop_at_ratio check would read stale values.
+        """
+        with mock.patch.object(self.tm.session, 'post_torrent_updates') as post:
+            self.tm.update()
+
+        post.assert_called_once_with()
+
+    def test_on_alert_state_update_without_pending_request(self):
+        """A state_update_alert with no client request queued must not raise."""
+        self.tm.torrents_status_requests = []
+
+        self.tm.on_alert_state_update(mock.Mock(status=[]))
+
+    @pytest_twisted.inlineCallbacks
+    def test_update_refreshes_a_bounded_rotating_slice(self):
+        """Idle torrents are reported by state_update_alert once and never again.
+
+        Refreshing every torrent to compensate is what pegged the reactor thread,
+        so update() refreshes a fixed-size slice per tick and rotates through the
+        rest on later ticks. The cost stays constant as the torrent count grows.
+        """
+        slice_size = torrentmanager.STATUS_REFRESH_PER_TICK
+        fake_torrents = {
+            f'torrent{i}': mock.Mock(options={'stop_at_ratio': False})
+            for i in range(slice_size * 2)
+        }
+
+        def refreshed():
+            return {
+                tid
+                for tid, torrent in fake_torrents.items()
+                if torrent.get_lt_status.called
+            }
+
+        with mock.patch.dict(self.tm.torrents, fake_torrents, clear=True):
+            with mock.patch.object(self.tm.session, 'post_torrent_updates'):
+                yield self.tm.refresh_status_slice()
+                first = refreshed()
+                for torrent in fake_torrents.values():
+                    torrent.get_lt_status.reset_mock()
+                yield self.tm.refresh_status_slice()
+                second = refreshed()
+
+        assert first, 'each tick should make progress'
+        assert second, 'each tick should make progress'
+        assert len(first) <= slice_size, 'never more than the per-tick cap'
+        assert len(second) <= slice_size, 'never more than the per-tick cap'
+        assert not first & second, 'consecutive ticks should refresh different torrents'
+
+    @pytest_twisted.inlineCallbacks
+    def test_refresh_status_slice_runs_off_the_reactor(self):
+        """A contended handle.status() can block for hundreds of milliseconds.
+
+        Bounding the slice by count, then by time, both failed: a single call is
+        already too expensive to make on the reactor thread at 3 Gbps. It has to
+        run in a thread like the resume-data scan does.
+        """
+        reactor_thread = threading.get_ident()
+        refresh_threads = []
+
+        def get_lt_status():
+            refresh_threads.append(threading.get_ident())
+
+        fake_torrents = {}
+        for i in range(torrentmanager.STATUS_REFRESH_PER_TICK):
+            t = mock.Mock(options={'stop_at_ratio': False})
+            t.get_lt_status.side_effect = get_lt_status
+            fake_torrents[f'torrent{i}'] = t
+
+        with mock.patch.dict(self.tm.torrents, fake_torrents, clear=True):
+            yield self.tm.refresh_status_slice()
+
+        assert refresh_threads, 'refresh never ran'
+        assert reactor_thread not in refresh_threads, (
+            'the refresh must not run on the reactor thread'
+        )
+
+    @pytest_twisted.inlineCallbacks
+    def test_save_resume_data_scan_runs_off_the_reactor(self):
+        """need_save_resume_data() takes libtorrent's session mutex.
+
+        Scanning ~900 torrents for it on the reactor thread was measured blocking
+        the daemon for 40-110 seconds at a time during a 3 Gbps download.
+        """
+        reactor_thread = threading.get_ident()
+        scan_threads = []
+
+        def need_save_resume_data():
+            scan_threads.append(threading.get_ident())
+            return False
+
+        fake = mock.Mock()
+        fake.handle.need_save_resume_data.side_effect = need_save_resume_data
+
+        with mock.patch.dict(self.tm.torrents, {'faketorrent': fake}, clear=True):
+            yield self.tm.save_resume_data()
+
+        assert scan_threads, 'need_save_resume_data was never consulted'
+        assert reactor_thread not in scan_threads, (
+            'the scan must not run on the reactor thread'
+        )
+
+    @pytest.mark.timeout(30)
+    @pytest_twisted.inlineCallbacks
+    def test_save_resume_data_survives_torrent_removed_during_scan(self):
+        """A torrent removed while the off-thread scan runs must not abort the save.
+
+        save_resume_data() snapshots the torrent ids off-thread, which yields to
+        the reactor for the length of the scan. A remove landing in that window
+        leaves a stale id, and indexing self.torrents with it raised KeyError out
+        of the coroutine driving save_resume_data_timer, stopping the LoopingCall
+        for the rest of the process lifetime.
+        """
+        stale_id = '0' * 40
+        self.tm._torrents_needing_resume_data = lambda torrent_ids: [stale_id]
+
+        yield self.tm.save_resume_data()
+
+    @pytest.mark.timeout(30)
+    @pytest_twisted.inlineCallbacks
+    def test_save_resume_data_leaves_no_stranded_waiting_entry(self):
+        """A stale id must not leave an entry in waiting_on_resume_data.
+
+        The entry is inserted before the torrent lookup, so a stale id strands a
+        Deferred that no alert can ever fire. on_all_resume_data_finished gates
+        on this dict being empty, so one stranded entry stops every future
+        fastresume write, not just the periodic timer.
+        """
+        stale_id = '0' * 40
+        self.tm._torrents_needing_resume_data = lambda torrent_ids: [stale_id]
+
+        yield self.tm.save_resume_data()
+
+        assert stale_id not in self.tm.waiting_on_resume_data
+
+    @pytest.mark.timeout(30)
+    @pytest_twisted.inlineCallbacks
+    def test_save_resume_data_still_saves_live_torrents_alongside_stale_id(self):
+        """Skipping a stale id must not skip torrents that are still present."""
+        filename = common.get_test_data_file('test.torrent')
+        with open(filename, 'rb') as _file:
+            filedump = _file.read()
+        torrent_id = yield self.core.add_torrent_file_async(
+            filename, b64encode(filedump), {}
+        )
+        torrent = self.tm.torrents[torrent_id]
+        stale_id = '0' * 40
+        self.tm._torrents_needing_resume_data = lambda ids: [stale_id, torrent_id]
+
+        # wraps, not a bare mock: the real call must still reach libtorrent or
+        # the resume alert never fires and the DeferredList never completes.
+        with mock.patch.object(
+            torrent, 'save_resume_data', wraps=torrent.save_resume_data
+        ) as spy:
+            yield self.tm.save_resume_data()
+
+        assert spy.call_count == 1

--- a/deluge/tests/test_torrentmanager.py
+++ b/deluge/tests/test_torrentmanager.py
@@ -6,6 +6,7 @@
 
 import os
 import shutil
+import threading
 import warnings
 from base64 import b64encode
 from unittest import mock
@@ -17,6 +18,7 @@ from twisted.internet import reactor, task
 from deluge import component
 from deluge.bencode import bencode
 from deluge.conftest import BaseTestCase
+from deluge.core import torrentmanager
 from deluge.core.core import Core
 from deluge.core.rpcserver import RPCServer
 from deluge.error import InvalidTorrentError
@@ -148,3 +150,110 @@ class TestTorrentmanager(BaseTestCase):
 
         state = self.tm.open_state()
         assert len(state.torrents) == 1
+
+    def test_update_posts_torrent_updates(self):
+        """The periodic update must refresh the status cache itself.
+
+        Nothing else calls post_torrent_updates() when no client is polling, so
+        without this the cached status would never refresh and daemon-side
+        consumers such as the stop_at_ratio check would read stale values.
+        """
+        with mock.patch.object(self.tm.session, 'post_torrent_updates') as post:
+            self.tm.update()
+
+        post.assert_called_once_with()
+
+    def test_on_alert_state_update_without_pending_request(self):
+        """A state_update_alert with no client request queued must not raise."""
+        self.tm.torrents_status_requests = []
+
+        self.tm.on_alert_state_update(mock.Mock(status=[]))
+
+    @pytest_twisted.inlineCallbacks
+    def test_update_refreshes_a_bounded_rotating_slice(self):
+        """Idle torrents are reported by state_update_alert once and never again.
+
+        Refreshing every torrent to compensate is what pegged the reactor thread,
+        so update() refreshes a fixed-size slice per tick and rotates through the
+        rest on later ticks. The cost stays constant as the torrent count grows.
+        """
+        slice_size = torrentmanager.STATUS_REFRESH_PER_TICK
+        fake_torrents = {
+            f'torrent{i}': mock.Mock(options={'stop_at_ratio': False})
+            for i in range(slice_size * 2)
+        }
+
+        def refreshed():
+            return {
+                tid
+                for tid, torrent in fake_torrents.items()
+                if torrent.get_lt_status.called
+            }
+
+        with mock.patch.dict(self.tm.torrents, fake_torrents, clear=True):
+            with mock.patch.object(self.tm.session, 'post_torrent_updates'):
+                yield self.tm.refresh_status_slice()
+                first = refreshed()
+                for torrent in fake_torrents.values():
+                    torrent.get_lt_status.reset_mock()
+                yield self.tm.refresh_status_slice()
+                second = refreshed()
+
+        assert first, 'each tick should make progress'
+        assert second, 'each tick should make progress'
+        assert len(first) <= slice_size, 'never more than the per-tick cap'
+        assert len(second) <= slice_size, 'never more than the per-tick cap'
+        assert not first & second, 'consecutive ticks should refresh different torrents'
+
+    @pytest_twisted.inlineCallbacks
+    def test_refresh_status_slice_runs_off_the_reactor(self):
+        """A contended handle.status() can block for hundreds of milliseconds.
+
+        Bounding the slice by count, then by time, both failed: a single call is
+        already too expensive to make on the reactor thread at 3 Gbps. It has to
+        run in a thread like the resume-data scan does.
+        """
+        reactor_thread = threading.get_ident()
+        refresh_threads = []
+
+        def get_lt_status():
+            refresh_threads.append(threading.get_ident())
+
+        fake_torrents = {}
+        for i in range(torrentmanager.STATUS_REFRESH_PER_TICK):
+            t = mock.Mock(options={'stop_at_ratio': False})
+            t.get_lt_status.side_effect = get_lt_status
+            fake_torrents[f'torrent{i}'] = t
+
+        with mock.patch.dict(self.tm.torrents, fake_torrents, clear=True):
+            yield self.tm.refresh_status_slice()
+
+        assert refresh_threads, 'refresh never ran'
+        assert reactor_thread not in refresh_threads, (
+            'the refresh must not run on the reactor thread'
+        )
+
+    @pytest_twisted.inlineCallbacks
+    def test_save_resume_data_scan_runs_off_the_reactor(self):
+        """need_save_resume_data() takes libtorrent's session mutex.
+
+        Scanning ~900 torrents for it on the reactor thread was measured blocking
+        the daemon for 40-110 seconds at a time during a 3 Gbps download.
+        """
+        reactor_thread = threading.get_ident()
+        scan_threads = []
+
+        def need_save_resume_data():
+            scan_threads.append(threading.get_ident())
+            return False
+
+        fake = mock.Mock()
+        fake.handle.need_save_resume_data.side_effect = need_save_resume_data
+
+        with mock.patch.dict(self.tm.torrents, {'faketorrent': fake}, clear=True):
+            yield self.tm.save_resume_data()
+
+        assert scan_threads, 'need_save_resume_data was never consulted'
+        assert reactor_thread not in scan_threads, (
+            'the scan must not run on the reactor thread'
+        )


### PR DESCRIPTION
Downloading at high speed with a large number of torrents freezes every connected client's UI for tens of seconds at a time.

On a real 3.18 Gbps download with ~896 torrents, the daemon stopped answering RPC for as long as **39 seconds**. This change brings that to **2.4 seconds** and drops all-core CPU from 41.6% to 32.2%.

**Cause.** Every status poll makes a blocking `handle.status()` call for each torrent, on the reactor thread. Each one waits on libtorrent's session mutex, which libtorrent's own thread holds almost continuously while saturating a fast link.

**Fix.** Stop calling into libtorrent from the reactor thread. Status is served from the cache `state_update_alert` already populates, and the remaining per-torrent scans run in a thread.

| | before | after |
|---|---|---|
| Worst RPC stall | 39,087 ms | 2,389 ms |
| RPC stall p50 / p90 | 0.8 / 2.9 ms | 1.2 / 9.8 ms |
| Busiest core, mean / max | 71.3% / 100.0% | 58.8% / 87.6% |
| All-core CPU | 41.6% | 32.2% |

---

### Where the time goes

Profiling the daemon during that download put 99.97% of all Python samples in one frame:

```
reactor mainLoop
  -> on_alert_state_update            torrentmanager.py:1640
  -> handle_torrents_status_callback  torrentmanager.py:1667
  -> get_status                       torrent.py:1037
  -> <lambda>                         torrent.py:1147
  -> status                           torrent.py:1076   <-- self.handle.status()
```

### Why it happens

`state_update_alert` carries status only for torrents that changed since the last `post_torrent_updates()`. `handle_torrents_status_callback` then builds status for *all* requested torrents, so any torrent absent from the alert has a cache older than the `status` property's 5s threshold, and the property calls `handle.status()` synchronously.

Torrent count and link speed multiply rather than add. Downloading fast through a few torrents leaves the rest idle, and idle torrents never appear in the alert, so their caches are always stale. Count sets the number of blocking calls; speed sets the cost of each.

### What changed

Four call sites matched "synchronous libtorrent call in a loop over all torrents, on the reactor thread": the `Torrent.status` fallback above, `get_file_priorities` and `get_name` (both calling `handle.status()` per torrent inside `status_funcs`), and `save_resume_data`'s `need_save_resume_data()` scan.

The 5s auto-refresh those relied on is replaced by a bounded rotating refresh via `deferToThread`. Something has to keep idle torrents fresh: libtorrent posts a torrent in `state_update_alert` once and then only when it changes, so serving the cache alone would freeze `active_time`, `seeding_time`, `next_announce` and similar for every idle seed. `Core.get_torrent_status` also no longer forces a fresh read, which had blocked the reactor serving every other client.

Moving the `need_save_resume_data()` scan off-thread introduces an await, so the ids it returns are a snapshot taken before the reactor ran again. `save_resume_data` therefore skips ids that are no longer present, and does so before creating the `waiting_on_resume_data` entry, since only a `save_resume_data` alert clears one and none arrives for a torrent that was never asked to save.

`create_state`'s `handle.is_paused()` loop is left for a separate change.

One thing worth knowing if you review the shape of this: no per-tick count or time budget makes a contended `handle.status()` safe on the reactor. A budget sized from an uncontended benchmark cost roughly 250x more under load, and a single contended call can block for hundreds of milliseconds. The work has to move off the thread.

### Tests

Ten added, asserting the reactor-thread guarantees rather than just the return values.

`pytest deluge/tests/test_core.py deluge/tests/test_torrent.py deluge/tests/test_torrentmanager.py` gives `62 passed, 1 skipped, 3 xfailed`.

`test_test_listen_port` is environment-dependent (it needs an inbound-reachable port) and is already marked `@pytest.mark.flaky`; where it fails it fails identically on unmodified `develop`.
