### PR TITLE
core: always resume AlertManager after a failed torrent add

### DIFF
--- a/deluge/core/torrentmanager.py
+++ b/deluge/core/torrentmanager.py
@@ -543,17 +543,28 @@ class TorrentManager(component.Component):
         # for this torrent being generated before a Torrent object is created.
         component.pause('AlertManager')
 
+        # finally, not just the except below: a paused AlertManager never calls
+        # pop_alerts() again, so any escape here stops every alert handler for good.
         try:
-            handle = self.session.add_torrent(add_torrent_params)
-            if not handle.is_valid():
-                raise InvalidTorrentError('Torrent handle is invalid!')
-        except (RuntimeError, InvalidTorrentError) as ex:
-            component.resume('AlertManager')
-            raise AddTorrentError('Unable to add torrent to session: %s' % ex)
+            try:
+                handle = self.session.add_torrent(add_torrent_params)
+                if not handle.is_valid():
+                    raise InvalidTorrentError('Torrent handle is invalid!')
+            except (RuntimeError, InvalidTorrentError) as ex:
+                raise AddTorrentError('Unable to add torrent to session: %s' % ex)
 
-        torrent = self._add_torrent_obj(
-            handle, options, state, filename, magnet, resume_data, filedump, save_state
-        )
+            torrent = self._add_torrent_obj(
+                handle,
+                options,
+                state,
+                filename,
+                magnet,
+                resume_data,
+                filedump,
+                save_state,
+            )
+        finally:
+            component.resume('AlertManager')
         return torrent.torrent_id
 
     def add_async(

--- a/deluge/tests/test_torrentmanager.py
+++ b/deluge/tests/test_torrentmanager.py
@@ -148,3 +148,28 @@ class TestTorrentmanager(BaseTestCase):
 
         state = self.tm.open_state()
         assert len(state.torrents) == 1
+
+    @pytest.mark.timeout(30)
+    def test_add_resumes_alertmanager_when_torrent_construction_fails(self):
+        """AlertManager must not be left paused if adding raises after the pause.
+
+        add() pauses AlertManager around session.add_torrent, but the resume for
+        the success path lives inside _add_torrent_obj. Anything raising between
+        the two left the pause set forever, so pop_alerts() was never called
+        again and the daemon went permanently deaf to libtorrent.
+        """
+        filename = common.get_test_data_file('test.torrent')
+        with open(filename, 'rb') as _file:
+            filedump = _file.read()
+
+        alertmanager = component.get('AlertManager')
+        assert alertmanager._component_state == 'Started'
+
+        with mock.patch(
+            'deluge.core.torrentmanager.Torrent',
+            side_effect=RuntimeError('handle went invalid'),
+        ):
+            with pytest.raises(RuntimeError):
+                self.tm.add(filedump=filedump, filename=filename)
+
+        assert alertmanager._component_state == 'Started'


### PR DESCRIPTION
A torrent add that fails at the wrong moment leaves the daemon permanently unable to process libtorrent alerts.

Status stops updating, resume data is never written again, `torrent_finished` never fires so move-on-complete and completion events stop, and client status polls stop returning rather than merely going stale. Torrents keep transferring throughout, so the daemon looks healthy from the outside. Nothing short of another successful synchronous add clears it.

**Cause.** `add()` pauses AlertManager around `session.add_torrent`, but the resume for the success path lives inside `_add_torrent_obj`, and the `except` clause covers only `add_torrent` itself. Anything raising between the two leaves the pause set. `AlertManager.pause()` clears the event that `wait_for_alert_in_thread` waits on, so `pop_alerts()` is then never called again.

**Fix.** Wrap the region in `try/finally`.

---

### Why the clients hang rather than go stale

`torrents_status_update` serves cached status only while `now - last_state_update_alert_ts < 1.5`. That timestamp is set in `on_alert_state_update`, which has stopped, so after 1.5s every poll takes the other branch: it appends to `torrents_status_requests`, calls `post_torrent_updates()`, and waits on a Deferred that only an alert can fire. There is no timeout on it.

### Why it cannot recover on its own

Only the synchronous `add()` pauses, so `Core.add_torrent_file` and `Core.add_torrent_magnet` are the exposed entry points. `add_async` never pauses, which is also why it cannot clear the condition: its resume runs from `on_alert_add_torrent`, an alert handler, and alerts have stopped.

Startup is unaffected, since `load_state` uses `add_async`.

### Scope

The window is small. It spans the `Torrent(...)` constructor, which is fully synchronous, so no other code can invalidate the handle mid-window. The raise candidates are `str(handle.info_hash())`, `handle.torrent_file()`, `get_lt_status()`, all of which raise `RuntimeError` on an invalidated handle, and `component.get('RPCServer')`.

Low probability per add, then, but the blast radius is the whole daemon and the fix costs nothing.

### A note on the shape

The early `component.resume('AlertManager')` inside `_add_torrent_obj` is deliberately kept rather than replaced. It resumes as soon as the `Torrent` object exists, which is what the pause comment asks for; moving it into the `finally` alone would widen the pause window to cover `torrent.resume()` and `queue_top()`. `ComponentRegistry.resume()` only acts on a component in the `Paused` state, so the `finally` is a no-op once the early resume has run.

### Tests

One regression test in `deluge/tests/test_torrentmanager.py`, asserting AlertManager is not left paused when the `Torrent` constructor raises. It fails on unmodified `develop` with `assert 'Paused' == 'Started'`.

`pytest deluge/tests/test_torrentmanager.py` gives `7 passed, 1 skipped`.

Not a regression: the behaviour is the same on 2.2.0. Found while auditing the daemon for failure modes that survive across days of uptime.

### Expect a red CI run on this PR, for a pre-existing reason

`pyopenssl` is unpinned and 26 removed `crypto.X509Req`, which `deluge/crypto_utils.py:112` still uses, so the test daemon cannot start and every test needing one errors. #514 fixes that properly. The same tests pass locally with `pyopenssl < 26` pinned.
