### PR TITLE
core: don't strand a torrent when remove() aborts after the handle is destroyed

### DIFF
--- a/deluge/core/torrentmanager.py
+++ b/deluge/core/torrentmanager.py
@@ -734,8 +734,12 @@ class TorrentManager(component.Component):
         try:
             self.session.remove_torrent(torrent.handle, 1 if remove_data else 0)
         except RuntimeError as ex:
-            log.warning('Error removing torrent: %s', ex)
-            return False
+            # An invalid handle means libtorrent already dropped it; bailing out
+            # here would leave a Torrent no later remove could ever clear.
+            if torrent.handle.is_valid():
+                log.warning('Error removing torrent: %s', ex)
+                return False
+            log.warning('Removing torrent with an invalid handle: %s', ex)
 
         # Remove fastresume data if it is exists
         self.resume_data.pop(torrent_id, None)
@@ -746,15 +750,13 @@ class TorrentManager(component.Component):
         )
         torrent.delete_torrentfile(delete_copies)
 
-        # Remove from set if it wasn't finished
+        # Remove from set if it wasn't finished. The handle is already dead here,
+        # so an inconsistent set must not abort the removal.
         if not torrent.is_finished:
             try:
                 self.queued_torrents.remove(torrent_id)
             except KeyError:
                 log.debug('%s is not in queued torrents set.', torrent_id)
-                raise InvalidTorrentError(
-                    '%s is not in queued torrents set.' % torrent_id
-                )
 
         # Remove the torrent from deluge's session
         del self.torrents[torrent_id]

--- a/deluge/tests/test_torrentmanager.py
+++ b/deluge/tests/test_torrentmanager.py
@@ -139,6 +139,58 @@ class TestTorrentmanager(BaseTestCase):
         with pytest.raises(InvalidTorrentError):
             self.tm.remove('torrentidthatdoesntexist')
 
+    @pytest_twisted.inlineCallbacks
+    def test_remove_torrent_missing_from_queued_set(self):
+        """An unfinished torrent absent from queued_torrents must still be removed.
+
+        By this point session.remove_torrent() has already destroyed the
+        libtorrent handle, so abandoning the removal leaves a Torrent whose
+        every later status read raises RuntimeError for the life of the daemon.
+
+        on_alert_torrent_finished reaches this state on its own: when a
+        move_completed path is set it queues the move and leaves is_finished
+        False, while still dropping the id from queued_torrents.
+        """
+        filename = common.get_test_data_file('test.torrent')
+        with open(filename, 'rb') as _file:
+            filedump = _file.read()
+        torrent_id = yield self.core.add_torrent_file_async(
+            filename, b64encode(filedump), {}
+        )
+        self.tm.queued_torrents.discard(torrent_id)
+        assert not self.tm.torrents[torrent_id].is_finished
+
+        assert self.tm.remove(torrent_id, False)
+        assert torrent_id not in self.tm.torrents
+
+    @pytest_twisted.inlineCallbacks
+    def test_remove_torrent_with_dead_handle(self):
+        """A torrent whose handle libtorrent already dropped must be removable.
+
+        remove_torrent() raises on an invalid handle, so returning False here
+        left the only existing zombies unremovable short of a daemon restart.
+        """
+        filename = common.get_test_data_file('test.torrent')
+        with open(filename, 'rb') as _file:
+            filedump = _file.read()
+        torrent_id = yield self.core.add_torrent_file_async(
+            filename, b64encode(filedump), {}
+        )
+        torrent = self.tm.torrents[torrent_id]
+
+        # Kill the handle behind TorrentManager's back, as an aborted remove does.
+        self.tm.session.remove_torrent(torrent.handle, 0)
+        for _ in range(100):
+            if not torrent.handle.is_valid():
+                break
+            yield task.deferLater(reactor, 0.05)
+        assert not torrent.handle.is_valid(), 'libtorrent never dropped the handle'
+        # A real zombie has outlived the 5s status cache, so reads hit the handle.
+        torrent._status_last_update = 0
+
+        assert self.tm.remove(torrent_id, False)
+        assert torrent_id not in self.tm.torrents
+
     def test_open_state(self):
         """Open a state with a UTF-8 encoded torrent filename."""
         shutil.copy(


### PR DESCRIPTION
A failed torrent removal can leave Deluge holding a torrent that no longer works.

Every later `get_torrent_status` for that id raises `RuntimeError: invalid torrent handle used [libtorrent:20]`, the torrent cannot be removed, and it stays that way for the life of the daemon. Restarting is the only way out.

**Cause.** `TorrentManager.remove()` does its destructive work before a validation that can throw. Once `session.remove_torrent()` has run the handle is dead, so if the id is then missing from `queued_torrents`, `remove()` raises `InvalidTorrentError` and `del self.torrents[torrent_id]` never runs.

**Fix.** Complete the removal rather than abandoning it, and add a recovery path so a torrent already stuck in this state can be cleared without a restart.

---

### How it is reached

`on_alert_torrent_finished` gets there on its own. With `move_completed` set and the paths differing, it queues the move and leaves `is_finished` False, while still dropping the id from `queued_torrents` at the end of the handler. If the move never completes, `storage_moved_alert` never fires, `is_finished` stays False, and a remove hits the `KeyError` path with the id already gone.

Observed by re-adding a torrent whose data was already at the move-completed destination: it completed immediately, queued a move onto an existing file, stuck in `Moving`, and removing it produced exactly one unreachable torrent.

### Why completing the removal is the right call

An inconsistent bookkeeping set is not a reason to abandon a removal libtorrent has already performed, so the `KeyError` is now logged and the removal completes.

That is already what `on_alert_torrent_finished` does with the same `KeyError` on the same set, so this makes the two paths agree.

### Recovery

`remove()` returned False when `remove_torrent()` raised, and `remove_torrent()` raises on an invalid handle, so a torrent already in this state could not be cleared without restarting the daemon.

It now checks `handle.is_valid()` and finishes the cleanup when the handle is already gone. The guard is deliberately narrow: a genuine `remove_torrent` failure still returns False.

### Tests

Two regression tests in `deluge/tests/test_torrentmanager.py`, both driving a real session and a real libtorrent handle rather than mocks.

`pytest deluge/tests/test_torrentmanager.py` gives `8 passed, 1 skipped`.

Not a regression: the behaviour is the same on 2.2.0. Found while profiling a daemon with ~900 torrents.
