### PR TITLE
web: require authentication for uploads

### DIFF
--- a/deluge/ui/web/server.py
+++ b/deluge/ui/web/server.py
@@ -126,6 +126,14 @@ class Upload(resource.Resource):
             request.finish()
             return server.NOT_DONE_YET
 
+        try:
+            component.get('Auth').check_request(request, level=AUTH_LEVEL_DEFAULT)
+        except NotAuthorizedError:
+            log.warning('Auth required to upload torrent files.')
+            request.setResponseCode(http.UNAUTHORIZED)
+            request.finish()
+            return server.NOT_DONE_YET
+
         files = request.args.get(b'file', [])
         filenames = []
 


### PR DESCRIPTION
The Web UI upload endpoint accepted unauthenticated multipart requests and wrote each supplied file to a new temporary directory. Repeated requests could exhaust the host temporary filesystem.

Require an authenticated Web UI session before accepting uploads. This preserves the existing upload flow for logged-in users while preventing anonymous clients from creating persistent temporary files.