### PR TITLE
auth: don't log a stored password that isn't a hash

### DIFF
--- a/deluge/core/authmanager.py
+++ b/deluge/core/authmanager.py
@@ -136,12 +136,13 @@ class AuthManager(component.Component):
 
         try:
             return check_password_hash(stored_password, password)
-        except InvalidHashError as ex:
+        except InvalidHashError:
+            # The unparsed value is not logged: for an entry predating password
+            # hashing it is the user's password.
             log.warning(
-                'Invalid hash method in password for user %s: %s'
+                'Invalid password hash for user %s.'
                 ' Falling back to plaintext validation.',
                 username,
-                ex.method,
             )
             return stored_password == password
 

--- a/deluge/security.py
+++ b/deluge/security.py
@@ -121,7 +121,7 @@ def check_password_hash(pwhash: str, password: str) -> bool:
     except ValueError as ve:
         raise InvalidHashError(
             'Invalid password hash format. Expected format: "$method$salt$hash".',
-            method=method if method else pwhash,
+            method=method,
         ) from ve
 
     return hmac.compare_digest(computed_hash, stored_hash)

--- a/deluge/tests/test_authmanager.py
+++ b/deluge/tests/test_authmanager.py
@@ -4,6 +4,7 @@
 # See LICENSE for more details.
 #
 
+import logging
 import os
 
 import pytest
@@ -119,3 +120,24 @@ class TestAuthManager(BaseTestCase):
         add_user_to_authfile('test', 'testpass', 'NORMAL')
 
         assert self.auth.authorize('test', 'testpass') == AUTH_LEVEL_NORMAL
+
+    @pytest.mark.parametrize(
+        ('password', 'leaked'),
+        [('testpass1', 'testpass1'), ('$testpa$$', 'testpa')],
+    )
+    def test_plaintext_password_not_logged(
+        self, password, leaked, add_user_to_authfile, caplog
+    ):
+        """A stored plaintext password must not reach the log.
+
+        check_password_hash reports the unparseable value as the hash "method"
+        and authmanager logs that, so an auth file entry that predates password
+        hashing wrote the user's password to the daemon log on every login.
+        Forced migration of such entries was deferred, so they persist.
+        """
+        add_user_to_authfile('test', password, AUTH_LEVEL_ADMIN)
+
+        with caplog.at_level(logging.WARNING):
+            assert self.auth.authorize('test', password) == AUTH_LEVEL_ADMIN
+
+        assert leaked not in caplog.text


### PR DESCRIPTION
The daemon writes a user's password to its log, in plaintext, on every login by that user, on any install whose `auth` file predates password hashing.

Observed on a live daemon, at WARNING:

```
[WARNING ][deluge.core.authmanager] Invalid hash method in password for user admin: <the account's actual password> Falling back to plaintext validation.
```

**Cause.** `check_password_hash` reports the value it could not parse as the hash `method`, falling back to the whole stored value when the format has no method to report. `AuthManager._verify_password` logs that. For a pre-hashing entry the unparsed value *is* the password.

**Fix.** Stop reporting the stored value in the error, and stop logging it at all.

---

### Why this is the common path, not an edge case

When password hashing landed in #484, forced migration of existing plaintext entries was deliberately deferred. From that discussion:

> I played around with implementing a forced migration to hashed passwords but it would likely require some rethinking of the `Account` class ... probably better suited to a future task

> I'm happy to leave forced migration as future task

That task has not happened, so pre-hashing entries persist indefinitely. The plaintext fallback in `_verify_password` exists precisely to keep serving them, and every trip through it logs the credential. Any daemon upgraded across the hashing change is affected for as long as its old entries remain.

`localclient` is unaffected: `_verify_password` returns before `check_password_hash`.

### Two leaks, two changes

`security.py` fell back to `method=method if method else pwhash`. When the stored value contains no `$`, the unpack fails before `method` is assigned, so the **entire password** became the reported method. That fallback is removed.

`authmanager.py` logged the reported method. When the stored value *does* contain a `$`, it splits and the reported method is a **leading fragment** of the password (`$testpa$$` reports `testpa`), so reporting it is unsafe even when it parses. The value is no longer logged.

The remaining message still names the user and says validation fell back to plaintext, which is the actionable part. The offending value can be read from the `auth` file.

`InvalidHashError.method` is kept, since it is part of the error's API; `authmanager`'s log call was its only consumer in the tree.

### Tests

Two cases in `deluge/tests/test_authmanager.py`, asserting via `caplog` that neither a whole plaintext password nor a fragment of one reaches the log. Both fail on unmodified `develop`, one per leak path.

`pytest deluge/tests/` gives `368 passed, 41 skipped, 5 xfailed`.

### Note for whoever merges

#487 touches this same log statement, joining its implicit string concatenation. It keeps the `%s` and `ex.method`, so it does not address the leak, but the two changes will conflict textually. Happy to rebase on whichever lands first.

### Expect a red CI run on this PR, for a pre-existing reason

`pyopenssl` is unpinned and 26 removed `crypto.X509Req`, which `deluge/crypto_utils.py:112` still uses, so the test daemon cannot start and every test needing one errors. #514 fixes that properly. The tests above pass locally with `pyopenssl < 26` pinned.
