### PR TITLE
core: include plugin status fields in the status diff

### DIFF
--- a/deluge/core/core.py
+++ b/deluge/core/core.py
@@ -782,8 +782,18 @@ class Core(component.Component):
         all_keys=False,
     ):
         try:
-            status = self.torrentmanager[torrent_id].get_status(
-                torrent_keys, diff, update=update, all_keys=all_keys
+            # Passed into get_status rather than merged over its result, so the
+            # plugin values take part in the diff instead of always looking new.
+            plugin_status = None
+            if len(plugin_keys) > 0 or all_keys:
+                plugin_status = self.pluginmanager.get_status(torrent_id, plugin_keys)
+
+            return self.torrentmanager[torrent_id].get_status(
+                torrent_keys,
+                diff,
+                update=update,
+                all_keys=all_keys,
+                plugin_status=plugin_status,
             )
         except KeyError:
             import traceback
@@ -791,11 +801,6 @@ class Core(component.Component):
             traceback.print_exc()
             # Torrent was probably removed meanwhile
             return {}
-
-        # Ask the plugin manager to fill in the plugin keys
-        if len(plugin_keys) > 0 or all_keys:
-            status.update(self.pluginmanager.get_status(torrent_id, plugin_keys))
-        return status
 
     @export
     def get_torrent_status(
@@ -819,16 +824,10 @@ class Core(component.Component):
         self, filter_dict: dict, keys: List[str], diff: bool = False
     ) -> dict:
         """returns all torrents , optionally filtered by filter_dict."""
-        all_keys = not keys
         torrent_ids = self.filtermanager.filter_torrent_ids(filter_dict)
-        status_dict, plugin_keys = await self.torrentmanager.torrents_status_update(
+        return await self.torrentmanager.torrents_status_update(
             torrent_ids, keys, diff=diff
         )
-        # Ask the plugin manager to fill in the plugin keys
-        if len(plugin_keys) > 0 or all_keys:
-            for key in status_dict:
-                status_dict[key].update(self.pluginmanager.get_status(key, plugin_keys))
-        return status_dict
 
     @export
     def get_filter_tree(

--- a/deluge/core/torrent.py
+++ b/deluge/core/torrent.py
@@ -1010,7 +1010,9 @@ class Torrent:
         except ValueError:
             return -1
 
-    def get_status(self, keys, diff=False, update=False, all_keys=False):
+    def get_status(
+        self, keys, diff=False, update=False, all_keys=False, plugin_status=None
+    ):
         """Returns the status of the torrent based on the keys provided
 
         Args:
@@ -1021,6 +1023,8 @@ class Torrent:
                 if False, the cached values will be returned
             all_keys (bool): If True return all keys while ignoring the keys param
                 if False, return only the requested keys
+            plugin_status (dict): Status fields supplied by plugins. Merged in
+                before the diff is taken so unchanged plugin values diff out.
 
         Returns:
             dict: a dictionary of the status keys and their values
@@ -1035,6 +1039,9 @@ class Torrent:
 
         for key in keys:
             status_dict[key] = self.status_funcs[key]()
+
+        if plugin_status:
+            status_dict.update(plugin_status)
 
         if diff:
             session_id = self.rpcserver.get_session_id()

--- a/deluge/core/torrentmanager.py
+++ b/deluge/core/torrentmanager.py
@@ -1706,7 +1706,14 @@ class TorrentManager(component.Component):
         """Build the status dictionary with torrent values"""
         d, torrent_ids, keys, diff = status_request
         status_dict = {}.fromkeys(torrent_ids)
+        all_keys = not keys
         torrent_keys, plugin_keys = self.separate_keys(keys, torrent_ids)
+
+        # Passed into get_status rather than merged over its result: merged
+        # afterwards they never diff out, so every torrent lands in every diff.
+        pluginmanager = None
+        if plugin_keys or all_keys:
+            pluginmanager = component.get('CorePluginManager')
 
         # Get the torrent status for each torrent_id
         for torrent_id in torrent_ids:
@@ -1715,11 +1722,19 @@ class TorrentManager(component.Component):
                 # Could be the clients cache (sessionproxy) isn't up to speed.
                 del status_dict[torrent_id]
             else:
+                plugin_status = (
+                    pluginmanager.get_status(torrent_id, plugin_keys)
+                    if pluginmanager
+                    else None
+                )
                 status_dict[torrent_id] = self.torrents[torrent_id].get_status(
-                    torrent_keys, diff, all_keys=not keys
+                    torrent_keys,
+                    diff,
+                    all_keys=all_keys,
+                    plugin_status=plugin_status,
                 )
         self.status_dict = status_dict
-        d.callback((status_dict, plugin_keys))
+        d.callback(status_dict)
 
     def torrents_status_update(self, torrent_ids, keys, diff=False):
         """Returns status dict for the supplied torrent_ids async.

--- a/deluge/tests/test_core.py
+++ b/deluge/tests/test_core.py
@@ -389,6 +389,42 @@ class TestCore(BaseTestCase):
         assert val[0] == ('invalidid1', 'torrent_id invalidid1 not in session.')
         assert val[1] == ('invalidid2', 'torrent_id invalidid2 not in session.')
 
+    @pytest_twisted.inlineCallbacks
+    def test_get_torrents_status_diff_excludes_unchanged_plugin_keys(self):
+        torrent_id = self.add_torrent('test.torrent')
+        self.core.pluginmanager.register_status_field('testfield', lambda _: 'static')
+
+        keys = ['name', 'testfield']
+        yield self.core.get_torrents_status({}, keys, diff=True)
+        diff = yield self.core.get_torrents_status({}, keys, diff=True)
+
+        assert diff[torrent_id] == {}
+
+    @pytest_twisted.inlineCallbacks
+    def test_get_torrents_status_diff_includes_changed_plugin_keys(self):
+        torrent_id = self.add_torrent('test.torrent')
+        values = iter(['before', 'after'])
+        self.core.pluginmanager.register_status_field(
+            'testfield', lambda _: next(values)
+        )
+
+        keys = ['name', 'testfield']
+        yield self.core.get_torrents_status({}, keys, diff=True)
+        diff = yield self.core.get_torrents_status({}, keys, diff=True)
+
+        assert diff[torrent_id] == {'testfield': 'after'}
+
+    @pytest_twisted.inlineCallbacks
+    def test_get_torrent_status_diff_excludes_unchanged_plugin_keys(self):
+        torrent_id = self.add_torrent('test.torrent')
+        self.core.pluginmanager.register_status_field('testfield', lambda _: 'static')
+
+        keys = ['name', 'testfield']
+        yield self.core.get_torrent_status(torrent_id, keys, diff=True)
+        diff = yield self.core.get_torrent_status(torrent_id, keys, diff=True)
+
+        assert diff == {}
+
     def test_get_session_status(self):
         status = self.core.get_session_status(
             ['net.recv_tracker_bytes', 'net.sent_tracker_bytes']


### PR DESCRIPTION
Enable any plugin that contributes a status field and the status diff stops being a diff: every torrent appears in every poll, forever.

Measured against a daemon with 898 torrents and the Label plugin enabled, using the WebUI's own 28 key request, every "diff" carried all 898 torrents at 24.7 KB against 89.8 KB for full status. That is 27.5% of full status where the genuine change rate is closer to 1%.

**Cause.** `Core.get_torrents_status` and `Core.create_torrent_status` merge the plugin manager's status fields over the *result* of the diff, so `Torrent.prev_status` never contains plugin keys and they can never diff out.

**Fix.** Pass the plugin fields into `Torrent.get_status` instead of merging them over its result, so they take part in the diff like any other key and `torrent.py` stays the only place that knows about diffing.

---

### Measured effect

Paired measurement on an idle 894 torrent daemon, same container and config, the three patched files as the only variable:

| | before | after |
|---|---|---|
| Torrents in each diff | 894 of 894 | 0 |
| Diff size | 22.0 KB | 0.0 KB |

Changed values still propagate: setting a label produced exactly one torrent carrying one field on the next round, then an empty diff again.

### What this does not change

The plugin manager is still called once per torrent per poll, for the same torrents in the same order, so plugins that rely on being polled are unaffected. Only the merge point moved.

`torrents_status_update` no longer returns `plugin_keys` alongside the status dict, since its only caller wanted them for the merge that has moved.

### Tests

Three tests in `deluge/tests/test_core.py` cover unchanged plugin keys diffing out, changed ones getting through, and the single torrent path.

`pytest deluge/tests/test_core.py` gives `40 passed`.

### Expect a red CI run on this PR, for a pre-existing reason

`pyopenssl` is unpinned here and resolves to 26.x, which removed `crypto.X509Req` that `deluge/crypto_utils.py:112` still uses, so the test daemon cannot start and every test needing one errors. #514 fixes that properly. The same tests pass locally and on a branch carrying a `pyopenssl < 26` pin.
