### PR TITLE
Add macOS standalone universal build and notarization workflow

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,0 +1,115 @@
+name: Build and Notarize macOS DMG
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build-macos:
+    runs-on: macos-14
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install System Dependencies
+        run: |
+          # Configure cross-compilation environment variables globally
+          export MACOSX_DEPLOYMENT_TARGET=11.0
+          export CFLAGS="-arch x86_64 -arch arm64 -mmacosx-version-min=11.0"
+          export CXXFLAGS="-arch x86_64 -arch arm64 -mmacosx-version-min=11.0"
+          export LDFLAGS="-arch x86_64 -arch arm64 -mmacosx-version-min=11.0"
+          
+          # Force Homebrew to compile universal packages targeting macOS 11.0+
+          brew install --formula --build-from-source dylibbundler create-dmg gtk+3 adwaita-icon-theme libtorrent-rasterbar
+
+      - name: Import Apple Developer Certificate
+        env:
+          BUILD_CERTIFICATE_BASE64: ${{ secrets.MACOS_CERTIFICATE }}
+          P12_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+          KEYCHAIN_PASSWORD: "temporary_actions_password"
+        run: |
+          # Create a temporary keychain to hold the certificate securely
+          echo $BUILD_CERTIFICATE_BASE64 | base64 --decode --output certificate.p12
+          security create-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security import certificate.p12 -k build.keychain -P "$P12_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" build.keychain
+
+      - name: Create Entitlements File
+        run: |
+          cat <<EOF > entitlements.plist
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://apple.com">
+          <plist version="1.0">
+          <dict>
+              <key>com.apple.security.cs.allow-jit</key>
+              <true/>
+              <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+              <true/>
+              <key>com.apple.security.cs.disable-library-validation</key>
+              <true/>
+          </dict>
+          </plist>
+          EOF
+
+      - name: Compile and Package App
+        run: |
+          export MACOSX_DEPLOYMENT_TARGET=11.0
+          pip install --upgrade pip setuptools wheel
+          pip install --no-binary :all: pygobject pycairo
+          pip install pyinstaller
+          pip install .
+
+          # Package universal binaries via PyInstaller
+          pyinstaller --noconfirm --onedir --windowed --name="Deluge" \
+            --target-architecture universal2 \
+            --add-data "deluge/ui/data:deluge/ui/data" \
+            venv/bin/deluge-gtk
+
+          # Link non-python C libraries into the bundle
+          dylibbundler -od -b -x dist/Deluge.app/Contents/MacOS/Deluge -d dist/Deluge.app/Contents/libs/
+
+          # Deep sign the completed .app bundle
+          codesign --force --options runtime --deep --sign "Developer ID Application" --entitlements entitlements.plist dist/Deluge.app
+
+      - name: Build Outer DMG Installer
+        run: |
+          create-dmg \
+            --volname "Deluge Universal Installer" \
+            --identity "Developer ID Application" \
+            "Deluge-2.2.0-Universal.dmg" \
+            "dist/"
+
+          codesign --force --sign "Developer ID Application" "Deluge-2.2.0-Universal.dmg"
+
+      - name: Notarize and Staple DMG
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          # Submit to Apple and block the workflow until processing completes
+          xcrun notarytool submit "Deluge-2.2.0-Universal.dmg" \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_PASSWORD" \
+            --team-id "$TEAM_ID" \
+            --wait
+
+          # Permanently attach the notarization ticket to the file
+          xcrun stapler staple "Deluge-2.2.0-Universal.dmg"
+
+      - name: Upload Finished DMG Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Deluge-macOS-Universal
+          path: Deluge-2.2.0-Universal.dmg


### PR DESCRIPTION
Build a universal standalone macos app for deluge

The following github secrets are required to build and notarize a DMG for Mac:
- **MACOS_CERTIFICATE**: Your Developer ID Application certificate exported from Keychain Access as a password-protected .p12 file, then converted to a base64 string.
- **MACOS_CERTIFICATE_PWD**: The password you used when exporting the .p12 file.
- **APPLE_DEVELOPER_IDENTITY**: Should be in the format: _Developer ID Application: Common Name_
- **APPLE_ID**: Your Apple Developer account email address.
- **APPLE_ID_PASSWORD**: An App-Specific Password generated at ://apple.com.
- **APPLE_TEAM_ID**: Your 10-character Apple Developer Team ID.

**MACOS_CERTIFICATE** (The Cryptographic .p12 Key)
To download your official Developer ID Application certificate, you must use a Mac to create a certificate signing request (CSR) and process it via the developer portal.
- Where to generate it: Go to the Apple Certificates, Identifiers & Profiles dashboard.
- How to create and download it:
    1. Click the + (plus sign) next to Certificates.
    2. Select Developer ID Application under the Software distribution options and click Continue.
    3. Upload your Mac's CSR file (generated locally using Keychain Access > Certificate Assistant > Request a Certificate from a Certificate Authority).
    4. Once Apple processes it, click Download to save the .cer file to your Mac.
 - How to convert it to a GitHub Secret:
    1. Double-click the downloaded .cer file to import it into your Mac's Keychain Access app.
    2. Inside Keychain Access, find the certificate under My Certificates. It will be named "Developer ID Application: Your Name/Company (Team ID)".
    3. Right-click the certificate and select Export "Developer ID Application...".
    4. Save it as a .p12 file (Personal Information Exchange).
    5. Assign it a password. This password is your MACOS_CERTIFICATE_PWD secret.
    6. Open your Mac's Terminal app and convert that file into a Base64 text string so GitHub can store it safely:
     - `base64 -i AuthCertificate.p12 -o- | pbcopy`
    7. The encoded string is now copied to your clipboard. Paste it directly into the MACOS_CERTIFICATE value field inside your GitHub repository secrets.

**APPLE_ID_PASSWORD** (App-Specific Password)
Apple Notary API calls cannot use your regular Apple ID password, and they do not support two-factor authentication (2FA) prompts. You must generate a dedicated security token.
- Where to find it: Go to the Apple ID Account Management Page.
- How to generate it:
    1. Log in with your Apple ID.
    2. Navigate to the Sign-In and Security section on the left sidebar.
    3. Click on App-Specific Passwords.
    4. Select Generate an app-specific password or click the + icon.
    5. Enter a label so you remember what it is for (e.g., GitHub Actions Deluge Build).
    6. Copy the generated password. It will look like a sequence of 16 letters separated by hyphens (e.g., abcd-efgh-ijkl-mnop).

**APPLE_TEAM_ID** (10-Character Identifier)
Your Team ID is a unique alphanumeric string assigned to your developer account by Apple.
- Where to find it: Go to the Apple Developer Account Center.
- How to copy it:
  1. Log in with your developer credentials.
  2. Click on Membership Details (or look at the top-right corner of the page under your name).
  3. Locate the Team ID field (e.g., [1](https://applepaydemo.apple.com/in-app-provisioning)A2B3C4D5E). Copy this exact string.
