### PR TITLE
tests: make add_watchdog actually time a deferred out

### DIFF
--- a/deluge/tests/common.py
+++ b/deluge/tests/common.py
@@ -52,17 +52,18 @@ def todo_test(caller):
 
 
 def add_watchdog(deferred, timeout=0.05, message=None):
-    def callback(value):
+    def on_timeout():
+        if message:
+            print(message)
+        deferred.cancel()
+
+    def cancel_watchdog(value):
         if not watchdog.called and not watchdog.cancelled:
             watchdog.cancel()
-        if not deferred.called:
-            if message:
-                print(message)
-            deferred.cancel()
         return value
 
-    deferred.addBoth(callback)
-    watchdog = reactor.callLater(timeout, defer.Deferred.addTimeout, deferred)
+    deferred.addBoth(cancel_watchdog)
+    watchdog = reactor.callLater(timeout, on_timeout)
     return watchdog
 
 

--- a/deluge/tests/test_watchdog.py
+++ b/deluge/tests/test_watchdog.py
@@ -1,0 +1,45 @@
+#
+# This file is part of Deluge and is licensed under GNU General Public License 3.0, or later, with
+# the additional special exception to link portions of this program with the OpenSSL library.
+# See LICENSE for more details.
+#
+
+"""Tests for the add_watchdog helper in deluge.tests.common."""
+
+import pytest
+import pytest_twisted
+from twisted.internet import defer, reactor
+
+from . import common
+
+
+@pytest_twisted.inlineCallbacks
+def test_watchdog_cancels_a_deferred_that_never_fires():
+    d = defer.Deferred()
+    common.add_watchdog(d, timeout=0.05)
+    # Bound the wait so a broken watchdog fails the test rather than hanging it.
+    d.addTimeout(2, reactor)
+
+    with pytest.raises(defer.CancelledError):
+        yield d
+
+
+@pytest_twisted.inlineCallbacks
+def test_watchdog_prints_its_message_on_timeout(capsys):
+    d = defer.Deferred()
+    common.add_watchdog(d, timeout=0.05, message='Timeout!')
+    d.addTimeout(2, reactor)
+
+    with pytest.raises(defer.CancelledError):
+        yield d
+
+    assert 'Timeout!' in capsys.readouterr().out
+
+
+def test_watchdog_is_cancelled_when_the_deferred_fires():
+    d = defer.Deferred()
+    watchdog = common.add_watchdog(d, timeout=30)
+
+    d.callback('done')
+
+    assert watchdog.cancelled, 'a fired deferred must not leave a pending watchdog'


### PR DESCRIPTION
Deluge's test watchdog does not time anything out.

Any test whose daemon fails to start hangs instead of failing. CI then runs to its job limit and is cancelled, which reports nothing at all, so a genuine breakage is indistinguishable from infrastructure flakiness.

**Cause.** `add_watchdog` schedules its timeout action as `reactor.callLater(timeout, defer.Deferred.addTimeout, deferred)`, which invokes the unbound `Deferred.addTimeout` with only `self`. That raises `TypeError: Deferred.addTimeout() missing 2 required positional arguments: 'timeout' and 'clock'` inside the reactor, so the deferred is never cancelled and the watchdog that exists to bound a wait instead lets it run forever.

**Fix.** Invoke the timeout properly. `test_client.py` now terminates in 104s with `CancelledError` instead of hanging indefinitely.

---

### The `message` argument was unreachable too

It sat behind `if not deferred.called` inside an `addBoth` callback, and a callback only runs once the deferred has fired, so that condition was always false.

`start_core` passes `timeout_msg='Timeout!'` and it has never printed. Moving the timeout action into its own function makes the message appear when the timeout actually fires.

### Tests

Three regression tests in `deluge/tests/test_watchdog.py` cover the cancel, the message, and the existing behaviour that a watchdog is cancelled when its deferred fires normally.

Each bounds its own wait, so a regression fails the test rather than hanging the suite.

`pytest deluge/tests/test_watchdog.py` gives `3 passed`.

### Expect a red CI run on this PR, for a pre-existing reason

`pyopenssl` is unpinned and 26 removed `crypto.X509Req`, which `deluge/crypto_utils.py:112` still uses, so the test daemon cannot start and every test needing one errors. #514 fixes that properly by porting the module to `cryptography`. Pinning `pyopenssl < 26` alongside that gives a fully green run locally: 361 passed on Linux 3.10, Linux 3.13 and Windows 3.10.

That interaction is the argument for this patch rather than against it. Before the change, the pyOpenSSL breakage presented as a cancelled job with no output. After it, the same breakage presents as a 59s report naming 45 errors.
